### PR TITLE
Add native FastAPI read endpoints for stats files and categories

### DIFF
--- a/ai_actuarial/api/app.py
+++ b/ai_actuarial/api/app.py
@@ -10,6 +10,7 @@ from starlette.responses import PlainTextResponse
 
 from .routers.meta import router as meta_router
 from .routers.migration import router as migration_router
+from .routers.read import router as read_router
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,15 @@ def _native_paths(app: FastAPI) -> list[str]:
     return sorted(paths)
 
 
+def _resolve_db_path() -> str:
+    from ai_actuarial.web.app import _get_sites_config_path, _load_yaml
+
+    config_data = _load_yaml(_get_sites_config_path(), default={})
+    db_path = (config_data.get("paths") or {}).get("db", "data/index.db")
+    db_path = str(db_path or "data/index.db")
+    return os.path.abspath(db_path) if not os.path.isabs(db_path) else db_path
+
+
 def create_app() -> FastAPI:
     app = FastAPI(
         title="AI Actuarial Info Search API",
@@ -48,17 +58,31 @@ def create_app() -> FastAPI:
 
     app.include_router(meta_router, prefix="/api", tags=["meta"])
     app.include_router(migration_router, prefix="/api", tags=["migration"])
+    app.include_router(read_router, prefix="/api", tags=["read"])
 
     app.state.legacy_backend = "flask"
     app.state.legacy_mount_enabled = False
     app.state.legacy_mount_error = None
+    app.state.legacy_flask_app = None
+    app.state.db_path = _resolve_db_path()
+    app.state.require_auth = os.getenv("REQUIRE_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
+    app.state.active_tasks_ref = {}
+    app.state.task_lock = None
 
     try:
-        from ai_actuarial.web.app import create_app as create_legacy_flask_app
+        from ai_actuarial.web.app import (
+            _active_tasks,
+            _task_lock,
+            create_app as create_legacy_flask_app,
+        )
 
         legacy_app = create_legacy_flask_app()
         app.mount("/", WSGIMiddleware(legacy_app))
         app.state.legacy_mount_enabled = True
+        app.state.legacy_flask_app = legacy_app
+        app.state.require_auth = bool(legacy_app.config.get("REQUIRE_AUTH", False))
+        app.state.active_tasks_ref = _active_tasks
+        app.state.task_lock = _task_lock
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to mount legacy Flask app into FastAPI gateway")
         app.state.legacy_mount_error = str(exc)

--- a/ai_actuarial/api/deps.py
+++ b/ai_actuarial/api/deps.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from ai_actuarial.storage import Storage
+from ai_actuarial.web.app import (
+    _PERMISSIONS,
+    _PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED,
+    _hash_token,
+    _permissions_for_group,
+)
+
+
+@dataclass(slots=True)
+class AuthContext:
+    token: dict[str, Any] | None
+    permissions: frozenset[str]
+
+
+def _extract_presented_token(request: Request) -> str | None:
+    auth = request.headers.get("Authorization", "") or ""
+    parts = auth.strip().split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip()
+    token = request.headers.get("X-API-Token")
+    return token.strip() if token else None
+
+
+def _decode_flask_session(request: Request) -> dict[str, Any]:
+    legacy_app = getattr(request.app.state, "legacy_flask_app", None)
+    if legacy_app is None:
+        return {}
+
+    cookie_name = legacy_app.config.get("SESSION_COOKIE_NAME", "session")
+    cookie_value = request.cookies.get(cookie_name)
+    if not cookie_value:
+        return {}
+
+    serializer = legacy_app.session_interface.get_signing_serializer(legacy_app)
+    if serializer is None:
+        return {}
+
+    try:
+        data = serializer.loads(cookie_value)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _validate_token_record(token: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not token:
+        return None
+    if not token.get("is_active"):
+        return None
+
+    expires_at = token.get("expires_at")
+    if not expires_at:
+        return token
+
+    try:
+        dt = datetime.fromisoformat(str(expires_at))
+        now = datetime.now(dt.tzinfo) if dt.tzinfo else datetime.now()
+    except Exception:
+        return None
+
+    return token if dt > now else None
+
+
+def _load_auth_context(request: Request) -> AuthContext:
+    cached = getattr(request.state, "auth_context", None)
+    if cached is not None:
+        return cached
+
+    db_path = getattr(request.app.state, "db_path", "")
+    if not db_path:
+        raise HTTPException(status_code=500, detail="Database path is unavailable")
+
+    token: dict[str, Any] | None = None
+    storage = Storage(db_path)
+    try:
+        session_data = _decode_flask_session(request)
+
+        email_user_id = session_data.get("email_user_id")
+        if email_user_id is not None:
+            try:
+                user = storage.get_user_by_id(int(email_user_id))
+            except Exception:
+                user = None
+
+            if user and user.get("is_active"):
+                user.pop("password_hash", None)
+                token = {
+                    "id": None,
+                    "subject": user["email"],
+                    "group_name": user["role"],
+                    "is_active": True,
+                    "_email_user_id": user["id"],
+                    "_email_user": user,
+                }
+
+        if not token:
+            token_id = session_data.get("auth_token_id")
+            if token_id is not None:
+                try:
+                    token = storage.get_auth_token_by_id(int(token_id))
+                except Exception:
+                    token = None
+
+        if not token:
+            presented = _extract_presented_token(request)
+            if presented:
+                token = storage.get_auth_token_by_hash(_hash_token(presented))
+    finally:
+        storage.close()
+
+    token = _validate_token_record(token)
+    permissions = _permissions_for_group((token or {}).get("group_name", ""))
+    context = AuthContext(token=token, permissions=permissions)
+    request.state.auth_context = context
+    return context
+
+
+def require_permissions(*required: str):
+    for permission in required:
+        if permission not in _PERMISSIONS:
+            raise ValueError(f"Unknown permission: {permission}")
+
+    def dependency(request: Request) -> AuthContext:
+        require_auth = bool(getattr(request.app.state, "require_auth", False))
+        if not require_auth and all(
+            permission in _PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED for permission in required
+        ):
+            return AuthContext(token=None, permissions=frozenset())
+
+        context = _load_auth_context(request)
+        if not context.token:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+        if any(permission not in context.permissions for permission in required):
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+        return context
+
+    return dependency

--- a/ai_actuarial/api/routers/read.py
+++ b/ai_actuarial/api/routers/read.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from ..deps import AuthContext, require_permissions
+from ..services.read import get_dashboard_stats, list_categories, list_files, parse_file_list_query
+
+router = APIRouter()
+
+
+def _get_db_path(request: Request) -> str:
+    db_path = str(getattr(request.app.state, "db_path", "") or "")
+    if not db_path:
+        raise RuntimeError("FastAPI runtime database path is unavailable")
+    return db_path
+
+
+def _get_active_task_count(request: Request) -> int:
+    active_tasks_ref = getattr(request.app.state, "active_tasks_ref", None)
+    if not isinstance(active_tasks_ref, dict):
+        return 0
+
+    task_lock = getattr(request.app.state, "task_lock", None)
+    if task_lock is None:
+        return len(active_tasks_ref)
+
+    with task_lock:
+        return len(active_tasks_ref)
+
+
+@router.get("/stats")
+def api_stats(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("stats.read")),
+) -> dict[str, int]:
+    return get_dashboard_stats(
+        db_path=_get_db_path(request),
+        active_tasks=_get_active_task_count(request),
+    )
+
+
+@router.get("/categories")
+def api_categories(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("files.read")),
+) -> dict[str, list[str]]:
+    mode = str(request.query_params.get("mode", "") or "")
+    return list_categories(db_path=_get_db_path(request), mode=mode)
+
+
+@router.get("/files")
+def api_files(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("files.read")),
+) -> dict[str, object]:
+    query = parse_file_list_query(request.query_params)
+    return list_files(db_path=_get_db_path(request), query=query)

--- a/ai_actuarial/api/routers/read.py
+++ b/ai_actuarial/api/routers/read.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..deps import AuthContext, require_permissions
 from ..services.read import get_dashboard_stats, list_categories, list_files, parse_file_list_query
@@ -11,7 +11,7 @@ router = APIRouter()
 def _get_db_path(request: Request) -> str:
     db_path = str(getattr(request.app.state, "db_path", "") or "")
     if not db_path:
-        raise RuntimeError("FastAPI runtime database path is unavailable")
+        raise HTTPException(status_code=500, detail="Database path is unavailable")
     return db_path
 
 

--- a/ai_actuarial/api/services/__init__.py
+++ b/ai_actuarial/api/services/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/ai_actuarial/api/services/read.py
+++ b/ai_actuarial/api/services/read.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from ai_actuarial.storage import Storage
+from ai_actuarial.web.app import _get_categories_config_path, _load_yaml, _parse_int_clamped
+
+FILE_LIST_FIELDS: tuple[str, ...] = (
+    "url",
+    "sha256",
+    "title",
+    "source_site",
+    "source_page_url",
+    "original_filename",
+    "local_path",
+    "bytes",
+    "content_type",
+    "last_modified",
+    "etag",
+    "published_time",
+    "first_seen",
+    "last_seen",
+    "crawl_time",
+    "deleted_at",
+    "category",
+    "summary",
+    "keywords",
+    "markdown_content",
+    "markdown_source",
+    "markdown_updated_at",
+    "rag_chunk_count",
+    "rag_indexed_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FileListQuery:
+    limit: int
+    offset: int
+    order_by: str
+    order_dir: str
+    query: str
+    source: str
+    category: str
+    include_deleted: bool
+
+
+def parse_file_list_query(raw_query: Mapping[str, str | None]) -> FileListQuery:
+    return FileListQuery(
+        limit=_parse_int_clamped(raw_query.get("limit", 20), default=20, min_value=1, max_value=1000),
+        offset=_parse_int_clamped(raw_query.get("offset", 0), default=0, min_value=0, max_value=1_000_000),
+        order_by=str(raw_query.get("order_by", "last_seen") or "last_seen"),
+        order_dir=str(raw_query.get("order_dir", "desc") or "desc"),
+        query=str(raw_query.get("query", "") or ""),
+        source=str(raw_query.get("source", "") or ""),
+        category=str(raw_query.get("category", "") or ""),
+        include_deleted=str(raw_query.get("include_deleted", "false") or "false").lower() == "true",
+    )
+
+
+def _project_file_row(file_row: dict[str, Any]) -> dict[str, Any]:
+    return {field: file_row.get(field) for field in FILE_LIST_FIELDS}
+
+
+def project_recent_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    fields = ("url", "title", "original_filename", "source_site", "content_type", "last_seen")
+    return [{field: item.get(field) for field in fields} for item in files]
+
+
+def project_database_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [_project_file_row(item) for item in files]
+
+
+def get_dashboard_stats(*, db_path: str, active_tasks: int) -> dict[str, int]:
+    storage = Storage(db_path)
+    try:
+        return {
+            "total_files": storage.get_file_count(require_local=True),
+            "cataloged_files": storage.get_cataloged_count(),
+            "total_sources": storage.get_sources_count(),
+            "active_tasks": active_tasks,
+        }
+    finally:
+        storage.close()
+
+
+def list_categories(*, db_path: str, mode: str = "") -> dict[str, list[str]]:
+    if mode.strip().lower() == "used":
+        storage = Storage(db_path)
+        try:
+            categories = storage.get_unique_categories()
+        finally:
+            storage.close()
+        return {"categories": categories}
+
+    category_config_path = _get_categories_config_path()
+    if os.path.exists(category_config_path):
+        cat_config = _load_yaml(category_config_path, default={})
+        configured = cat_config.get("categories") or {}
+        if isinstance(configured, dict):
+            return {"categories": list(configured.keys())}
+        return {"categories": []}
+
+    storage = Storage(db_path)
+    try:
+        categories = storage.get_unique_categories()
+    finally:
+        storage.close()
+    return {"categories": categories}
+
+
+def list_files(*, db_path: str, query: FileListQuery) -> dict[str, Any]:
+    storage = Storage(db_path)
+    try:
+        files, total = storage.query_files_with_catalog(
+            limit=query.limit,
+            offset=query.offset,
+            order_by=query.order_by,
+            order_dir=query.order_dir,
+            query=query.query,
+            source=query.source,
+            category=query.category,
+            include_deleted=query.include_deleted,
+        )
+    finally:
+        storage.close()
+
+    return {
+        "files": project_database_files(files),
+        "total": total,
+        "limit": query.limit,
+        "offset": query.offset,
+    }

--- a/docs/开发日志-2026-03-09-fastapi原生读接口第一批.md
+++ b/docs/开发日志-2026-03-09-fastapi原生读接口第一批.md
@@ -1,0 +1,113 @@
+# 2026-03-09 FastAPI 原生读接口第一批
+
+## 进展摘要
+
+- 分支：`feature/fastapi-native-read-endpoints`
+- 目标：将 `GET /api/stats`、`GET /api/categories`、`GET /api/files` 迁移为 FastAPI 原生路由，同时保持 React 现有调用方式不变。
+- 结果：3 个接口已完成原生迁移，legacy Flask fallback 继续保留给未迁移接口使用。
+- 自动化测试已通过，全量 `pytest` 结果为 `403 passed, 39 warnings, 4 subtests passed`。
+
+## 已完成任务
+
+- 为 FastAPI 新增共享权限依赖：
+  - 支持 bearer token
+  - 支持 Flask session cookie 解码
+  - 对齐 `REQUIRE_AUTH=true/false` 两种模式下的权限行为
+- 为 FastAPI 新增读服务层：
+  - stats 聚合函数
+  - categories 读取函数
+  - files 列表查询与字段投影函数
+- 新增原生路由：
+  - `/api/stats`
+  - `/api/categories`
+  - `/api/files`
+- 扩展 FastAPI app state：
+  - `legacy_flask_app`
+  - `db_path`
+  - `require_auth`
+  - 任务计数引用
+- 新增 FastAPI 集成测试，覆盖：
+  - native path 生效
+  - 文件分页/筛选/包含已删除
+  - bearer token 鉴权
+  - Flask session cookie 鉴权
+
+## 关键实现说明
+
+### 1. 路由未直接转发 Flask
+
+这 3 个接口已不再通过 HTTP/WSGI 间接调用 legacy Flask，而是直接复用现有 Python 逻辑：
+
+- [`deps.py`](/c:/Projects/AI_actuarial_inforsearch/ai_actuarial/api/deps.py)
+- [`read.py`](/c:/Projects/AI_actuarial_inforsearch/ai_actuarial/api/services/read.py)
+- [`read.py`](/c:/Projects/AI_actuarial_inforsearch/ai_actuarial/api/routers/read.py)
+
+### 2. `/api/files` 先内部拆小、外部保持兼容
+
+- 对外仍保留 `GET /api/files`
+- 内部已拆成：
+  - query 参数解析
+  - storage 查询
+  - 文件行字段投影
+- 当前没有改 React 页面地址，因此 Dashboard 和 Database 不需要同步修改
+
+### 3. 鉴权语义保持现状
+
+- `REQUIRE_AUTH=false` 时，这 3 个读接口继续允许公共访问
+- `REQUIRE_AUTH=true` 时，支持：
+  - bearer token
+  - Flask session cookie
+
+## 兼容性注意点
+
+- `/api/categories?mode=used` 当前沿用了 legacy Flask 语义：
+  - 它返回数据库里“出现过”的分类
+  - 不会自动过滤已删除 catalog 记录里的历史分类
+- 这意味着已删除文件对应的分类仍可能出现在 `mode=used` 结果中。
+- 这是旧行为兼容，不是本次 FastAPI 迁移引入的新问题。
+
+## 自动化验证
+
+### 定向测试
+
+```bash
+.\.venv\Scripts\python.exe -m pytest -q -o addopts= tests\test_fastapi_entrypoint.py tests\test_fastapi_read_endpoints.py tests\test_auth_tokens.py::TestTokenAuth::test_api_requires_auth tests\test_auth_tokens.py::TestTokenAuth::test_bearer_token_reader_can_read_stats
+```
+
+结果：
+
+- `8 passed`
+
+### 全量测试
+
+```bash
+.\.venv\Scripts\python.exe -m pytest -q -o addopts=
+```
+
+结果：
+
+- `403 passed`
+- `39 warnings`
+- `4 subtests passed`
+
+## 用户测试清单
+
+- [ ] 启动 FastAPI 网关：`python -m ai_actuarial api --host 127.0.0.1 --port 8000`
+- [ ] 打开 Dashboard，确认统计卡片和最近文件正常加载
+- [ ] 打开 Database，确认文件列表、搜索、source/category 筛选、include deleted 正常
+- [ ] 在启用认证的环境下，验证登录后仍能正常访问 Dashboard 和 Database
+- [ ] 在未登录且 `REQUIRE_AUTH=true` 的环境下，确认原生 read 接口会返回未授权
+- [ ] 检查 `/api/migration/status`，确认 native paths 已包含 `/api/stats`、`/api/categories`、`/api/files`
+
+## 提交记录
+
+- `44c77d4` `feat: add native fastapi read endpoints for stats files and categories`
+
+## 下一步
+
+- 评估是否要继续把 `/api/files` 拆成更小的对外接口：
+  - `/api/dashboard/recent-files`
+  - `/api/database/files`
+  - `/api/database/filter-options`
+- 继续迁移下一批低风险读接口，例如 `/api/sources`
+- 如果确认读接口这条线稳定，再推进更复杂的详情类与任务类接口

--- a/docs/规划文档-2026-03-09-fastapi原生读接口Phase0.md
+++ b/docs/规划文档-2026-03-09-fastapi原生读接口Phase0.md
@@ -1,0 +1,172 @@
+# FastAPI 原生读接口实施计划
+
+## 一、现状分析
+
+- 当前分支：`feature/fastapi-native-read-endpoints`
+- 基线分支：`feature/react-fastapi-migration`
+- 当前 FastAPI 仅原生提供：
+  - `/api/health`
+  - `/api/migration/status`
+- 其余 API 仍由 FastAPI 网关挂载 legacy Flask 回退。
+- 本次目标的 3 个接口目前都在 Flask 中实现：
+  - `/api/stats`
+  - `/api/files`
+  - `/api/categories`
+- React 端直接依赖这些接口：
+  - Dashboard：`/api/stats`、`/api/files`
+  - Database：`/api/files`、`/api/categories`
+  - task options：`/api/categories?mode=used`
+
+## 二、需求说明
+
+目标是在不改变前端调用方式的前提下，把以下接口改为 FastAPI 原生实现：
+
+- `GET /api/stats`
+- `GET /api/files`
+- `GET /api/categories`
+
+约束条件：
+
+- 返回 JSON 结构必须与当前 Flask 接口保持兼容。
+- 保留现有鉴权语义：
+  - `REQUIRE_AUTH=true` 时必须走 token/session 权限校验。
+  - `REQUIRE_AUTH=false` 时保留公共只读访问行为。
+- legacy Flask fallback 继续保留，未迁移接口不受影响。
+- 完成后必须通过自动化测试，并补文档记录。
+
+## 三、技术方案
+
+### 方案概述
+
+在 `ai_actuarial/api/routers/` 下新增读接口路由模块，FastAPI 直接调用现有 `Storage` 抽象和配置读取逻辑，避免通过 HTTP 再转发到 Flask。
+
+### 关键设计
+
+1. 鉴权与权限
+
+- 为 FastAPI 增加与 Flask 行为一致的轻量权限依赖。
+- 优先复用现有 Flask 中成熟的 token/session 规则，而不是重新定义一套新的权限模型。
+- 本批只覆盖 `stats.read` / `files.read` 这类读权限。
+
+2. 数据来源
+
+- `/api/stats`：直接调用 `Storage.get_file_count()`、`get_cataloged_count()`、`get_sources_count()`，并补上运行中任务数。
+- `/api/files`：直接调用 `Storage.query_files_with_catalog()`，保留现有 query 参数和分页格式。
+- `/api/categories`：
+  - `mode=used` 时走数据库唯一分类。
+  - 默认模式优先读取 `categories.yaml`，缺失时回退数据库。
+
+3. 兼容策略
+
+- 响应字段名、默认值、查询参数名称保持不变。
+- React 端不改调用地址，不改请求参数。
+- 通过新增 FastAPI 测试确认原生路由优先于 Flask fallback 生效。
+
+4. 测试策略
+
+- 新增 FastAPI 集成测试，覆盖：
+  - 基本成功响应
+  - `REQUIRE_AUTH=true` 时的鉴权
+  - `REQUIRE_AUTH=false` 时的公共访问
+  - `/api/files` 的分页/筛选
+  - `/api/categories?mode=used`
+  - `/api/migration/status` 中 native path 列表更新
+- 回归全量 pytest。
+
+## 四、实施步骤
+
+### Phase 1: 搭建共享依赖与测试骨架
+
+**时间估算**: 1-1.5 小时
+
+**步骤**:
+
+- [ ] 设计 FastAPI 读接口模块结构与响应模型
+- [ ] 建立 FastAPI 侧读权限依赖
+- [ ] 新增原生读接口测试文件骨架
+
+### Phase 2: 迁移 `/api/stats`
+
+**时间估算**: 0.5-1 小时
+
+**步骤**:
+
+- [ ] 实现 `GET /api/stats`
+- [ ] 补 Dashboard 依赖字段测试
+- [ ] 确认 native route 出现在 migration status 中
+
+### Phase 3: 迁移 `/api/categories`
+
+**时间估算**: 0.5-1 小时
+
+**步骤**:
+
+- [ ] 实现 `GET /api/categories`
+- [ ] 覆盖默认模式与 `mode=used`
+- [ ] 校验 Database / task options 依赖字段
+
+### Phase 4: 迁移 `/api/files`
+
+**时间估算**: 1-2 小时
+
+**步骤**:
+
+- [ ] 实现 `GET /api/files`
+- [ ] 保持分页、排序、筛选参数兼容
+- [ ] 校验 Dashboard / Database 使用场景
+
+### Phase 5: 自动化验证与文档
+
+**时间估算**: 0.5-1 小时
+
+**步骤**:
+
+- [ ] 跑新增 FastAPI 测试
+- [ ] 跑全量 pytest
+- [ ] 记录开发日志与测试结果
+
+## 五、关键决策点
+
+### 决策 1: 直接复用 Storage，还是调用 legacy Flask 逻辑
+
+**选项**: A. 通过 HTTP/WSGI 间接调用 Flask；B. 直接调用 Storage 和配置逻辑
+
+**选择**: B
+
+**理由**: 这批接口本身就是读接口，底层逻辑简单稳定，直接调用抽象层更清晰，也更符合“原生 FastAPI”目标。
+
+### 决策 2: 先迁移哪个接口
+
+**选项**: A. 先做 `/api/files`；B. 先做 `/api/stats` 和 `/api/categories`
+
+**选择**: B
+
+**理由**: `/api/stats` 和 `/api/categories` 读路径更短、依赖更少，适合作为 FastAPI 鉴权和返回契约的第一批验证。
+
+### 决策 3: 是否顺带重构 Flask 权限逻辑
+
+**选项**: A. 先抽出完整共享 auth 模块；B. 先做最小兼容适配
+
+**选择**: B
+
+**理由**: 当前目标是接口迁移，不是权限系统重构。先保证兼容和测试通过，再考虑后续抽象。
+
+## 六、风险与注意事项
+
+- FastAPI 原生路由和 Flask mount 的优先级必须验证，避免看起来迁了但实际仍走 Flask。
+- `/api/files` 返回结构较大，字段兼容性是本批最大回归点。
+- 认证场景要覆盖 `REQUIRE_AUTH=true` 和 `false` 两种模式。
+- `categories.yaml` 与数据库 fallback 的行为必须与 Flask 保持一致。
+
+## 七、成功标准
+
+- [ ] `/api/stats`、`/api/files`、`/api/categories` 由 FastAPI 原生提供
+- [ ] React 端 Dashboard / Database / task options 无需改动即可正常调用
+- [ ] `/api/migration/status` 能反映新增 native paths
+- [ ] 新增测试通过
+- [ ] 全量 pytest 通过
+- [ ] 开发日志完成
+
+## 八、时间估算
+
+**总计**: 3.5-6.5 小时

--- a/docs/规划文档-2026-03-09-fastapi原生读接口Phase0.md
+++ b/docs/规划文档-2026-03-09-fastapi原生读接口Phase0.md
@@ -7,83 +7,198 @@
 - 当前 FastAPI 仅原生提供：
   - `/api/health`
   - `/api/migration/status`
-- 其余 API 仍由 FastAPI 网关挂载 legacy Flask 回退。
-- 本次目标的 3 个接口目前都在 Flask 中实现：
-  - `/api/stats`
-  - `/api/files`
-  - `/api/categories`
-- React 端直接依赖这些接口：
-  - Dashboard：`/api/stats`、`/api/files`
-  - Database：`/api/files`、`/api/categories`
-  - task options：`/api/categories?mode=used`
+- 目标接口目前仍由 legacy Flask 提供：
+  - `GET /api/stats`
+  - `GET /api/files`
+  - `GET /api/categories`
+- React 端实际依赖如下：
+  - Dashboard：
+    - `GET /api/stats`
+    - `GET /api/files?limit=8&order_by=last_seen&order_dir=desc`
+  - Database：
+    - `GET /api/files`
+    - `GET /api/sources`
+    - `GET /api/categories`
+  - task options：
+    - `GET /api/categories?mode=used`
+
+### 代码现状判断
+
+- `/api/stats` 本身已经很小，只是组合了几个独立方法：
+  - `Storage.get_file_count()`
+  - `Storage.get_cataloged_count()`
+  - `Storage.get_sources_count()`
+  - 运行中任务数
+- `/api/categories` 也比较清晰：
+  - 默认模式优先读 `categories.yaml`
+  - `mode=used` 回退数据库唯一分类
+- `/api/files` 表面是一个大接口，但底层核心查询已经收敛到单一函数：
+  - `Storage.query_files_with_catalog()`
+- 这个查询函数当前返回字段很多，明显超过某些页面的最小需要。
+
+### 页面实际字段依赖
+
+- Dashboard 对 `/api/files` 只需要：
+  - `url`
+  - `title`
+  - `original_filename`
+  - `source_site`
+  - `content_type`
+  - `last_seen`
+- Database 对 `/api/files` 需要：
+  - `url`
+  - `title`
+  - `original_filename`
+  - `source_site`
+  - `content_type`
+  - `last_seen`
+  - `category`
+  - `summary`
+  - `markdown_content`
+  - `markdown_source`
+  - `bytes`
+  - `deleted_at`
+- 当前 `Storage.query_files_with_catalog()` 实际会返回更多字段：
+  - `sha256`
+  - `source_page_url`
+  - `local_path`
+  - `last_modified`
+  - `etag`
+  - `published_time`
+  - `first_seen`
+  - `crawl_time`
+  - `keywords`
+  - `markdown_updated_at`
+  - `rag_chunk_count`
+  - `rag_indexed_at`
+
+结论：
+
+- 你说得对，`/api/files` 里面的内容不该简单当成一个“页面大接口”照搬。
+- 但短期内不建议直接修改前端公共 API 地址，因为那会扩大迁移面。
+- 更稳的做法是：
+  - 对外继续兼容 `GET /api/files`
+  - 在 FastAPI 内部先拆成更小的服务函数和响应投影
+  - 如果后面确认收益明显，再新增更细的专用小接口
 
 ## 二、需求说明
 
-目标是在不改变前端调用方式的前提下，把以下接口改为 FastAPI 原生实现：
+目标是在不破坏现有 React 调用的前提下，把以下接口迁为 FastAPI 原生：
 
 - `GET /api/stats`
-- `GET /api/files`
 - `GET /api/categories`
+- `GET /api/files`
+
+同时引入更小的内部能力拆分：
+
+- stats 聚合函数
+- category 读取函数
+- file list 查询与字段投影函数
+
+可选的后续优化目标：
+
+- 为 Dashboard 单独提供更轻量的 recent-files 接口
+- 为 Database 单独提供 filters/options 接口
+- 将 `/api/files` 从“全字段大列表”收缩成更明确的 view model
 
 约束条件：
 
-- 返回 JSON 结构必须与当前 Flask 接口保持兼容。
-- 保留现有鉴权语义：
-  - `REQUIRE_AUTH=true` 时必须走 token/session 权限校验。
-  - `REQUIRE_AUTH=false` 时保留公共只读访问行为。
-- legacy Flask fallback 继续保留，未迁移接口不受影响。
-- 完成后必须通过自动化测试，并补文档记录。
+- 当前 React 页面不改 URL，不改现有调用参数
+- 当前 JSON 契约先保持兼容
+- `REQUIRE_AUTH=true/false` 两种模式都要维持现有行为
+- legacy Flask fallback 保留，未迁移接口不受影响
 
 ## 三、技术方案
 
 ### 方案概述
 
-在 `ai_actuarial/api/routers/` 下新增读接口路由模块，FastAPI 直接调用现有 `Storage` 抽象和配置读取逻辑，避免通过 HTTP 再转发到 Flask。
+在 `ai_actuarial/api/routers/` 下新增读接口模块，在 `ai_actuarial/api/` 下新增共享依赖/服务层，将现有 Flask 读逻辑拆成更小的 Python 函数，然后由 FastAPI 路由组合返回兼容 JSON。
 
-### 关键设计
+### 分层方案
 
-1. 鉴权与权限
+1. 路由层
 
-- 为 FastAPI 增加与 Flask 行为一致的轻量权限依赖。
-- 优先复用现有 Flask 中成熟的 token/session 规则，而不是重新定义一套新的权限模型。
-- 本批只覆盖 `stats.read` / `files.read` 这类读权限。
+- 负责解析 query 参数
+- 调用权限依赖
+- 组装 HTTP 响应
 
-2. 数据来源
+2. 服务层
 
-- `/api/stats`：直接调用 `Storage.get_file_count()`、`get_cataloged_count()`、`get_sources_count()`，并补上运行中任务数。
-- `/api/files`：直接调用 `Storage.query_files_with_catalog()`，保留现有 query 参数和分页格式。
-- `/api/categories`：
-  - `mode=used` 时走数据库唯一分类。
-  - 默认模式优先读取 `categories.yaml`，缺失时回退数据库。
+- `get_dashboard_stats(...)`
+- `list_categories(...)`
+- `list_used_categories(...)`
+- `list_files(...)`
+- `project_recent_files(...)`
+- `project_database_files(...)`
 
-3. 兼容策略
+3. 数据层
 
-- 响应字段名、默认值、查询参数名称保持不变。
-- React 端不改调用地址，不改请求参数。
-- 通过新增 FastAPI 测试确认原生路由优先于 Flask fallback 生效。
+- 优先复用现有 `Storage` 抽象
+- 配置仍复用 `_get_categories_config_path()` 与 YAML 读取逻辑
 
-4. 测试策略
+### `/api/files` 的建议拆法
 
-- 新增 FastAPI 集成测试，覆盖：
-  - 基本成功响应
-  - `REQUIRE_AUTH=true` 时的鉴权
-  - `REQUIRE_AUTH=false` 时的公共访问
-  - `/api/files` 的分页/筛选
-  - `/api/categories?mode=used`
-  - `/api/migration/status` 中 native path 列表更新
-- 回归全量 pytest。
+#### 对外第一阶段
+
+仍保留：
+
+- `GET /api/files`
+
+但在 FastAPI 内部拆成：
+
+- 参数解析函数
+- 文件查询函数
+- Dashboard/Database 共用字段投影函数
+
+#### 对外第二阶段可选
+
+如果后续想进一步瘦身，可新增：
+
+- `GET /api/dashboard/recent-files`
+- `GET /api/database/files`
+- `GET /api/database/filter-options`
+
+然后再逐步让 React 页面切过去。
+
+这样做的好处：
+
+- 先把“Flask -> FastAPI 原生”这个目标完成
+- 不把“接口瘦身”和“框架迁移”耦合到同一个 PR
+- 未来如果要继续拆 API，有现成的服务层可以复用
+
+### 鉴权设计
+
+- 为 FastAPI 增加轻量权限依赖
+- 行为对齐现有 Flask：
+  - `stats.read`
+  - `files.read`
+- `REQUIRE_AUTH=false` 时保留公共只读访问
+- `REQUIRE_AUTH=true` 时沿用 token/session 语义
+
+### 测试策略
+
+新增 FastAPI 集成测试，覆盖：
+
+- `/api/stats`
+- `/api/categories`
+- `/api/files`
+- `REQUIRE_AUTH=true`
+- `REQUIRE_AUTH=false`
+- `/api/files` 的分页、排序、筛选
+- `mode=used`
+- `/api/migration/status` 中 native path 列表更新
 
 ## 四、实施步骤
 
-### Phase 1: 搭建共享依赖与测试骨架
+### Phase 1: 建立共享服务层与测试骨架
 
 **时间估算**: 1-1.5 小时
 
 **步骤**:
 
-- [ ] 设计 FastAPI 读接口模块结构与响应模型
-- [ ] 建立 FastAPI 侧读权限依赖
-- [ ] 新增原生读接口测试文件骨架
+- [ ] 抽出 FastAPI 读接口共享依赖
+- [ ] 抽出 stats/categories/files 服务函数
+- [ ] 新增 FastAPI 读接口测试骨架
 
 ### Phase 2: 迁移 `/api/stats`
 
@@ -92,8 +207,8 @@
 **步骤**:
 
 - [ ] 实现 `GET /api/stats`
-- [ ] 补 Dashboard 依赖字段测试
-- [ ] 确认 native route 出现在 migration status 中
+- [ ] 保持 Dashboard 字段兼容
+- [ ] 验证 native route 生效
 
 ### Phase 3: 迁移 `/api/categories`
 
@@ -103,19 +218,29 @@
 
 - [ ] 实现 `GET /api/categories`
 - [ ] 覆盖默认模式与 `mode=used`
-- [ ] 校验 Database / task options 依赖字段
+- [ ] 验证 Database 和 task options 契约
 
 ### Phase 4: 迁移 `/api/files`
 
-**时间估算**: 1-2 小时
+**时间估算**: 1.5-2.5 小时
 
 **步骤**:
 
 - [ ] 实现 `GET /api/files`
-- [ ] 保持分页、排序、筛选参数兼容
-- [ ] 校验 Dashboard / Database 使用场景
+- [ ] 内部拆分参数解析、查询、字段投影
+- [ ] 对齐 Dashboard 与 Database 的共同字段
+- [ ] 验证分页、排序、筛选语义
 
-### Phase 5: 自动化验证与文档
+### Phase 5: 评估下一步接口瘦身
+
+**时间估算**: 0.5 小时
+
+**步骤**:
+
+- [ ] 判断是否值得新增 `recent-files` / `database/files` / `filter-options`
+- [ ] 如果不在本轮实施，记录为后续子 PR 范围
+
+### Phase 6: 自动化验证与文档
 
 **时间估算**: 0.5-1 小时
 
@@ -123,50 +248,52 @@
 
 - [ ] 跑新增 FastAPI 测试
 - [ ] 跑全量 pytest
-- [ ] 记录开发日志与测试结果
+- [ ] 补开发日志与测试结果
 
 ## 五、关键决策点
 
-### 决策 1: 直接复用 Storage，还是调用 legacy Flask 逻辑
+### 决策 1: 是先改外部接口，还是先拆内部服务层
 
-**选项**: A. 通过 HTTP/WSGI 间接调用 Flask；B. 直接调用 Storage 和配置逻辑
+**选项**: A. 直接新增很多细接口并同步改 React；B. 先保持旧 URL，不改 React，内部先拆小
 
 **选择**: B
 
-**理由**: 这批接口本身就是读接口，底层逻辑简单稳定，直接调用抽象层更清晰，也更符合“原生 FastAPI”目标。
+**理由**: 这次主任务是迁移到 FastAPI 原生，不是同时做前端 API 全面重构。先内部拆小、外部兼容，风险最低。
 
-### 决策 2: 先迁移哪个接口
+### 决策 2: `/api/files` 是否保留
+
+**选项**: A. 立即废弃 `/api/files`；B. 本轮保留 `/api/files`，后续再演进
+
+**选择**: B
+
+**理由**: Dashboard 和 Database 都依赖它，立即拆掉会扩大改动范围。当前更适合先把逻辑拆干净，再看是否值得把 URL 层也切开。
+
+### 决策 3: 优先迁移顺序
 
 **选项**: A. 先做 `/api/files`；B. 先做 `/api/stats` 和 `/api/categories`
 
 **选择**: B
 
-**理由**: `/api/stats` 和 `/api/categories` 读路径更短、依赖更少，适合作为 FastAPI 鉴权和返回契约的第一批验证。
-
-### 决策 3: 是否顺带重构 Flask 权限逻辑
-
-**选项**: A. 先抽出完整共享 auth 模块；B. 先做最小兼容适配
-
-**选择**: B
-
-**理由**: 当前目标是接口迁移，不是权限系统重构。先保证兼容和测试通过，再考虑后续抽象。
+**理由**: 这两个接口更简单，适合先验证 FastAPI 权限、配置访问和原生路由优先级。
 
 ## 六、风险与注意事项
 
-- FastAPI 原生路由和 Flask mount 的优先级必须验证，避免看起来迁了但实际仍走 Flask。
-- `/api/files` 返回结构较大，字段兼容性是本批最大回归点。
-- 认证场景要覆盖 `REQUIRE_AUTH=true` 和 `false` 两种模式。
-- `categories.yaml` 与数据库 fallback 的行为必须与 Flask 保持一致。
+- `/api/files` 的字段兼容性是这一批最大的回归点。
+- FastAPI 原生路由必须验证优先级，避免表面迁移但实际仍走 Flask。
+- `categories.yaml` 与数据库 fallback 行为必须与 Flask 一致。
+- 内部服务层拆分不能顺带改变排序、筛选、默认值语义。
 
 ## 七、成功标准
 
-- [ ] `/api/stats`、`/api/files`、`/api/categories` 由 FastAPI 原生提供
-- [ ] React 端 Dashboard / Database / task options 无需改动即可正常调用
-- [ ] `/api/migration/status` 能反映新增 native paths
+- [ ] `GET /api/stats` 由 FastAPI 原生提供
+- [ ] `GET /api/categories` 由 FastAPI 原生提供
+- [ ] `GET /api/files` 由 FastAPI 原生提供
+- [ ] React 端 Dashboard / Database / task options 无需改动即可继续工作
+- [ ] FastAPI 内部已形成更小的服务函数边界
 - [ ] 新增测试通过
 - [ ] 全量 pytest 通过
 - [ ] 开发日志完成
 
 ## 八、时间估算
 
-**总计**: 3.5-6.5 小时
+**总计**: 4.5-7.5 小时

--- a/tests/test_fastapi_read_endpoints.py
+++ b/tests/test_fastapi_read_endpoints.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from ai_actuarial.api.app import create_app
+from ai_actuarial.storage import Storage
+
+
+def _write_config_files(base_dir: Path) -> tuple[Path, Path, Path]:
+    db_path = base_dir / "index.db"
+    config_path = base_dir / "sites.yaml"
+    categories_path = base_dir / "categories.yaml"
+
+    config = {
+        "paths": {
+            "db": str(db_path),
+            "download_dir": str(base_dir / "files"),
+            "updates_dir": str(base_dir / "updates"),
+            "last_run_new": str(base_dir / "last_run_new.json"),
+        },
+        "defaults": {
+            "user_agent": "test-agent/1.0",
+            "max_pages": 10,
+            "max_depth": 1,
+            "file_exts": [".pdf"],
+        },
+        "sites": [],
+    }
+    categories = {
+        "categories": {
+            "AI": ["artificial intelligence"],
+            "Pricing": ["premium"],
+            "Reserve": ["reserve"],
+        }
+    }
+
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    categories_path.write_text(yaml.safe_dump(categories, sort_keys=False), encoding="utf-8")
+    return db_path, config_path, categories_path
+
+
+def _seed_storage(db_path: Path) -> dict[str, object]:
+    storage = Storage(str(db_path))
+    try:
+        storage.insert_file(
+            url="https://alpha.example/doc-a.pdf",
+            sha256="hash-alpha",
+            title="Alpha Document",
+            source_site="alpha.example",
+            source_page_url="https://alpha.example",
+            original_filename="doc-a.pdf",
+            local_path="/tmp/doc-a.pdf",
+            bytes=1024,
+            content_type="application/pdf",
+        )
+        storage.upsert_catalog_item(
+            item={
+                "url": "https://alpha.example/doc-a.pdf",
+                "sha256": "hash-alpha",
+                "keywords": ["ai"],
+                "summary": "Alpha summary",
+                "category": "AI; Risk",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+
+        storage.insert_file(
+            url="https://beta.example/doc-b.docx",
+            sha256="hash-beta",
+            title="Beta Document",
+            source_site="beta.example",
+            source_page_url="https://beta.example",
+            original_filename="doc-b.docx",
+            local_path="/tmp/doc-b.docx",
+            bytes=2048,
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+        storage.upsert_catalog_item(
+            item={
+                "url": "https://beta.example/doc-b.docx",
+                "sha256": "hash-beta",
+                "keywords": ["pricing"],
+                "summary": "Beta summary",
+                "category": "Pricing",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+
+        storage.insert_file(
+            url="https://gamma.example/doc-c.pdf",
+            sha256="hash-gamma",
+            title="Gamma Deleted",
+            source_site="gamma.example",
+            source_page_url="https://gamma.example",
+            original_filename="doc-c.pdf",
+            local_path="/tmp/doc-c.pdf",
+            bytes=512,
+            content_type="application/pdf",
+        )
+        storage.upsert_catalog_item(
+            item={
+                "url": "https://gamma.example/doc-c.pdf",
+                "sha256": "hash-gamma",
+                "keywords": ["archived"],
+                "summary": "Gamma summary",
+                "category": "Archive",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+        deleted_at = datetime.now(timezone.utc).isoformat()
+        storage.mark_file_deleted("https://gamma.example/doc-c.pdf", deleted_at)
+        storage.clear_local_path("https://gamma.example/doc-c.pdf")
+
+        user_id = storage.create_user(
+            "reader@example.com",
+            "test-password-hash",
+            role="registered",
+            display_name="Reader",
+        )
+        token_plain = "reader-token"
+        storage.upsert_auth_token_by_hash(
+            subject="reader-token",
+            group_name="reader",
+            token_hash=hashlib.sha256(token_plain.encode("utf-8")).hexdigest(),
+            is_active=True,
+        )
+
+        storage._conn.execute(
+            "UPDATE files SET last_seen = ? WHERE url = ?",
+            ("2026-03-08T10:00:00+00:00", "https://alpha.example/doc-a.pdf"),
+        )
+        storage._conn.execute(
+            "UPDATE files SET last_seen = ? WHERE url = ?",
+            ("2026-03-09T10:00:00+00:00", "https://beta.example/doc-b.docx"),
+        )
+        storage._conn.execute(
+            "UPDATE files SET last_seen = ? WHERE url = ?",
+            ("2026-03-07T10:00:00+00:00", "https://gamma.example/doc-c.pdf"),
+        )
+        storage._conn.commit()
+    finally:
+        storage.close()
+
+    return {"user_id": user_id, "token_plain": token_plain}
+
+
+def _build_test_client(tmp_path: Path, monkeypatch, *, require_auth: bool) -> tuple[TestClient, object, dict[str, object]]:
+    db_path, config_path, categories_path = _write_config_files(tmp_path)
+    seed = _seed_storage(db_path)
+
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("CATEGORIES_CONFIG_PATH", str(categories_path))
+    monkeypatch.setenv("FLASK_SECRET_KEY", "fastapi-read-test-secret")
+    if require_auth:
+        monkeypatch.setenv("REQUIRE_AUTH", "true")
+    else:
+        monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+
+    app = create_app()
+    client = TestClient(app)
+    return client, app, seed
+
+
+def _make_session_cookie(app, payload: dict[str, object]) -> str:
+    legacy_app = app.state.legacy_flask_app
+    serializer = legacy_app.session_interface.get_signing_serializer(legacy_app)
+    assert serializer is not None
+    return serializer.dumps(payload)
+
+
+def test_fastapi_stats_and_categories_are_native(tmp_path: Path, monkeypatch) -> None:
+    client, app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
+
+    stats = client.get("/api/stats")
+    assert stats.status_code == 200
+    assert stats.json() == {
+        "total_files": 2,
+        "cataloged_files": 2,
+        "total_sources": 3,
+        "active_tasks": 0,
+    }
+
+    categories = client.get("/api/categories")
+    assert categories.status_code == 200
+    assert categories.json()["categories"] == ["AI", "Pricing", "Reserve"]
+
+    used_categories = client.get("/api/categories?mode=used")
+    assert used_categories.status_code == 200
+    assert used_categories.json()["categories"] == ["AI", "Archive", "Pricing", "Risk"]
+
+    migration = client.get("/api/migration/status")
+    body = migration.json()
+    assert "/api/stats" in body["native_paths"]
+    assert "/api/categories" in body["native_paths"]
+    assert "/api/files" in body["native_paths"]
+
+
+def test_fastapi_files_supports_filters_sorting_and_deleted(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
+
+    response = client.get("/api/files?limit=10&order_by=title&order_dir=asc")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert body["limit"] == 10
+    assert body["offset"] == 0
+    assert [item["title"] for item in body["files"]] == ["Alpha Document", "Beta Document"]
+
+    filtered = client.get("/api/files?category=AI")
+    assert filtered.status_code == 200
+    filtered_body = filtered.json()
+    assert filtered_body["total"] == 1
+    assert filtered_body["files"][0]["title"] == "Alpha Document"
+    assert filtered_body["files"][0]["category"] == "AI; Risk"
+
+    deleted = client.get("/api/files?include_deleted=true&order_by=title&order_dir=asc")
+    assert deleted.status_code == 200
+    deleted_body = deleted.json()
+    assert deleted_body["total"] == 3
+    assert [item["title"] for item in deleted_body["files"]] == [
+        "Alpha Document",
+        "Beta Document",
+        "Gamma Deleted",
+    ]
+
+
+def test_fastapi_native_read_routes_require_bearer_auth(tmp_path: Path, monkeypatch) -> None:
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
+
+    unauthorized = client.get("/api/stats")
+    assert unauthorized.status_code == 401
+
+    authorized = client.get(
+        "/api/files",
+        headers={"Authorization": f"Bearer {seed['token_plain']}"},
+    )
+    assert authorized.status_code == 200
+    assert authorized.json()["total"] == 2
+
+
+def test_fastapi_native_read_routes_accept_flask_session_cookie(tmp_path: Path, monkeypatch) -> None:
+    client, app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
+
+    cookie_name = app.state.legacy_flask_app.config.get("SESSION_COOKIE_NAME", "session")
+    session_cookie = _make_session_cookie(app, {"email_user_id": seed["user_id"]})
+    client.cookies.set(cookie_name, session_cookie)
+
+    response = client.get("/api/categories?mode=used")
+    assert response.status_code == 200
+    assert response.json()["categories"] == ["AI", "Archive", "Pricing", "Risk"]


### PR DESCRIPTION
## Summary
- add native FastAPI implementations for `GET /api/stats`, `GET /api/categories`, and `GET /api/files`
- keep legacy Flask fallback for all unported routes while moving these read endpoints to FastAPI-native services
- preserve existing auth semantics for both bearer-token and Flask session-cookie access

## Included in this PR
- FastAPI read router and shared auth dependency
- read service layer for stats, categories, and files
- native FastAPI integration tests for read routes
- development log for the first batch of native read endpoints

## Validation
- `./.venv/Scripts/python.exe -m pytest -q -o addopts= tests/test_fastapi_entrypoint.py tests/test_fastapi_read_endpoints.py tests/test_auth_tokens.py::TestTokenAuth::test_api_requires_auth tests/test_auth_tokens.py::TestTokenAuth::test_bearer_token_reader_can_read_stats`
- `./.venv/Scripts/python.exe -m pytest -q -o addopts=` -> `403 passed, 39 warnings, 4 subtests passed`

## Notes
- `/api/files` is still exposed as the existing compatible endpoint, but the FastAPI implementation is internally split into smaller read-service functions
- `/api/categories?mode=used` intentionally preserves the current legacy behavior, including historical categories from deleted catalog items
- follow-up work can decide whether to introduce smaller external endpoints such as `recent-files`, `database/files`, or `filter-options`