### PR TITLE
Unify AI runtime config across chat, catalog, embeddings, and OCR

### DIFF
--- a/ai_actuarial/ai_runtime.py
+++ b/ai_actuarial/ai_runtime.py
@@ -1,0 +1,372 @@
+"""Unified AI runtime configuration and provider resolution."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+AI_SUPPORTED_PROVIDERS = {
+    "openai",
+    "mistral",
+    "siliconflow",
+    "anthropic",
+    "google",
+    "deepseek",
+    "zhipuai",
+    "moonshot",
+    "qwen",
+    "cohere",
+    "kimi",
+    "minimax",
+    "local",
+}
+
+KNOWN_LLM_PROVIDERS = {
+    "openai": {
+        "display_name": "OpenAI",
+        "default_base_url": "https://api.openai.com/v1",
+        "api_key_hint": "sk-...",
+    },
+    "mistral": {
+        "display_name": "Mistral AI",
+        "default_base_url": "https://api.mistral.ai/v1",
+        "api_key_hint": "...",
+    },
+    "anthropic": {
+        "display_name": "Anthropic",
+        "default_base_url": "https://api.anthropic.com",
+        "api_key_hint": "sk-ant-...",
+    },
+    "google": {
+        "display_name": "Google Gemini",
+        "default_base_url": "https://generativelanguage.googleapis.com",
+        "api_key_hint": "AIza...",
+    },
+    "deepseek": {
+        "display_name": "DeepSeek",
+        "default_base_url": "https://api.deepseek.com/v1",
+        "api_key_hint": "sk-...",
+    },
+    "zhipuai": {
+        "display_name": "ZhipuAI",
+        "default_base_url": "https://open.bigmodel.cn/api/paas/v4",
+        "api_key_hint": "...",
+    },
+    "moonshot": {
+        "display_name": "Moonshot (Kimi)",
+        "default_base_url": "https://api.moonshot.cn/v1",
+        "api_key_hint": "sk-...",
+    },
+    "qwen": {
+        "display_name": "Qwen",
+        "default_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "api_key_hint": "sk-...",
+    },
+    "siliconflow": {
+        "display_name": "SiliconFlow",
+        "default_base_url": "https://api.siliconflow.cn/v1",
+        "api_key_hint": "sk-...",
+    },
+    "cohere": {
+        "display_name": "Cohere",
+        "default_base_url": "https://api.cohere.com/v1",
+        "api_key_hint": "...",
+    },
+    "kimi": {
+        "display_name": "Kimi (Moonshot v2)",
+        "default_base_url": "https://api.moonshot.cn/v1",
+        "api_key_hint": "sk-...",
+    },
+    "minimax": {
+        "display_name": "MiniMax",
+        "default_base_url": "https://api.minimax.chat/v1",
+        "api_key_hint": "...",
+    },
+    "brave_search": {
+        "display_name": "Brave Search",
+        "default_base_url": "",
+        "api_key_hint": "BSA...",
+        "is_search_provider": True,
+    },
+    "serpapi": {
+        "display_name": "Google (SerpAPI)",
+        "default_base_url": "",
+        "api_key_hint": "...",
+        "is_search_provider": True,
+    },
+    "serper": {
+        "display_name": "Google (Serper.dev)",
+        "default_base_url": "",
+        "api_key_hint": "...",
+        "is_search_provider": True,
+    },
+    "tavily": {
+        "display_name": "Tavily",
+        "default_base_url": "",
+        "api_key_hint": "tvly-...",
+        "is_search_provider": True,
+    },
+}
+
+PROVIDER_STARTUP_ENV_MAP = {
+    "openai": ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+    "mistral": ("MISTRAL_API_KEY", "MISTRAL_BASE_URL"),
+    "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"),
+    "google": ("GOOGLE_API_KEY", "GOOGLE_BASE_URL"),
+    "deepseek": ("DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL"),
+    "zhipuai": ("ZHIPUAI_API_KEY", "ZHIPUAI_BASE_URL"),
+    "moonshot": ("MOONSHOT_API_KEY", "MOONSHOT_BASE_URL"),
+    "qwen": ("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
+    "siliconflow": ("SILICONFLOW_API_KEY", "SILICONFLOW_BASE_URL"),
+    "cohere": ("COHERE_API_KEY", "COHERE_BASE_URL"),
+    "kimi": ("KIMI_API_KEY", "KIMI_BASE_URL"),
+    "minimax": ("MINIMAX_API_KEY", "MINIMAX_BASE_URL"),
+    "brave_search": ("BRAVE_API_KEY", None),
+    "serpapi": ("SERPAPI_API_KEY", None),
+    "serper": ("SERPER_API_KEY", None),
+    "tavily": ("TAVILY_API_KEY", None),
+}
+
+PROVIDER_ENV_VARS = {
+    provider: key_env
+    for provider, (key_env, _) in PROVIDER_STARTUP_ENV_MAP.items()
+}
+
+PROVIDER_BASE_URL_ENV_VARS = {
+    provider: base_url_env
+    for provider, (_, base_url_env) in PROVIDER_STARTUP_ENV_MAP.items()
+}
+
+CHAT_OPENAI_COMPATIBLE_PROVIDERS = {
+    "openai",
+    "mistral",
+    "deepseek",
+    "moonshot",
+    "kimi",
+    "qwen",
+    "zhipuai",
+    "siliconflow",
+    "minimax",
+}
+
+DEFAULT_AI_FUNCTION_CONFIG = {
+    "catalog": {"provider": "openai", "model": "gpt-4o-mini"},
+    "embeddings": {"provider": "openai", "model": "text-embedding-3-large"},
+    "chatbot": {"provider": "openai", "model": "gpt-4-turbo"},
+    "ocr": {"provider": "local", "model": "docling"},
+}
+
+
+@dataclass(frozen=True)
+class ProviderCredentials:
+    provider: str
+    api_key: str | None
+    base_url: str | None
+    source: str
+    configured: bool
+
+
+@dataclass(frozen=True)
+class AIFunctionRuntime:
+    function_name: str
+    provider: str
+    model: str
+    raw_config: dict[str, Any]
+    api_key: str | None = None
+    base_url: str | None = None
+    credential_source: str = "none"
+
+
+def get_provider_api_key_env_var(provider: str | None) -> str | None:
+    """Return the env var that stores the provider API key."""
+    return PROVIDER_ENV_VARS.get(_normalize_provider(provider))
+
+
+def get_provider_base_url_env_var(provider: str | None) -> str | None:
+    """Return the env var that stores the provider base URL."""
+    return PROVIDER_BASE_URL_ENV_VARS.get(_normalize_provider(provider))
+
+
+def get_provider_default_base_url(provider: str | None) -> str | None:
+    """Return the default base URL for a provider if one is known."""
+    info = KNOWN_LLM_PROVIDERS.get(_normalize_provider(provider), {})
+    base_url = str(info.get("default_base_url") or "").strip()
+    return base_url or None
+
+
+def is_chat_provider_supported(provider: str | None) -> bool:
+    """Return whether the provider is currently supported by the chat runtime."""
+    return _normalize_provider(provider) in CHAT_OPENAI_COMPATIBLE_PROVIDERS
+
+
+def get_ai_function_section(
+    function_name: str,
+    *,
+    yaml_config: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the normalized ai_config section for a single AI function."""
+    from config.yaml_config import load_ai_config
+
+    if yaml_config is None:
+        ai_config = load_ai_config()
+    else:
+        ai_config = dict(yaml_config.get("ai_config") or {})
+
+    raw_section = ai_config.get(function_name) or {}
+    if not isinstance(raw_section, Mapping):
+        raw_section = {}
+
+    normalized = dict(raw_section)
+    defaults = DEFAULT_AI_FUNCTION_CONFIG.get(function_name, {})
+
+    provider = normalized.get("provider")
+    if function_name == "chatbot" and not provider:
+        provider = normalized.get("llm_provider")
+    normalized["provider"] = _normalize_provider(
+        provider,
+        default=str(defaults.get("provider") or "openai"),
+    )
+
+    model = str(normalized.get("model") or defaults.get("model") or "").strip()
+    if model:
+        normalized["model"] = model
+    elif "model" in defaults:
+        normalized["model"] = str(defaults["model"])
+
+    return normalized
+
+
+def resolve_ai_function_runtime(
+    function_name: str,
+    *,
+    storage: Any | None = None,
+    yaml_config: Mapping[str, Any] | None = None,
+) -> AIFunctionRuntime:
+    """Resolve effective runtime config for an AI function."""
+    section = get_ai_function_section(function_name, yaml_config=yaml_config)
+    provider = _normalize_provider(
+        section.get("provider"),
+        default=str(DEFAULT_AI_FUNCTION_CONFIG.get(function_name, {}).get("provider") or "openai"),
+    )
+    model = str(
+        section.get("model")
+        or DEFAULT_AI_FUNCTION_CONFIG.get(function_name, {}).get("model")
+        or ""
+    ).strip()
+
+    if provider == "local":
+        return AIFunctionRuntime(
+            function_name=function_name,
+            provider=provider,
+            model=model,
+            raw_config=section,
+            api_key=None,
+            base_url=None,
+            credential_source="local",
+        )
+
+    credentials = resolve_provider_credentials(provider, storage=storage)
+    return AIFunctionRuntime(
+        function_name=function_name,
+        provider=provider,
+        model=model,
+        raw_config=section,
+        api_key=credentials.api_key,
+        base_url=credentials.base_url,
+        credential_source=credentials.source,
+    )
+
+
+def resolve_provider_credentials(
+    provider: str | None,
+    *,
+    storage: Any | None = None,
+    category: str = "llm",
+) -> ProviderCredentials:
+    """Resolve provider credentials from DB first, then environment fallback."""
+    normalized_provider = _normalize_provider(provider)
+
+    if storage is not None:
+        db_credentials = _resolve_provider_credentials_from_storage(
+            normalized_provider,
+            storage=storage,
+            category=category,
+        )
+        if db_credentials is not None:
+            return db_credentials
+
+    api_key_env = get_provider_api_key_env_var(normalized_provider)
+    api_key = str(os.getenv(api_key_env) or "").strip() or None
+    base_url = _get_effective_base_url(normalized_provider)
+    if api_key:
+        return ProviderCredentials(
+            provider=normalized_provider,
+            api_key=api_key,
+            base_url=base_url,
+            source="env",
+            configured=True,
+        )
+
+    return ProviderCredentials(
+        provider=normalized_provider,
+        api_key=None,
+        base_url=base_url,
+        source="missing",
+        configured=False,
+    )
+
+
+def _resolve_provider_credentials_from_storage(
+    provider: str,
+    *,
+    storage: Any,
+    category: str,
+) -> ProviderCredentials | None:
+    """Resolve provider credentials from the provider token store."""
+    try:
+        row = storage.get_llm_provider(provider, category=category)
+    except Exception:
+        logger.exception("Failed to load provider credentials from storage for %s", provider)
+        return None
+
+    if not row:
+        return None
+
+    encrypted_key = str(row.get("api_key_encrypted") or "").strip()
+    if not encrypted_key:
+        return None
+
+    try:
+        from ai_actuarial.services.token_encryption import TokenEncryption
+
+        api_key = TokenEncryption().decrypt(encrypted_key)
+    except Exception:
+        logger.warning(
+            "Could not decrypt stored provider key for %s; falling back to environment",
+            provider,
+        )
+        return None
+
+    base_url = str(row.get("api_base_url") or "").strip() or _get_effective_base_url(provider)
+    return ProviderCredentials(
+        provider=provider,
+        api_key=api_key,
+        base_url=base_url,
+        source="db",
+        configured=True,
+    )
+
+
+def _get_effective_base_url(provider: str) -> str | None:
+    base_url_env = get_provider_base_url_env_var(provider)
+    env_base_url = str(os.getenv(base_url_env) or "").strip() if base_url_env else ""
+    return env_base_url or get_provider_default_base_url(provider)
+
+
+def _normalize_provider(provider: str | None, *, default: str = "openai") -> str:
+    normalized = str(provider or "").strip().lower()
+    return normalized or default

--- a/ai_actuarial/ai_runtime.py
+++ b/ai_actuarial/ai_runtime.py
@@ -428,7 +428,7 @@ def resolve_provider_credentials(
             return db_credentials
 
     api_key_env = get_provider_api_key_env_var(normalized_provider)
-    api_key = str(os.getenv(api_key_env) or "").strip() or None
+    api_key = str(os.getenv(api_key_env) or "").strip() or None if api_key_env else None
     base_url = _get_effective_base_url(normalized_provider)
     if api_key:
         return ProviderCredentials(

--- a/ai_actuarial/ai_runtime.py
+++ b/ai_actuarial/ai_runtime.py
@@ -153,11 +153,33 @@ CHAT_OPENAI_COMPATIBLE_PROVIDERS = {
     "minimax",
 }
 
+EMBEDDING_OPENAI_COMPATIBLE_PROVIDERS = {
+    "openai",
+    "siliconflow",
+    "qwen",
+    "zhipuai",
+    "minimax",
+}
+
 DEFAULT_AI_FUNCTION_CONFIG = {
     "catalog": {"provider": "openai", "model": "gpt-4o-mini"},
     "embeddings": {"provider": "openai", "model": "text-embedding-3-large"},
     "chatbot": {"provider": "openai", "model": "gpt-4-turbo"},
     "ocr": {"provider": "local", "model": "docling"},
+}
+
+OCR_ENGINE_PROVIDER_MAP = {
+    "docling": "local",
+    "marker": "local",
+    "local": "local",
+    "mistral": "mistral",
+    "deepseekocr": "siliconflow",
+}
+
+OCR_PROVIDER_ENGINE_MAP = {
+    "local": "docling",
+    "mistral": "mistral",
+    "siliconflow": "deepseekocr",
 }
 
 
@@ -181,6 +203,17 @@ class AIFunctionRuntime:
     credential_source: str = "none"
 
 
+@dataclass(frozen=True)
+class OCRRuntime:
+    engine: str
+    provider: str
+    model: str
+    api_key: str | None
+    base_url: str | None
+    credential_source: str
+    raw_config: dict[str, Any]
+
+
 def get_provider_api_key_env_var(provider: str | None) -> str | None:
     """Return the env var that stores the provider API key."""
     return PROVIDER_ENV_VARS.get(_normalize_provider(provider))
@@ -201,6 +234,17 @@ def get_provider_default_base_url(provider: str | None) -> str | None:
 def is_chat_provider_supported(provider: str | None) -> bool:
     """Return whether the provider is currently supported by the chat runtime."""
     return _normalize_provider(provider) in CHAT_OPENAI_COMPATIBLE_PROVIDERS
+
+
+def is_catalog_provider_supported(provider: str | None) -> bool:
+    """Return whether the provider is currently supported by the catalog runtime."""
+    return _normalize_provider(provider) in CHAT_OPENAI_COMPATIBLE_PROVIDERS
+
+
+def is_embedding_provider_supported(provider: str | None) -> bool:
+    """Return whether the provider is currently supported by the embedding runtime."""
+    normalized = _normalize_provider(provider)
+    return normalized == "local" or normalized in EMBEDDING_OPENAI_COMPATIBLE_PROVIDERS
 
 
 def get_ai_function_section(
@@ -245,9 +289,18 @@ def resolve_ai_function_runtime(
     *,
     storage: Any | None = None,
     yaml_config: Mapping[str, Any] | None = None,
+    provider_override: str | None = None,
+    model_override: str | None = None,
 ) -> AIFunctionRuntime:
     """Resolve effective runtime config for an AI function."""
     section = get_ai_function_section(function_name, yaml_config=yaml_config)
+    if provider_override:
+        section["provider"] = _normalize_provider(
+            provider_override,
+            default=str(section.get("provider") or "openai"),
+        )
+    if model_override:
+        section["model"] = str(model_override).strip()
     provider = _normalize_provider(
         section.get("provider"),
         default=str(DEFAULT_AI_FUNCTION_CONFIG.get(function_name, {}).get("provider") or "openai"),
@@ -279,6 +332,81 @@ def resolve_ai_function_runtime(
         base_url=credentials.base_url,
         credential_source=credentials.source,
     )
+
+
+def resolve_ocr_runtime(
+    *,
+    storage: Any | None = None,
+    yaml_config: Mapping[str, Any] | None = None,
+    engine_override: str | None = None,
+    model_override: str | None = None,
+) -> OCRRuntime:
+    """Resolve OCR runtime including engine/provider/model mapping."""
+    engine = str(engine_override or "").strip().lower()
+    provider_override = OCR_ENGINE_PROVIDER_MAP.get(engine) if engine else None
+    effective_model_override = model_override
+    if effective_model_override is None and engine:
+        if engine in {"docling", "marker"}:
+            effective_model_override = engine
+        elif engine in {"mistral", "deepseekocr"}:
+            effective_model_override = ""
+
+    runtime = resolve_ai_function_runtime(
+        "ocr",
+        storage=storage,
+        yaml_config=yaml_config,
+        provider_override=provider_override,
+        model_override=effective_model_override,
+    )
+
+    resolved_engine = _resolve_ocr_engine(runtime.provider, runtime.model, engine_override=engine_override)
+    resolved_model = _resolve_ocr_model(runtime.provider, runtime.model, resolved_engine)
+    return OCRRuntime(
+        engine=resolved_engine,
+        provider=runtime.provider,
+        model=resolved_model,
+        api_key=runtime.api_key,
+        base_url=runtime.base_url,
+        credential_source=runtime.credential_source,
+        raw_config=runtime.raw_config,
+    )
+
+
+def apply_runtime_environment(runtime: AIFunctionRuntime) -> None:
+    """Project runtime config into process env for legacy settings-based consumers."""
+    provider = runtime.provider
+    if provider != "local":
+        key_env = get_provider_api_key_env_var(provider)
+        base_env = get_provider_base_url_env_var(provider)
+        if key_env and runtime.api_key:
+            os.environ[key_env] = runtime.api_key
+        if base_env and runtime.base_url:
+            os.environ[base_env] = runtime.base_url
+
+    if runtime.function_name == "embeddings":
+        os.environ["RAG_EMBEDDING_PROVIDER"] = provider
+        os.environ["RAG_EMBEDDING_MODEL"] = runtime.model
+
+    _reload_settings_if_available()
+
+
+def apply_ocr_runtime_environment(runtime: OCRRuntime) -> None:
+    """Project OCR runtime config into env/settings for doc_to_md engines."""
+    if runtime.provider != "local":
+        key_env = get_provider_api_key_env_var(runtime.provider)
+        base_env = get_provider_base_url_env_var(runtime.provider)
+        if key_env and runtime.api_key:
+            os.environ[key_env] = runtime.api_key
+        if base_env and runtime.base_url:
+            os.environ[base_env] = runtime.base_url
+
+    os.environ["DEFAULT_ENGINE"] = runtime.engine
+    if runtime.provider == "mistral":
+        os.environ["MISTRAL_DEFAULT_MODEL"] = runtime.model
+    elif runtime.provider == "siliconflow":
+        os.environ["SILICONFLOW_DEFAULT_MODEL"] = runtime.model
+
+    _reload_settings_if_available()
 
 
 def resolve_provider_credentials(
@@ -365,6 +493,45 @@ def _get_effective_base_url(provider: str) -> str | None:
     base_url_env = get_provider_base_url_env_var(provider)
     env_base_url = str(os.getenv(base_url_env) or "").strip() if base_url_env else ""
     return env_base_url or get_provider_default_base_url(provider)
+
+
+def _resolve_ocr_engine(provider: str, model: str, *, engine_override: str | None = None) -> str:
+    if engine_override:
+        normalized_override = str(engine_override).strip().lower()
+        if normalized_override == "auto":
+            return "docling"
+        return normalized_override
+
+    normalized_provider = _normalize_provider(provider, default="local")
+    if normalized_provider == "local":
+        normalized_model = str(model or "").strip().lower()
+        if normalized_model in {"docling", "marker"}:
+            return normalized_model
+        return OCR_PROVIDER_ENGINE_MAP["local"]
+    return OCR_PROVIDER_ENGINE_MAP.get(normalized_provider, OCR_PROVIDER_ENGINE_MAP["local"])
+
+
+def _resolve_ocr_model(provider: str, model: str, engine: str) -> str:
+    normalized_provider = _normalize_provider(provider, default="local")
+    normalized_model = str(model or "").strip()
+    if normalized_model:
+        return normalized_model
+    if normalized_provider == "mistral":
+        return "mistral-ocr-latest"
+    if normalized_provider == "siliconflow":
+        return "deepseek-ai/DeepSeek-OCR"
+    if engine in {"docling", "marker"}:
+        return engine
+    return DEFAULT_AI_FUNCTION_CONFIG["ocr"]["model"]
+
+
+def _reload_settings_if_available() -> None:
+    try:
+        from config.settings import reload_settings
+
+        reload_settings()
+    except Exception:
+        return
 
 
 def _normalize_provider(provider: str | None, *, default: str = "openai") -> str:

--- a/ai_actuarial/catalog_incremental.py
+++ b/ai_actuarial/catalog_incremental.py
@@ -446,6 +446,9 @@ def _process_single_row(
     *,
     db_path: str,
     provider: str,
+    catalog_model: str | None = None,
+    catalog_api_key: str | None = None,
+    catalog_base_url: str | None = None,
     input_source: str,
     catalog_system_prompt: str | None = None,
     output_language: str = "auto",
@@ -463,7 +466,9 @@ def _process_single_row(
 
     try:
         provider_norm = (provider or "local").strip().lower()
-        if provider_norm not in {"local", "openai"}:
+        from .ai_runtime import is_catalog_provider_supported
+
+        if provider_norm != "local" and not is_catalog_provider_supported(provider_norm):
             raise RuntimeError(f"unsupported catalog provider: {provider}")
 
         source_norm = (input_source or "source").strip().lower()
@@ -510,6 +515,10 @@ def _process_single_row(
                 content=text,
                 custom_system_prompt=catalog_system_prompt,
                 output_language=output_language,
+                provider=provider_norm,
+                model=catalog_model,
+                api_key=catalog_api_key,
+                base_url=catalog_base_url,
             )
             keywords = llm.keywords
             suggested_title = llm.suggested_title
@@ -601,6 +610,32 @@ def run_incremental_catalog(
         dict with stats: {scanned, processed, written, skipped_ai, errors}
     """
     conn = _connect(db_path)
+    provider_norm = (provider or "local").strip().lower()
+    catalog_model: str | None = None
+    catalog_api_key: str | None = None
+    catalog_base_url: str | None = None
+    if provider_norm != "local":
+        from .ai_runtime import is_catalog_provider_supported, resolve_ai_function_runtime
+        from .storage import Storage
+
+        if not is_catalog_provider_supported(provider_norm):
+            conn.close()
+            raise RuntimeError(f"unsupported catalog provider: {provider}")
+
+        runtime_storage = Storage(db_path)
+        try:
+            runtime = resolve_ai_function_runtime(
+                "catalog",
+                storage=runtime_storage,
+                provider_override=provider_norm,
+            )
+        finally:
+            runtime_storage.close()
+
+        provider = runtime.provider
+        catalog_model = runtime.model
+        catalog_api_key = runtime.api_key
+        catalog_base_url = runtime.base_url
     
     # Ensure output directories exist
     out_jsonl.parent.mkdir(parents=True, exist_ok=True)
@@ -689,6 +724,9 @@ def run_incremental_catalog(
                     max_chars,
                     db_path=db_path,
                     provider=provider,
+                    catalog_model=catalog_model,
+                    catalog_api_key=catalog_api_key,
+                    catalog_base_url=catalog_base_url,
                     input_source=input_source,
                     catalog_system_prompt=catalog_system_prompt,
                     output_language=output_language,
@@ -840,6 +878,32 @@ def run_catalog_for_urls(
 ) -> dict:
     """Catalog a specific list of file URLs (used by File Details actions)."""
     conn = _connect(db_path)
+    provider_norm = (provider or "local").strip().lower()
+    catalog_model: str | None = None
+    catalog_api_key: str | None = None
+    catalog_base_url: str | None = None
+    if provider_norm != "local":
+        from .ai_runtime import is_catalog_provider_supported, resolve_ai_function_runtime
+        from .storage import Storage
+
+        if not is_catalog_provider_supported(provider_norm):
+            conn.close()
+            raise RuntimeError(f"unsupported catalog provider: {provider}")
+
+        runtime_storage = Storage(db_path)
+        try:
+            runtime = resolve_ai_function_runtime(
+                "catalog",
+                storage=runtime_storage,
+                provider_override=provider_norm,
+            )
+        finally:
+            runtime_storage.close()
+
+        provider = runtime.provider
+        catalog_model = runtime.model
+        catalog_api_key = runtime.api_key
+        catalog_base_url = runtime.base_url
 
     out_jsonl.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
@@ -928,6 +992,9 @@ def run_catalog_for_urls(
                 max_chars,
                 db_path=db_path,
                 provider=provider,
+                catalog_model=catalog_model,
+                catalog_api_key=catalog_api_key,
+                catalog_base_url=catalog_base_url,
                 input_source=input_source,
                 catalog_system_prompt=catalog_system_prompt,
                 output_language=output_language,

--- a/ai_actuarial/catalog_llm.py
+++ b/ai_actuarial/catalog_llm.py
@@ -6,7 +6,11 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from config.settings import get_settings
+from ai_actuarial.ai_runtime import (
+    get_provider_api_key_env_var,
+    is_catalog_provider_supported,
+    resolve_ai_function_runtime,
+)
 
 from .catalog import CATEGORY_RULES
 
@@ -91,10 +95,13 @@ def catalog_with_openai(
     content: str,
     custom_system_prompt: str | None = None,
     output_language: str = "auto",
+    provider: str | None = None,
+    model: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    storage: Any | None = None,
 ) -> LlmCatalogResult:
-    """Use OpenAI Chat Completions to generate summary/keywords/category.
-
-    Requires `OPENAI_API_KEY` in `.env` (read via `config.settings`).
+    """Use an OpenAI-compatible chat completion API for catalog generation.
 
     Args:
         title: Optional existing document title used as a context hint.
@@ -117,18 +124,37 @@ def catalog_with_openai(
           source website name or publication series header.
         - Use specific domain keyphrases for keywords, avoiding generic words like 'report'.
     """
-    settings = get_settings()
-    if not settings.openai_api_key:
-        raise RuntimeError("OPENAI_API_KEY missing")
+    runtime = resolve_ai_function_runtime(
+        "catalog",
+        storage=storage,
+        provider_override=provider,
+        model_override=model,
+    )
+    resolved_provider = runtime.provider
+    resolved_model = model or runtime.model
+    resolved_api_key = api_key or runtime.api_key
+    resolved_base_url = base_url or runtime.base_url
+
+    if not is_catalog_provider_supported(resolved_provider):
+        raise RuntimeError(
+            f"Catalog provider '{resolved_provider}' is not supported by the runtime"
+        )
+    if not resolved_api_key:
+        env_var = get_provider_api_key_env_var(resolved_provider) or "API_KEY"
+        raise RuntimeError(
+            f"{env_var} missing for catalog provider '{resolved_provider}'"
+        )
 
     try:
         from openai import OpenAI  # type: ignore
     except Exception as exc:  # pragma: no cover
-        raise RuntimeError("OpenAI catalog provider requires `openai` package") from exc
+        raise RuntimeError("Catalog provider requires `openai` package") from exc
 
     categories = sorted({*(CATEGORY_RULES or {}).keys(), "Other"})
-    model = settings.openai_default_model
-    client = OpenAI(api_key=settings.openai_api_key, base_url=settings.openai_base_url)
+    client_kwargs = {"api_key": resolved_api_key}
+    if resolved_base_url:
+        client_kwargs["base_url"] = resolved_base_url
+    client = OpenAI(**client_kwargs)
 
     safe_title = (title or "").strip()
     safe_content = (content or "").strip()
@@ -199,14 +225,14 @@ def catalog_with_openai(
     )
 
     completion = client.chat.completions.create(
-        model=model,
+        model=resolved_model,
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ],
         temperature=0.2,
         response_format={"type": "json_object"},
-        timeout=settings.openai_timeout_seconds,
+        timeout=60.0,
     )
 
     content_text = ""
@@ -227,4 +253,10 @@ def catalog_with_openai(
     category = "; ".join(selected[:3])
     suggested_title = str(payload.get("suggested_title") or "").strip() or None
 
-    return LlmCatalogResult(summary=summary, keywords=keywords, category=category, model=model, suggested_title=suggested_title)
+    return LlmCatalogResult(
+        summary=summary,
+        keywords=keywords,
+        category=category,
+        model=resolved_model,
+        suggested_title=suggested_title,
+    )

--- a/ai_actuarial/catalog_llm.py
+++ b/ai_actuarial/catalog_llm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -134,6 +135,15 @@ def catalog_with_openai(
     resolved_model = model or runtime.model
     resolved_api_key = api_key or runtime.api_key
     resolved_base_url = base_url or runtime.base_url
+    raw_timeout = runtime.raw_config.get("timeout_seconds")
+    try:
+        timeout_seconds = (
+            float(raw_timeout)
+            if raw_timeout not in (None, "")
+            else float(str(os.getenv("OPENAI_TIMEOUT_SECONDS") or "60").strip())
+        )
+    except (TypeError, ValueError):
+        timeout_seconds = 60.0
 
     if not is_catalog_provider_supported(resolved_provider):
         raise RuntimeError(
@@ -232,7 +242,7 @@ def catalog_with_openai(
         ],
         temperature=0.2,
         response_format={"type": "json_object"},
-        timeout=60.0,
+        timeout=timeout_seconds,
     )
 
     content_text = ""

--- a/ai_actuarial/chatbot/config.py
+++ b/ai_actuarial/chatbot/config.py
@@ -94,11 +94,19 @@ class ChatbotConfig:
 
         if not self.api_key:
             env_var = get_provider_api_key_env_var(self.llm_provider)
-            self.api_key = str(os.getenv(env_var) or "").strip() or None
+            self.api_key = (
+                str(os.getenv(env_var) or "").strip() or None
+                if env_var
+                else None
+            )
 
         if not self.base_url:
             base_url_env = get_provider_base_url_env_var(self.llm_provider)
-            self.base_url = str(os.getenv(base_url_env) or "").strip() or None
+            self.base_url = (
+                str(os.getenv(base_url_env) or "").strip() or None
+                if base_url_env
+                else None
+            )
 
         self.model = os.getenv("CHATBOT_MODEL", self.model)
         self.temperature = float(os.getenv("CHATBOT_TEMPERATURE", str(self.temperature)))
@@ -124,8 +132,16 @@ class ChatbotConfig:
             model=os.getenv("CHATBOT_MODEL", "gpt-4"),
             temperature=_safe_float(os.getenv("CHATBOT_TEMPERATURE"), "CHATBOT_TEMPERATURE", 0.7),
             max_tokens=_safe_int(os.getenv("CHATBOT_MAX_TOKENS"), "CHATBOT_MAX_TOKENS", 1000),
-            api_key=str(os.getenv(api_key_env) or "").strip() or None,
-            base_url=str(os.getenv(base_url_env) or "").strip() or None,
+            api_key=(
+                str(os.getenv(api_key_env) or "").strip() or None
+                if api_key_env
+                else None
+            ),
+            base_url=(
+                str(os.getenv(base_url_env) or "").strip() or None
+                if base_url_env
+                else None
+            ),
             _apply_env_defaults=False,
             top_k=_safe_int(os.getenv("CHATBOT_TOP_K"), "CHATBOT_TOP_K", 5),
             similarity_threshold=_safe_float(

--- a/ai_actuarial/chatbot/config.py
+++ b/ai_actuarial/chatbot/config.py
@@ -1,274 +1,303 @@
-"""
-Configuration for the AI chatbot module.
-"""
+"""Configuration for the AI chatbot module."""
+
+from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Any, List, Mapping
+
+from ai_actuarial.ai_runtime import (
+    AI_SUPPORTED_PROVIDERS,
+    get_ai_function_section,
+    get_provider_api_key_env_var,
+    get_provider_base_url_env_var,
+    is_chat_provider_supported,
+    resolve_ai_function_runtime,
+)
+
+
+def _safe_int(value: Any, key: str, default: int) -> int:
+    if value in (None, ""):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid value for {key}: {value!r}. Expected integer.") from exc
+
+
+def _safe_float(value: Any, key: str, default: float) -> float:
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid value for {key}: {value!r}. Expected float.") from exc
 
 
 @dataclass
 class ChatbotConfig:
     """Configuration for the chatbot system."""
-    
+
     # LLM Settings
-    llm_provider: str = "openai"  # openai, anthropic, ollama
-    model: str = "gpt-4"  # gpt-4, gpt-4-turbo, gpt-3.5-turbo
+    llm_provider: str = "openai"
+    model: str = "gpt-4"
     temperature: float = 0.7
     max_tokens: int = 1000
-    api_key: Optional[str] = None
-    
+    api_key: str | None = None
+    base_url: str | None = None
+    _apply_env_defaults: bool = field(default=True, repr=False, compare=False)
+
     # Retrieval Settings
-    top_k: int = 5  # Number of chunks to retrieve
+    top_k: int = 5
     similarity_threshold: float = 0.4
-    min_results: int = 1  # Minimum results required
-    
+    min_results: int = 1
+
     # Conversation Settings
-    max_messages: int = 20  # Maximum messages to keep in context
-    max_context_tokens: int = 8000  # Maximum tokens in context window
-    summarization_threshold: int = 15  # When to start summarizing old messages
-    
+    max_messages: int = 20
+    max_context_tokens: int = 8000
+    summarization_threshold: int = 15
+
     # Mode Settings
     default_mode: str = "expert"
     available_modes: List[str] = field(default_factory=lambda: [
         "expert", "summary", "tutorial", "comparison"
     ])
-    
+
     # Retry & Rate Limiting
     max_retries: int = 3
-    retry_delay: float = 1.0  # seconds
+    retry_delay: float = 1.0
     exponential_backoff: bool = True
-    rate_limit_rpm: int = 60  # requests per minute
-    
+    rate_limit_rpm: int = 60
+
     # Quality & Validation
     require_citations: bool = True
     validate_citations: bool = True
     hallucination_check: bool = True
-    
+
     # Multi-KB Query Settings
     multi_kb_enabled: bool = True
-    min_results_per_kb: int = 2  # Minimum results from each KB in multi-KB query
-    kb_diversity_weight: float = 0.3  # Weight for diversity in ranking
-    
-    def __post_init__(self):
-        """Load configuration from environment variables."""
-        # Load API key from environment if not provided
+    min_results_per_kb: int = 2
+    kb_diversity_weight: float = 0.3
+
+    def __post_init__(self) -> None:
+        """Apply lightweight environment defaults for direct instantiation."""
+        if not self._apply_env_defaults:
+            return
+
+        provider_from_env = str(
+            os.getenv("CHATBOT_LLM_PROVIDER")
+            or os.getenv("CHATBOT_PROVIDER")
+            or ""
+        ).strip().lower()
+        if provider_from_env:
+            self.llm_provider = provider_from_env
+
         if not self.api_key:
-            self.api_key = os.getenv("OPENAI_API_KEY")
-        
-        # Load other settings from environment
+            env_var = get_provider_api_key_env_var(self.llm_provider)
+            self.api_key = str(os.getenv(env_var) or "").strip() or None
+
+        if not self.base_url:
+            base_url_env = get_provider_base_url_env_var(self.llm_provider)
+            self.base_url = str(os.getenv(base_url_env) or "").strip() or None
+
         self.model = os.getenv("CHATBOT_MODEL", self.model)
         self.temperature = float(os.getenv("CHATBOT_TEMPERATURE", str(self.temperature)))
         self.max_tokens = int(os.getenv("CHATBOT_MAX_TOKENS", str(self.max_tokens)))
         self.top_k = int(os.getenv("CHATBOT_TOP_K", str(self.top_k)))
-        self.similarity_threshold = float(os.getenv("RAG_SIMILARITY_THRESHOLD", str(self.similarity_threshold)))
-    
+        self.similarity_threshold = float(
+            os.getenv("RAG_SIMILARITY_THRESHOLD", str(self.similarity_threshold))
+        )
+
     @classmethod
     def from_env(cls) -> "ChatbotConfig":
-        """
-        Create configuration from environment variables.
-        
-        This method explicitly loads all configuration from environment variables,
-        providing clear error messages for invalid values.
-        """
-        def safe_int(var_name: str, default: int) -> int:
-            """Get integer from environment with error handling."""
-            value = os.getenv(var_name)
-            if not value:
-                return default
-            try:
-                return int(value)
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid value for {var_name}: {value!r}. Expected an integer."
-                ) from e
-        
-        def safe_float(var_name: str, default: float) -> float:
-            """Get float from environment with error handling."""
-            value = os.getenv(var_name)
-            if not value:
-                return default
-            try:
-                return float(value)
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid value for {var_name}: {value!r}. Expected a float."
-                ) from e
-        
+        """Create configuration from environment variables."""
+        provider = str(
+            os.getenv("CHATBOT_LLM_PROVIDER")
+            or os.getenv("CHATBOT_PROVIDER")
+            or "openai"
+        ).strip().lower()
+        api_key_env = get_provider_api_key_env_var(provider)
+        base_url_env = get_provider_base_url_env_var(provider)
+
         return cls(
-            # LLM Settings
-            llm_provider=os.getenv("CHATBOT_LLM_PROVIDER", "openai"),
+            llm_provider=provider,
             model=os.getenv("CHATBOT_MODEL", "gpt-4"),
-            temperature=safe_float("CHATBOT_TEMPERATURE", 0.7),
-            max_tokens=safe_int("CHATBOT_MAX_TOKENS", 1000),
-            api_key=os.getenv("OPENAI_API_KEY"),
-            
-            # Retrieval Settings
-            top_k=safe_int("CHATBOT_TOP_K", 5),
-            similarity_threshold=safe_float("RAG_SIMILARITY_THRESHOLD", 0.4),
-            min_results=safe_int("CHATBOT_MIN_RESULTS", 1),
-            
-            # Conversation Settings
-            max_messages=safe_int("CHATBOT_MAX_MESSAGES", 20),
-            max_context_tokens=safe_int("CHATBOT_MAX_CONTEXT_TOKENS", 8000),
-            summarization_threshold=safe_int("CHATBOT_SUMMARIZATION_THRESHOLD", 15),
-            
-            # Mode Settings
+            temperature=_safe_float(os.getenv("CHATBOT_TEMPERATURE"), "CHATBOT_TEMPERATURE", 0.7),
+            max_tokens=_safe_int(os.getenv("CHATBOT_MAX_TOKENS"), "CHATBOT_MAX_TOKENS", 1000),
+            api_key=str(os.getenv(api_key_env) or "").strip() or None,
+            base_url=str(os.getenv(base_url_env) or "").strip() or None,
+            _apply_env_defaults=False,
+            top_k=_safe_int(os.getenv("CHATBOT_TOP_K"), "CHATBOT_TOP_K", 5),
+            similarity_threshold=_safe_float(
+                os.getenv("RAG_SIMILARITY_THRESHOLD"),
+                "RAG_SIMILARITY_THRESHOLD",
+                0.4,
+            ),
+            min_results=_safe_int(os.getenv("CHATBOT_MIN_RESULTS"), "CHATBOT_MIN_RESULTS", 1),
+            max_messages=_safe_int(os.getenv("CHATBOT_MAX_MESSAGES"), "CHATBOT_MAX_MESSAGES", 20),
+            max_context_tokens=_safe_int(
+                os.getenv("CHATBOT_MAX_CONTEXT_TOKENS"),
+                "CHATBOT_MAX_CONTEXT_TOKENS",
+                8000,
+            ),
+            summarization_threshold=_safe_int(
+                os.getenv("CHATBOT_SUMMARIZATION_THRESHOLD"),
+                "CHATBOT_SUMMARIZATION_THRESHOLD",
+                15,
+            ),
             default_mode=os.getenv("CHATBOT_DEFAULT_MODE", "expert"),
-            
-            # Retry & Rate Limiting
-            max_retries=safe_int("CHATBOT_MAX_RETRIES", 3),
-            retry_delay=safe_float("CHATBOT_RETRY_DELAY", 1.0),
+            max_retries=_safe_int(os.getenv("CHATBOT_MAX_RETRIES"), "CHATBOT_MAX_RETRIES", 3),
+            retry_delay=_safe_float(os.getenv("CHATBOT_RETRY_DELAY"), "CHATBOT_RETRY_DELAY", 1.0),
             exponential_backoff=os.getenv("CHATBOT_EXPONENTIAL_BACKOFF", "true").lower() == "true",
-            rate_limit_rpm=safe_int("CHATBOT_RATE_LIMIT_RPM", 60),
-            
-            # Quality & Validation
+            rate_limit_rpm=_safe_int(os.getenv("CHATBOT_RATE_LIMIT_RPM"), "CHATBOT_RATE_LIMIT_RPM", 60),
             require_citations=os.getenv("CHATBOT_REQUIRE_CITATIONS", "true").lower() == "true",
             validate_citations=os.getenv("CHATBOT_VALIDATE_CITATIONS", "true").lower() == "true",
             hallucination_check=os.getenv("CHATBOT_HALLUCINATION_CHECK", "true").lower() == "true",
-            
-            # Multi-KB Query Settings
             multi_kb_enabled=os.getenv("CHATBOT_MULTI_KB_ENABLED", "true").lower() == "true",
-            min_results_per_kb=safe_int("CHATBOT_MIN_RESULTS_PER_KB", 2),
-            kb_diversity_weight=safe_float("CHATBOT_KB_DIVERSITY_WEIGHT", 0.3),
+            min_results_per_kb=_safe_int(
+                os.getenv("CHATBOT_MIN_RESULTS_PER_KB"),
+                "CHATBOT_MIN_RESULTS_PER_KB",
+                2,
+            ),
+            kb_diversity_weight=_safe_float(
+                os.getenv("CHATBOT_KB_DIVERSITY_WEIGHT"),
+                "CHATBOT_KB_DIVERSITY_WEIGHT",
+                0.3,
+            ),
         )
-    
+
     @classmethod
-    def from_yaml(cls, yaml_config: dict) -> "ChatbotConfig":
-        """
-        Create configuration from sites.yaml ai_config section.
-        
-        Args:
-            yaml_config: The full YAML configuration dictionary
-            
-        Returns:
-            ChatbotConfig instance
-            
-        Raises:
-            ValueError: If configuration values are invalid
-        """
-        chatbot = yaml_config.get("ai_config", {}).get("chatbot", {})
-        
-        # Helper to get nested values with defaults and type conversion
-        def get_val(key: str, default, converter=None):
-            value = chatbot.get(key)
-            if value is None:
-                return default
-            if converter:
-                try:
-                    return converter(value)
-                except (ValueError, TypeError) as e:
-                    raise ValueError(
-                        f"Invalid value for chatbot.{key} in sites.yaml: {value!r}. "
-                        f"Expected {converter.__name__} type."
-                    ) from e
-            return value
-        
+    def from_yaml(
+        cls,
+        yaml_config: Mapping[str, Any],
+        *,
+        storage: Any | None = None,
+    ) -> "ChatbotConfig":
+        """Create configuration from sites.yaml ai_config.chatbot."""
+        section = get_ai_function_section("chatbot", yaml_config=yaml_config)
+        runtime = resolve_ai_function_runtime("chatbot", storage=storage, yaml_config=yaml_config)
+
         try:
             return cls(
-                # LLM Settings
-                llm_provider=get_val("llm_provider", "openai"),
-                model=get_val("model", "gpt-4"),
-                temperature=get_val("temperature", 0.7, float),
-                max_tokens=get_val("max_tokens", 1000, int),
-                api_key=os.getenv("OPENAI_API_KEY"),  # Always from environment
-                
-                # Retrieval Settings
-                top_k=get_val("top_k", 5, int),
-                similarity_threshold=get_val("similarity_threshold", 0.4, float),
-                min_results=get_val("min_results", 1, int),
-                
-                # Conversation Settings
-                max_messages=get_val("max_messages", 20, int),
-                max_context_tokens=get_val("max_context_tokens", 8000, int),
-                summarization_threshold=get_val("summarization_threshold", 15, int),
-                
-                # Mode Settings
-                default_mode=get_val("default_mode", "expert"),
-                
-                # Retry & Rate Limiting
-                max_retries=get_val("max_retries", 3, int),
-                retry_delay=get_val("retry_delay", 1.0, float),
-                exponential_backoff=get_val("exponential_backoff", True, bool),
-                rate_limit_rpm=get_val("rate_limit_rpm", 60, int),
-                
-                # Quality & Validation
-                require_citations=get_val("require_citations", True, bool),
-                validate_citations=get_val("validate_citations", True, bool),
-                hallucination_check=get_val("hallucination_check", True, bool),
-                
-                # Multi-KB Query Settings
-                multi_kb_enabled=get_val("multi_kb_enabled", True, bool),
-                min_results_per_kb=get_val("min_results_per_kb", 2, int),
-                kb_diversity_weight=get_val("kb_diversity_weight", 0.3, float),
+                llm_provider=runtime.provider,
+                model=runtime.model or "gpt-4",
+                temperature=_safe_float(section.get("temperature"), "chatbot.temperature", 0.7),
+                max_tokens=_safe_int(section.get("max_tokens"), "chatbot.max_tokens", 1000),
+                api_key=runtime.api_key,
+                base_url=runtime.base_url,
+                _apply_env_defaults=False,
+                top_k=_safe_int(section.get("top_k"), "chatbot.top_k", 5),
+                similarity_threshold=_safe_float(
+                    section.get("similarity_threshold"),
+                    "chatbot.similarity_threshold",
+                    0.4,
+                ),
+                min_results=_safe_int(section.get("min_results"), "chatbot.min_results", 1),
+                max_messages=_safe_int(section.get("max_messages"), "chatbot.max_messages", 20),
+                max_context_tokens=_safe_int(
+                    section.get("max_context_tokens"),
+                    "chatbot.max_context_tokens",
+                    8000,
+                ),
+                summarization_threshold=_safe_int(
+                    section.get("summarization_threshold"),
+                    "chatbot.summarization_threshold",
+                    15,
+                ),
+                default_mode=str(section.get("default_mode") or "expert"),
+                max_retries=_safe_int(section.get("max_retries"), "chatbot.max_retries", 3),
+                retry_delay=_safe_float(section.get("retry_delay"), "chatbot.retry_delay", 1.0),
+                exponential_backoff=bool(section.get("exponential_backoff", True)),
+                rate_limit_rpm=_safe_int(section.get("rate_limit_rpm"), "chatbot.rate_limit_rpm", 60),
+                require_citations=bool(section.get("require_citations", True)),
+                validate_citations=bool(section.get("validate_citations", True)),
+                hallucination_check=bool(section.get("hallucination_check", True)),
+                multi_kb_enabled=bool(section.get("multi_kb_enabled", True)),
+                min_results_per_kb=_safe_int(
+                    section.get("min_results_per_kb"),
+                    "chatbot.min_results_per_kb",
+                    2,
+                ),
+                kb_diversity_weight=_safe_float(
+                    section.get("kb_diversity_weight"),
+                    "chatbot.kb_diversity_weight",
+                    0.3,
+                ),
             )
         except ValueError:
-            # Re-raise configuration errors with context
             raise
-        except Exception as e:
-            raise ValueError(f"Error loading chatbot configuration from sites.yaml: {e}") from e
-    
+        except Exception as exc:
+            raise ValueError(
+                f"Error loading chatbot configuration from sites.yaml: {exc}"
+            ) from exc
+
     @classmethod
-    def from_config(cls) -> "ChatbotConfig":
-        """
-        Create configuration from sites.yaml with .env fallback.
-        
-        This is the recommended method for loading configuration. It will:
-        1. Try to load from sites.yaml ai_config.chatbot section
-        2. Fall back to environment variables if not found
-        
-        Returns:
-            ChatbotConfig instance
-            
-        Raises:
-            ValueError: If configuration values are invalid in sites.yaml
-        """
+    def from_config(
+        cls,
+        *,
+        storage: Any | None = None,
+        default_mode: str | None = None,
+    ) -> "ChatbotConfig":
+        """Create configuration from sites.yaml with environment fallback."""
         try:
             from config.yaml_config import load_yaml_config
         except (ImportError, ModuleNotFoundError):
-            # If the YAML config loader is not available, fall back to env
-            return cls.from_env()
-        
-        try:
-            yaml_config = load_yaml_config()
-        except (FileNotFoundError, OSError):
-            # If the YAML file is missing or inaccessible, fall back to env
-            return cls.from_env()
-        
-        if "ai_config" in yaml_config and "chatbot" in yaml_config.get("ai_config", {}):
-            # This may raise ValueError if configuration is invalid
-            return cls.from_yaml(yaml_config)
-        
-        # Fallback to environment variables if ai_config.chatbot section is not present
-        return cls.from_env()
-    
-    def validate(self):
+            config = cls.from_env()
+        else:
+            try:
+                yaml_config = load_yaml_config()
+            except (FileNotFoundError, OSError):
+                config = cls.from_env()
+            else:
+                if "ai_config" in yaml_config and "chatbot" in yaml_config.get("ai_config", {}):
+                    config = cls.from_yaml(yaml_config, storage=storage)
+                else:
+                    config = cls.from_env()
+
+        if default_mode is not None:
+            config.default_mode = default_mode
+        return config
+
+    def validate(self) -> bool:
         """Validate configuration parameters."""
         errors = []
-        
-        if not self.api_key:
-            errors.append("API key is required (OPENAI_API_KEY environment variable)")
-        
+        provider = str(self.llm_provider or "").strip().lower()
+
+        if provider not in AI_SUPPORTED_PROVIDERS:
+            errors.append(f"Unsupported LLM provider: {provider}")
+        elif not is_chat_provider_supported(provider):
+            errors.append(
+                f"Provider '{provider}' is configured but chat runtime currently supports: "
+                "openai, mistral, deepseek, moonshot, kimi, qwen, zhipuai, siliconflow, minimax"
+            )
+
+        if provider != "local" and not self.api_key:
+            env_var = get_provider_api_key_env_var(provider) or "API_KEY"
+            errors.append(
+                f"API key is required for provider '{provider}' ({env_var} environment variable or provider store)"
+            )
+
         if self.temperature < 0 or self.temperature > 2:
             errors.append(f"Temperature must be between 0 and 2, got {self.temperature}")
-        
+
         if self.max_tokens < 1:
             errors.append(f"max_tokens must be positive, got {self.max_tokens}")
-        
+
         if self.top_k < 1:
             errors.append(f"top_k must be positive, got {self.top_k}")
-        
+
         if self.similarity_threshold < 0 or self.similarity_threshold > 1:
-            errors.append(f"similarity_threshold must be between 0 and 1, got {self.similarity_threshold}")
-        
+            errors.append(
+                f"similarity_threshold must be between 0 and 1, got {self.similarity_threshold}"
+            )
+
         if self.default_mode not in self.available_modes:
             errors.append(f"default_mode '{self.default_mode}' not in available_modes")
-        
+
         if errors:
             raise ValueError(f"Invalid chatbot configuration: {'; '.join(errors)}")
-        
+
         return True
 
 
-# Default configuration instance
 default_config = ChatbotConfig()

--- a/ai_actuarial/chatbot/config.py
+++ b/ai_actuarial/chatbot/config.py
@@ -11,6 +11,7 @@ from ai_actuarial.ai_runtime import (
     get_ai_function_section,
     get_provider_api_key_env_var,
     get_provider_base_url_env_var,
+    get_provider_default_base_url,
     is_chat_provider_supported,
     resolve_ai_function_runtime,
 )
@@ -107,6 +108,8 @@ class ChatbotConfig:
                 if base_url_env
                 else None
             )
+            if not self.base_url:
+                self.base_url = get_provider_default_base_url(self.llm_provider)
 
         self.model = os.getenv("CHATBOT_MODEL", self.model)
         self.temperature = float(os.getenv("CHATBOT_TEMPERATURE", str(self.temperature)))
@@ -141,7 +144,7 @@ class ChatbotConfig:
                 str(os.getenv(base_url_env) or "").strip() or None
                 if base_url_env
                 else None
-            ),
+            ) or get_provider_default_base_url(provider),
             _apply_env_defaults=False,
             top_k=_safe_int(os.getenv("CHATBOT_TOP_K"), "CHATBOT_TOP_K", 5),
             similarity_threshold=_safe_float(

--- a/ai_actuarial/chatbot/conversation.py
+++ b/ai_actuarial/chatbot/conversation.py
@@ -41,7 +41,7 @@ class ConversationManager:
             config: Chatbot configuration
         """
         self.storage = storage
-        self.config = config or ChatbotConfig.from_config()
+        self.config = config or ChatbotConfig.from_config(storage=storage)
         
         # Initialize database schema
         self._init_schema()

--- a/ai_actuarial/chatbot/conversation.py
+++ b/ai_actuarial/chatbot/conversation.py
@@ -41,7 +41,7 @@ class ConversationManager:
             config: Chatbot configuration
         """
         self.storage = storage
-        self.config = config or ChatbotConfig()
+        self.config = config or ChatbotConfig.from_config()
         
         # Initialize database schema
         self._init_schema()

--- a/ai_actuarial/chatbot/llm.py
+++ b/ai_actuarial/chatbot/llm.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Any, Optional
 
 import openai
 
+from ai_actuarial.ai_runtime import is_chat_provider_supported
 from ai_actuarial.chatbot.config import ChatbotConfig
 from ai_actuarial.chatbot.exceptions import LLMException
 from ai_actuarial.chatbot.prompts import build_full_prompt
@@ -39,7 +40,7 @@ class LLMClient:
         Raises:
             LLMException: If API key is missing
         """
-        self.config = config or ChatbotConfig()
+        self.config = config or ChatbotConfig.from_config()
         
         # Validate configuration
         try:
@@ -47,16 +48,18 @@ class LLMClient:
         except ValueError as e:
             raise LLMException(f"Invalid configuration: {e}")
         
-        # Initialize OpenAI client
-        if self.config.llm_provider == "openai":
-            self.client = openai.OpenAI(
-                api_key=self.config.api_key,
-                timeout=60.0  # 60 second timeout
-            )
-        else:
+        # Initialize OpenAI-compatible client
+        if not is_chat_provider_supported(self.config.llm_provider):
             raise LLMException(
                 f"Unsupported LLM provider: {self.config.llm_provider}"
             )
+        client_kwargs: dict[str, Any] = {
+            "api_key": self.config.api_key,
+            "timeout": 60.0,
+        }
+        if self.config.base_url:
+            client_kwargs["base_url"] = self.config.base_url
+        self.client = openai.OpenAI(**client_kwargs)
         
         # Rate limiting state
         self._last_request_time = 0.0

--- a/ai_actuarial/chatbot/llm.py
+++ b/ai_actuarial/chatbot/llm.py
@@ -30,7 +30,12 @@ class LLMClient:
     - Comprehensive error handling
     """
     
-    def __init__(self, config: Optional[ChatbotConfig] = None):
+    def __init__(
+        self,
+        config: Optional[ChatbotConfig] = None,
+        *,
+        storage=None,
+    ):
         """
         Initialize LLM client.
         
@@ -40,7 +45,7 @@ class LLMClient:
         Raises:
             LLMException: If API key is missing
         """
-        self.config = config or ChatbotConfig.from_config()
+        self.config = config or ChatbotConfig.from_config(storage=storage)
         
         # Validate configuration
         try:

--- a/ai_actuarial/chatbot/retrieval.py
+++ b/ai_actuarial/chatbot/retrieval.py
@@ -45,7 +45,7 @@ class RAGRetriever:
             config: Chatbot configuration
         """
         self.storage = storage
-        self.config = config or ChatbotConfig()
+        self.config = config or ChatbotConfig.from_config()
         
         # Initialize RAG components
         self.kb_manager = KnowledgeBaseManager(storage)

--- a/ai_actuarial/chatbot/retrieval.py
+++ b/ai_actuarial/chatbot/retrieval.py
@@ -45,7 +45,7 @@ class RAGRetriever:
             config: Chatbot configuration
         """
         self.storage = storage
-        self.config = config or ChatbotConfig.from_config()
+        self.config = config or ChatbotConfig.from_config(storage=storage)
         
         # Initialize RAG components
         self.kb_manager = KnowledgeBaseManager(storage)

--- a/ai_actuarial/chatbot/retrieval.py
+++ b/ai_actuarial/chatbot/retrieval.py
@@ -49,7 +49,7 @@ class RAGRetriever:
         
         # Initialize RAG components
         self.kb_manager = KnowledgeBaseManager(storage)
-        self.embedding_generator = EmbeddingGenerator()
+        self.embedding_generator = EmbeddingGenerator(storage=self.storage)
         
         # Cache for loaded vector stores
         self._vector_store_cache: Dict[str, VectorStore] = {}

--- a/ai_actuarial/chatbot/router.py
+++ b/ai_actuarial/chatbot/router.py
@@ -39,7 +39,7 @@ class QueryRouter:
             config: Chatbot configuration
         """
         self.storage = storage
-        self.config = config or ChatbotConfig()
+        self.config = config or ChatbotConfig.from_config()
         self.kb_manager = KnowledgeBaseManager(storage)
         
         # Common actuarial/insurance keywords by category

--- a/ai_actuarial/chatbot/router.py
+++ b/ai_actuarial/chatbot/router.py
@@ -39,7 +39,7 @@ class QueryRouter:
             config: Chatbot configuration
         """
         self.storage = storage
-        self.config = config or ChatbotConfig.from_config()
+        self.config = config or ChatbotConfig.from_config(storage=storage)
         self.kb_manager = KnowledgeBaseManager(storage)
         
         # Common actuarial/insurance keywords by category

--- a/ai_actuarial/rag/config.py
+++ b/ai_actuarial/rag/config.py
@@ -5,44 +5,61 @@ Provides centralized configuration management for RAG components with
 environment variable support and sensible defaults.
 """
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Mapping
+
+from ai_actuarial.ai_runtime import (
+    get_ai_function_section,
+    get_provider_api_key_env_var,
+    get_provider_base_url_env_var,
+    is_embedding_provider_supported,
+    resolve_ai_function_runtime,
+)
 
 
 @dataclass
 class RAGConfig:
     """Configuration for RAG system."""
-    
+
     # Chunking configuration
-    chunk_strategy: Literal["semantic_structure", "token_based"] = "semantic_structure"
-    max_chunk_tokens: int = 800  # Larger for academic content
-    min_chunk_tokens: int = 100  # Avoid tiny fragments
-    preserve_headers: bool = True  # Preserve markdown headers
-    preserve_citations: bool = True  # Keep citations intact
-    include_hierarchy: bool = True  # Add parent section context
-    
+    chunk_strategy: str = "semantic_structure"
+    max_chunk_tokens: int = 800
+    min_chunk_tokens: int = 100
+    preserve_headers: bool = True
+    preserve_citations: bool = True
+    include_hierarchy: bool = True
+
     # Embedding configuration
-    embedding_provider: Literal["openai", "local"] = "openai"
-    embedding_model: str = "text-embedding-3-large"  # or "text-embedding-3-small"
-    embedding_batch_size: int = 64  # Batch size for API calls
+    embedding_provider: str = "openai"
+    embedding_model: str = "text-embedding-3-large"
+    embedding_batch_size: int = 64
     embedding_cache_enabled: bool = True
-    
+
     # Vector store configuration
-    similarity_threshold: float = 0.4  # Filter low-quality matches
-    index_type: str = "Flat"  # FAISS index type (Flat, IVF, HNSW)
-    
+    similarity_threshold: float = 0.4
+    index_type: str = "Flat"
+
     # API configuration
+    api_key: str = ""
+    api_base_url: str = ""
     openai_api_key: str = ""
     openai_max_retries: int = 3
     openai_timeout: int = 60
-    
+
     # Storage paths
     data_dir: str = "data/rag"
-    
+
     @classmethod
     def from_env(cls) -> "RAGConfig":
         """Create configuration from environment variables."""
+        provider = str(os.getenv("RAG_EMBEDDING_PROVIDER", "openai")).strip().lower() or "openai"
+        api_key_env = get_provider_api_key_env_var(provider)
+        base_url_env = get_provider_base_url_env_var(provider)
+        api_key = str(os.getenv(api_key_env) or "").strip() if api_key_env else ""
+        api_base_url = str(os.getenv(base_url_env) or "").strip() if base_url_env else ""
         return cls(
             chunk_strategy=os.getenv("RAG_CHUNK_STRATEGY", "semantic_structure"),
             max_chunk_tokens=int(os.getenv("RAG_MAX_CHUNK_TOKENS", "800")),
@@ -50,144 +67,182 @@ class RAGConfig:
             preserve_headers=os.getenv("RAG_PRESERVE_HEADERS", "true").lower() == "true",
             preserve_citations=os.getenv("RAG_PRESERVE_CITATIONS", "true").lower() == "true",
             include_hierarchy=os.getenv("RAG_INCLUDE_HIERARCHY", "true").lower() == "true",
-            
-            embedding_provider=os.getenv("RAG_EMBEDDING_PROVIDER", "openai"),
+            embedding_provider=provider,
             embedding_model=os.getenv("RAG_EMBEDDING_MODEL", "text-embedding-3-large"),
             embedding_batch_size=int(os.getenv("RAG_EMBEDDING_BATCH_SIZE", "64")),
             embedding_cache_enabled=os.getenv("RAG_EMBEDDING_CACHE_ENABLED", "true").lower() == "true",
-            
             similarity_threshold=float(os.getenv("RAG_SIMILARITY_THRESHOLD", "0.4")),
             index_type=os.getenv("RAG_INDEX_TYPE", "Flat"),
-            
-            openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+            api_key=api_key,
+            api_base_url=api_base_url,
+            openai_api_key=api_key,
             openai_max_retries=int(os.getenv("OPENAI_MAX_RETRIES", "3")),
             openai_timeout=int(os.getenv("OPENAI_TIMEOUT", "60")),
-            
             data_dir=os.getenv("RAG_DATA_DIR", "data/rag"),
         )
-    
+
     @classmethod
-    def from_yaml(cls, yaml_config: dict) -> "RAGConfig":
+    def from_yaml(
+        cls,
+        yaml_config: Mapping[str, Any],
+        *,
+        storage: Any | None = None,
+    ) -> "RAGConfig":
         """Create configuration from sites.yaml rag_config and ai_config sections."""
         rag_cfg = yaml_config.get("rag_config", {})
-        ai_cfg = yaml_config.get("ai_config", {}).get("embeddings", {})
-        
-        def safe_int(value, key: str, default: int):
-            """Safely convert value to int with helpful error message."""
+        section = get_ai_function_section("embeddings", yaml_config=yaml_config)
+        runtime = resolve_ai_function_runtime(
+            "embeddings",
+            storage=storage,
+            yaml_config=yaml_config,
+        )
+
+        def safe_int(value: Any, key: str, default: int) -> int:
             if value is None:
                 return default
             try:
                 return int(value)
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError) as exc:
                 raise ValueError(
                     f"Invalid value for {key} in sites.yaml: {value!r}. Expected integer."
-                ) from e
-        
-        def safe_float(value, key: str, default: float):
-            """Safely convert value to float with helpful error message."""
+                ) from exc
+
+        def safe_float(value: Any, key: str, default: float) -> float:
             if value is None:
                 return default
             try:
                 return float(value)
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError) as exc:
                 raise ValueError(
                     f"Invalid value for {key} in sites.yaml: {value!r}. Expected float."
-                ) from e
-        
-        def safe_bool(value, key: str, default: bool):
-            """Safely convert value to bool with proper string handling."""
+                ) from exc
+
+        def safe_bool(value: Any, key: str, default: bool) -> bool:
             if value is None:
                 return default
-            # Handle string boolean values
             if isinstance(value, str):
-                if value.lower() in ('true', '1', 'yes'):
+                lowered = value.lower()
+                if lowered in {"true", "1", "yes"}:
                     return True
-                elif value.lower() in ('false', '0', 'no'):
+                if lowered in {"false", "0", "no"}:
                     return False
-                else:
-                    raise ValueError(
-                        f"Invalid boolean value for {key} in sites.yaml: {value!r}. "
-                        f"Expected true/false, yes/no, 1/0, or boolean type."
-                    )
-            # Handle actual boolean values from YAML
+                raise ValueError(
+                    f"Invalid boolean value for {key} in sites.yaml: {value!r}. "
+                    "Expected true/false, yes/no, 1/0, or boolean type."
+                )
             return bool(value)
-        
+
         try:
+            api_key = str(runtime.api_key or "").strip()
+            api_base_url = str(runtime.base_url or "").strip()
             return cls(
-                # Chunking configuration from rag_config
-                chunk_strategy=rag_cfg.get("chunk_strategy", "semantic_structure"),
-                max_chunk_tokens=safe_int(rag_cfg.get("max_chunk_tokens"), "rag_config.max_chunk_tokens", 800),
-                min_chunk_tokens=safe_int(rag_cfg.get("min_chunk_tokens"), "rag_config.min_chunk_tokens", 100),
-                preserve_headers=safe_bool(rag_cfg.get("preserve_headers"), "rag_config.preserve_headers", True),
-                preserve_citations=safe_bool(rag_cfg.get("preserve_citations"), "rag_config.preserve_citations", True),
-                include_hierarchy=safe_bool(rag_cfg.get("include_hierarchy"), "rag_config.include_hierarchy", True),
-                
-                # Embedding configuration from ai_config.embeddings
-                embedding_provider=ai_cfg.get("provider", "openai"),
-                embedding_model=ai_cfg.get("model", "text-embedding-3-large"),
-                embedding_batch_size=safe_int(ai_cfg.get("batch_size"), "ai_config.embeddings.batch_size", 64),
-                embedding_cache_enabled=safe_bool(ai_cfg.get("cache_enabled"), "ai_config.embeddings.cache_enabled", True),
-                
-                # Vector store configuration from ai_config.embeddings
-                similarity_threshold=safe_float(ai_cfg.get("similarity_threshold"), "ai_config.embeddings.similarity_threshold", 0.4),
-                index_type=rag_cfg.get("index_type", "Flat"),
-                
-                # API configuration (still from environment for sensitive data)
-                openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+                chunk_strategy=str(rag_cfg.get("chunk_strategy", "semantic_structure")),
+                max_chunk_tokens=safe_int(
+                    rag_cfg.get("max_chunk_tokens"),
+                    "rag_config.max_chunk_tokens",
+                    800,
+                ),
+                min_chunk_tokens=safe_int(
+                    rag_cfg.get("min_chunk_tokens"),
+                    "rag_config.min_chunk_tokens",
+                    100,
+                ),
+                preserve_headers=safe_bool(
+                    rag_cfg.get("preserve_headers"),
+                    "rag_config.preserve_headers",
+                    True,
+                ),
+                preserve_citations=safe_bool(
+                    rag_cfg.get("preserve_citations"),
+                    "rag_config.preserve_citations",
+                    True,
+                ),
+                include_hierarchy=safe_bool(
+                    rag_cfg.get("include_hierarchy"),
+                    "rag_config.include_hierarchy",
+                    True,
+                ),
+                embedding_provider=runtime.provider,
+                embedding_model=runtime.model or "text-embedding-3-large",
+                embedding_batch_size=safe_int(
+                    section.get("batch_size"),
+                    "ai_config.embeddings.batch_size",
+                    64,
+                ),
+                embedding_cache_enabled=safe_bool(
+                    section.get("cache_enabled"),
+                    "ai_config.embeddings.cache_enabled",
+                    True,
+                ),
+                similarity_threshold=safe_float(
+                    section.get("similarity_threshold"),
+                    "ai_config.embeddings.similarity_threshold",
+                    0.4,
+                ),
+                index_type=str(rag_cfg.get("index_type", "Flat")),
+                api_key=api_key,
+                api_base_url=api_base_url,
+                openai_api_key=api_key,
                 openai_max_retries=int(os.getenv("OPENAI_MAX_RETRIES", "3")),
                 openai_timeout=int(os.getenv("OPENAI_TIMEOUT", "60")),
-                
-                # Storage paths (can be overridden by environment)
                 data_dir=os.getenv("RAG_DATA_DIR", "data/rag"),
             )
         except ValueError:
-            # Re-raise configuration errors with context
             raise
-        except Exception as e:
-            raise ValueError(f"Error loading RAG configuration from sites.yaml: {e}") from e
-    
+        except Exception as exc:
+            raise ValueError(f"Error loading RAG configuration from sites.yaml: {exc}") from exc
+
     @classmethod
-    def from_config(cls) -> "RAGConfig":
+    def from_config(
+        cls,
+        *,
+        storage: Any | None = None,
+    ) -> "RAGConfig":
         """
         Create configuration from sites.yaml with .env fallback.
-        
+
         This is the recommended method for loading configuration. It will:
         1. Try to load from sites.yaml rag_config and ai_config sections
         2. Fall back to environment variables if not found
-        
+
         Raises:
             ValueError: If configuration values are invalid in sites.yaml
         """
         try:
             from config.yaml_config import load_yaml_config
         except (ImportError, ModuleNotFoundError):
-            # If the YAML config loader is not available, fall back to env
             return cls.from_env()
-        
+
         try:
             yaml_config = load_yaml_config()
         except (FileNotFoundError, OSError):
-            # If the YAML file is missing or inaccessible, fall back to env
             return cls.from_env()
-        
-        # Check if either rag_config or ai_config.embeddings exist
+
         has_rag_config = "rag_config" in yaml_config
         has_ai_embeddings = "ai_config" in yaml_config and "embeddings" in yaml_config.get("ai_config", {})
-        
+
         if has_rag_config or has_ai_embeddings:
-            # This may raise ValueError if configuration is invalid
-            return cls.from_yaml(yaml_config)
-        
-        # Fallback to environment variables if sections are not present
+            return cls.from_yaml(yaml_config, storage=storage)
+
         return cls.from_env()
-    
+
     def validate(self) -> None:
         """Validate configuration."""
-        if self.embedding_provider == "openai" and not self.openai_api_key:
-            raise ValueError("OPENAI_API_KEY is required when using OpenAI embeddings")
-        
+        provider = str(self.embedding_provider or "").strip().lower()
+        if not is_embedding_provider_supported(provider):
+            raise ValueError(
+                "Embedding provider '%s' is not supported. Supported providers: local, "
+                "openai, siliconflow, qwen, zhipuai, minimax" % provider
+            )
+
+        if provider != "local" and not self.api_key:
+            env_var = get_provider_api_key_env_var(provider) or "API_KEY"
+            raise ValueError(
+                f"{env_var} is required when using {provider} embeddings"
+            )
+
         if self.max_chunk_tokens <= self.min_chunk_tokens:
             raise ValueError("max_chunk_tokens must be greater than min_chunk_tokens")
-        
+
         if not 0 <= self.similarity_threshold <= 1:
             raise ValueError("similarity_threshold must be between 0 and 1")

--- a/ai_actuarial/rag/config.py
+++ b/ai_actuarial/rag/config.py
@@ -15,6 +15,7 @@ from ai_actuarial.ai_runtime import (
     get_ai_function_section,
     get_provider_api_key_env_var,
     get_provider_base_url_env_var,
+    get_provider_default_base_url,
     is_embedding_provider_supported,
     resolve_ai_function_runtime,
 )
@@ -60,6 +61,8 @@ class RAGConfig:
         base_url_env = get_provider_base_url_env_var(provider)
         api_key = str(os.getenv(api_key_env) or "").strip() if api_key_env else ""
         api_base_url = str(os.getenv(base_url_env) or "").strip() if base_url_env else ""
+        if not api_base_url:
+            api_base_url = str(get_provider_default_base_url(provider) or "").strip()
         return cls(
             chunk_strategy=os.getenv("RAG_CHUNK_STRATEGY", "semantic_structure"),
             max_chunk_tokens=int(os.getenv("RAG_MAX_CHUNK_TOKENS", "800")),

--- a/ai_actuarial/rag/embeddings.py
+++ b/ai_actuarial/rag/embeddings.py
@@ -20,6 +20,7 @@ from typing import List, Optional
 
 from openai import OpenAI, APITimeoutError, RateLimitError, APIError
 
+from ai_actuarial.ai_runtime import is_embedding_provider_supported
 from ai_actuarial.rag.config import RAGConfig
 from ai_actuarial.rag.exceptions import EmbeddingException
 
@@ -78,25 +79,40 @@ class EmbeddingGenerator:
     Supports multiple providers with automatic fallback and caching.
     """
     
-    def __init__(self, config: Optional[RAGConfig] = None):
+    def __init__(
+        self,
+        config: Optional[RAGConfig] = None,
+        *,
+        storage=None,
+    ):
         """
         Initialize embedding generator.
         
         Args:
             config: RAG configuration (defaults to config-based config)
         """
-        self.config = config or RAGConfig.from_config()
+        self.config = config or RAGConfig.from_config(storage=storage)
         self.cache = EmbeddingCache(f"{self.config.data_dir}/embeddings_cache") if self.config.embedding_cache_enabled else None
-        
-        # Initialize OpenAI client if using OpenAI
-        if self.config.embedding_provider == "openai":
-            if not self.config.openai_api_key:
-                raise EmbeddingException("OpenAI API key required but not provided")
-            
-            self.openai_client = OpenAI(
-                api_key=self.config.openai_api_key,
-                timeout=self.config.openai_timeout
-            )
+
+        provider = str(self.config.embedding_provider or "").strip().lower()
+        if not is_embedding_provider_supported(provider):
+            raise EmbeddingException(f"Unsupported embedding provider: {provider}")
+
+        # Initialize OpenAI-compatible client for remote providers.
+        if provider != "local":
+            api_key = self.config.api_key or self.config.openai_api_key
+            if not api_key:
+                raise EmbeddingException(
+                    f"API key required for embedding provider '{provider}' but not provided"
+                )
+
+            client_kwargs = {
+                "api_key": api_key,
+                "timeout": self.config.openai_timeout,
+            }
+            if self.config.api_base_url:
+                client_kwargs["base_url"] = self.config.api_base_url
+            self.openai_client = OpenAI(**client_kwargs)
         else:
             self.openai_client = None
         
@@ -135,7 +151,7 @@ class EmbeddingGenerator:
             
             # Generate embeddings for uncached texts
             if uncached_texts:
-                if self.config.embedding_provider == "openai":
+                if self.config.embedding_provider != "local":
                     new_embeddings = self._generate_openai_embeddings(uncached_texts)
                 else:
                     new_embeddings = self._generate_local_embeddings(uncached_texts)
@@ -156,7 +172,7 @@ class EmbeddingGenerator:
             return all_embeddings
         else:
             # No caching
-            if self.config.embedding_provider == "openai":
+            if self.config.embedding_provider != "local":
                 return self._generate_openai_embeddings(texts)
             else:
                 return self._generate_local_embeddings(texts)
@@ -290,8 +306,8 @@ class EmbeddingGenerator:
         Returns:
             Embedding dimension
         """
-        if self.config.embedding_provider == "openai":
-            # OpenAI embedding dimensions
+        if self.config.embedding_provider != "local":
+            # OpenAI-compatible embedding dimensions
             if "text-embedding-3-large" in self.config.embedding_model:
                 return 3072
             elif "text-embedding-3-small" in self.config.embedding_model:

--- a/ai_actuarial/rag/embeddings.py
+++ b/ai_actuarial/rag/embeddings.py
@@ -94,16 +94,16 @@ class EmbeddingGenerator:
         self.config = config or RAGConfig.from_config(storage=storage)
         self.cache = EmbeddingCache(f"{self.config.data_dir}/embeddings_cache") if self.config.embedding_cache_enabled else None
 
-        provider = str(self.config.embedding_provider or "").strip().lower()
-        if not is_embedding_provider_supported(provider):
-            raise EmbeddingException(f"Unsupported embedding provider: {provider}")
+        self.provider = str(self.config.embedding_provider or "").strip().lower()
+        if not is_embedding_provider_supported(self.provider):
+            raise EmbeddingException(f"Unsupported embedding provider: {self.provider}")
 
         # Initialize OpenAI-compatible client for remote providers.
-        if provider != "local":
+        if self.provider != "local":
             api_key = self.config.api_key or self.config.openai_api_key
             if not api_key:
                 raise EmbeddingException(
-                    f"API key required for embedding provider '{provider}' but not provided"
+                    f"API key required for embedding provider '{self.provider}' but not provided"
                 )
 
             client_kwargs = {
@@ -151,7 +151,7 @@ class EmbeddingGenerator:
             
             # Generate embeddings for uncached texts
             if uncached_texts:
-                if self.config.embedding_provider != "local":
+                if self.provider != "local":
                     new_embeddings = self._generate_openai_embeddings(uncached_texts)
                 else:
                     new_embeddings = self._generate_local_embeddings(uncached_texts)
@@ -172,7 +172,7 @@ class EmbeddingGenerator:
             return all_embeddings
         else:
             # No caching
-            if self.config.embedding_provider != "local":
+            if self.provider != "local":
                 return self._generate_openai_embeddings(texts)
             else:
                 return self._generate_local_embeddings(texts)
@@ -306,7 +306,7 @@ class EmbeddingGenerator:
         Returns:
             Embedding dimension
         """
-        if self.config.embedding_provider != "local":
+        if self.provider != "local":
             # OpenAI-compatible embedding dimensions
             if "text-embedding-3-large" in self.config.embedding_model:
                 return 3072

--- a/ai_actuarial/rag/knowledge_base.py
+++ b/ai_actuarial/rag/knowledge_base.py
@@ -112,7 +112,7 @@ class KnowledgeBaseManager:
             config: RAG configuration
         """
         self.storage = storage
-        self.config = config or RAGConfig.from_config()
+        self.config = config or RAGConfig.from_config(storage=storage)
         
         # Ensure RAG tables exist
         self._ensure_rag_tables()

--- a/ai_actuarial/web/app.py
+++ b/ai_actuarial/web/app.py
@@ -60,6 +60,7 @@ from ..ai_runtime import (
     PROVIDER_BASE_URL_ENV_VARS,
     PROVIDER_ENV_VARS,
     PROVIDER_STARTUP_ENV_MAP,
+    resolve_ocr_runtime,
 )
 logger = logging.getLogger(__name__)
 
@@ -355,13 +356,24 @@ def _permissions_for_group(group_name: str) -> frozenset[str]:
     return _GROUP_PERMISSIONS.get((group_name or "").strip().lower(), frozenset())
 
 
-def convert_file_to_markdown(file_path: str, conversion_tool: str, content_type: str) -> dict[str, str]:
+def convert_file_to_markdown(
+    file_path: str,
+    conversion_tool: str,
+    content_type: str,
+    *,
+    model: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, str]:
     """Convert a local file to markdown using `doc_to_md` engines.
 
     Args:
         file_path: Local path to the file to convert.
         conversion_tool: Engine name ('marker', 'docling', 'mistral', 'deepseekocr').
         content_type: MIME type (kept for logging/diagnostics).
+        model: Optional model override for OCR/API engines.
+        api_key: Optional provider API key override.
+        base_url: Optional provider base URL override.
 
     Returns:
         Dict with: markdown, engine, model
@@ -373,14 +385,26 @@ def convert_file_to_markdown(file_path: str, conversion_tool: str, content_type:
     # For compatibility with older clients, treat it as marker.
     if (conversion_tool or "").strip().lower() == "auto":
         conversion_tool = "marker"
-    logger.info("Converting %s using %s (content_type=%s)", file_path, conversion_tool, content_type)
+    logger.info(
+        "Converting %s using %s (content_type=%s, model=%s)",
+        file_path,
+        conversion_tool,
+        content_type,
+        model or "-",
+    )
 
     try:
         from doc_to_md.registry import convert_path
     except Exception as exc:  # noqa: BLE001
         raise RuntimeError(f"doc_to_md package not available: {exc}") from exc
 
-    output = convert_path(Path(file_path), engine=conversion_tool)  # type: ignore[arg-type]
+    output = convert_path(
+        Path(file_path),
+        engine=conversion_tool,
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+    )  # type: ignore[arg-type]
     markdown = (output.markdown or "").strip()
     if not markdown:
         raise RuntimeError("Engine returned empty markdown")
@@ -3918,9 +3942,9 @@ sites:
             elif collection_type == "markdown_conversion":
                 # Markdown conversion task
                 file_urls = data.get("file_urls", []) or []
-                conversion_tool = data.get("conversion_tool", "docling")
-                if (conversion_tool or "").strip().lower() == "auto":
-                    conversion_tool = "docling"
+                conversion_tool = data.get("conversion_tool", "auto")
+                if not str(conversion_tool or "").strip():
+                    conversion_tool = "auto"
                 overwrite_existing = data.get("overwrite_existing", False)
                 skip_existing = bool(data.get("skip_existing", True))
                 scan_start_index = data.get("scan_start_index")
@@ -3999,6 +4023,22 @@ sites:
                 
                 logger.info(f"Starting markdown conversion for {len(file_urls)} files")
                 _append_task_log(task_id, "INFO", f"Markdown conversion started: files={len(file_urls)}, engine={conversion_tool}, overwrite={overwrite_existing}")
+
+                ocr_runtime = resolve_ocr_runtime(
+                    storage=storage,
+                    engine_override=None
+                    if str(conversion_tool or "").strip().lower() == "auto"
+                    else str(conversion_tool or "").strip().lower(),
+                )
+                _append_task_log(
+                    task_id,
+                    "INFO",
+                    (
+                        "Markdown runtime resolved: "
+                        f"engine={ocr_runtime.engine} provider={ocr_runtime.provider} "
+                        f"model={ocr_runtime.model} credentials={ocr_runtime.credential_source}"
+                    ),
+                )
                 
                 converted_count = 0
                 error_count = 0
@@ -4073,20 +4113,34 @@ sites:
                         
                         # Convert file to markdown using doc_to_md engines.
                         try:
-                            _append_task_log(task_id, "INFO", f"Converting: {file_url} (path={local_path}) engine={conversion_tool}")
+                            _append_task_log(
+                                task_id,
+                                "INFO",
+                                (
+                                    f"Converting: {file_url} (path={local_path}) "
+                                    f"engine={ocr_runtime.engine} model={ocr_runtime.model}"
+                                ),
+                            )
                             conversion = convert_file_to_markdown(
                                 local_path,
-                                conversion_tool,
+                                ocr_runtime.engine,
                                 file_info.get("content_type", ""),
+                                model=ocr_runtime.model,
+                                api_key=ocr_runtime.api_key,
+                                base_url=ocr_runtime.base_url,
                             )
                         except Exception as exc:  # noqa: BLE001
                             error_count += 1
-                            errors.append(f"{file_url}: conversion failed ({conversion_tool})")
-                            _append_task_log(task_id, "ERROR", f"Conversion failed: {file_url} engine={conversion_tool} error={exc}")
+                            errors.append(f"{file_url}: conversion failed ({ocr_runtime.engine})")
+                            _append_task_log(
+                                task_id,
+                                "ERROR",
+                                f"Conversion failed: {file_url} engine={ocr_runtime.engine} error={exc}",
+                            )
                             continue
 
                         markdown_content = conversion["markdown"]
-                        used_engine = conversion.get("engine") or conversion_tool
+                        used_engine = conversion.get("engine") or ocr_runtime.engine
 
                         # Save markdown to database
                         success, error = storage.update_file_markdown(

--- a/ai_actuarial/web/app.py
+++ b/ai_actuarial/web/app.py
@@ -54,6 +54,13 @@ import csv
 import io
 import yaml
 import schedule
+from ..ai_runtime import (
+    AI_SUPPORTED_PROVIDERS,
+    KNOWN_LLM_PROVIDERS,
+    PROVIDER_BASE_URL_ENV_VARS,
+    PROVIDER_ENV_VARS,
+    PROVIDER_STARTUP_ENV_MAP,
+)
 logger = logging.getLogger(__name__)
 
 # Global state for task tracking
@@ -726,26 +733,6 @@ def create_app(config: dict[str, Any] | None = None) -> Any:
     # manual restart.  DB values never override keys already present in the
     # environment (i.e. .env takes priority over DB on startup).
     #
-    # Tuple layout: (api_key_env_var, base_url_env_var | None)
-    _PROVIDER_STARTUP_ENV_MAP = {
-        "openai":     ("OPENAI_API_KEY",    "OPENAI_BASE_URL"),
-        "mistral":    ("MISTRAL_API_KEY",   "MISTRAL_BASE_URL"),
-        "anthropic":  ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"),
-        "google":     ("GOOGLE_API_KEY",    "GOOGLE_BASE_URL"),
-        "deepseek":   ("DEEPSEEK_API_KEY",  "DEEPSEEK_BASE_URL"),
-        "zhipuai":    ("ZHIPUAI_API_KEY",   "ZHIPUAI_BASE_URL"),
-        "moonshot":   ("MOONSHOT_API_KEY",  "MOONSHOT_BASE_URL"),
-        "qwen":       ("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
-        "siliconflow":("SILICONFLOW_API_KEY","SILICONFLOW_BASE_URL"),
-        "cohere":     ("COHERE_API_KEY",    "COHERE_BASE_URL"),
-        "kimi":       ("KIMI_API_KEY",      "KIMI_BASE_URL"),
-        "minimax":    ("MINIMAX_API_KEY",   "MINIMAX_BASE_URL"),
-        # Search providers
-        "brave_search":  ("BRAVE_API_KEY",   None),
-        "serpapi":       ("SERPAPI_API_KEY",  None),
-        "serper":        ("SERPER_API_KEY",   None),
-        "tavily":        ("TAVILY_API_KEY",   None),
-    }
     _startup_storage = None
     try:
         from ..services.token_encryption import TokenEncryption as _TE
@@ -753,7 +740,7 @@ def create_app(config: dict[str, Any] | None = None) -> Any:
         _enc = _TE()
         for _p in _startup_storage.list_llm_providers():
             _pname = _p["provider"]
-            _key_env, _url_env = _PROVIDER_STARTUP_ENV_MAP.get(_pname, (None, None))
+            _key_env, _url_env = PROVIDER_STARTUP_ENV_MAP.get(_pname, (None, None))
             if _key_env and not os.getenv(_key_env):  # Don't override .env values
                 try:
                     os.environ[_key_env] = _enc.decrypt(_p["api_key_encrypted"])
@@ -2849,121 +2836,6 @@ sites:
     # AI model configuration
     # Models are now fetched dynamically from LLM provider APIs
     # See ai_actuarial/llm_models.py for implementation
-    AI_SUPPORTED_PROVIDERS = {
-        "openai", "mistral", "siliconflow", "anthropic",
-        "google", "deepseek", "zhipuai", "moonshot", "qwen", "cohere",
-        "kimi", "minimax",
-        "local",
-    }
-
-    # Known LLM providers that can be configured with API keys
-    KNOWN_LLM_PROVIDERS = {
-        "openai": {
-            "display_name": "OpenAI",
-            "default_base_url": "https://api.openai.com/v1",
-            "api_key_hint": "sk-...",
-        },
-        "mistral": {
-            "display_name": "Mistral AI",
-            "default_base_url": "https://api.mistral.ai",
-            "api_key_hint": "...",
-        },
-        "anthropic": {
-            "display_name": "Anthropic",
-            "default_base_url": "https://api.anthropic.com",
-            "api_key_hint": "sk-ant-...",
-        },
-        "google": {
-            "display_name": "Google Gemini",
-            "default_base_url": "https://generativelanguage.googleapis.com",
-            "api_key_hint": "AIza...",
-        },
-        "deepseek": {
-            "display_name": "DeepSeek",
-            "default_base_url": "https://api.deepseek.com/v1",
-            "api_key_hint": "sk-...",
-        },
-        "zhipuai": {
-            "display_name": "智谱AI (ZhipuAI)",
-            "default_base_url": "https://open.bigmodel.cn/api/paas/v4",
-            "api_key_hint": "...",
-        },
-        "moonshot": {
-            "display_name": "Moonshot (Kimi)",
-            "default_base_url": "https://api.moonshot.cn/v1",
-            "api_key_hint": "sk-...",
-        },
-        "qwen": {
-            "display_name": "阿里通义 (Qwen)",
-            "default_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-            "api_key_hint": "sk-...",
-        },
-        "siliconflow": {
-            "display_name": "SiliconFlow",
-            "default_base_url": "https://api.siliconflow.cn/v1",
-            "api_key_hint": "sk-...",
-        },
-        "cohere": {
-            "display_name": "Cohere",
-            "default_base_url": "https://api.cohere.com/v1",
-            "api_key_hint": "...",
-        },
-        "kimi": {
-            "display_name": "Kimi (Moonshot v2)",
-            "default_base_url": "https://api.moonshot.cn/v1",
-            "api_key_hint": "sk-...",
-        },
-        "minimax": {
-            "display_name": "MiniMax",
-            "default_base_url": "https://api.minimax.chat/v1",
-            "api_key_hint": "...",
-        },
-        # Search providers
-        "brave_search": {
-            "display_name": "Brave Search",
-            "default_base_url": "",
-            "api_key_hint": "BSA...",
-            "is_search_provider": True,
-        },
-        "serpapi": {
-            "display_name": "Google (SerpAPI)",
-            "default_base_url": "",
-            "api_key_hint": "...",
-            "is_search_provider": True,
-        },
-        "serper": {
-            "display_name": "Google (Serper.dev)",
-            "default_base_url": "",
-            "api_key_hint": "...",
-            "is_search_provider": True,
-        },
-        "tavily": {
-            "display_name": "Tavily",
-            "default_base_url": "",
-            "api_key_hint": "tvly-...",
-            "is_search_provider": True,
-        },
-    }
-
-    # Mapping from provider name to the environment variable that holds its API key
-    _PROVIDER_ENV_VARS = {
-        "openai": "OPENAI_API_KEY",
-        "mistral": "MISTRAL_API_KEY",
-        "anthropic": "ANTHROPIC_API_KEY",
-        "google": "GOOGLE_API_KEY",
-        "deepseek": "DEEPSEEK_API_KEY",
-        "zhipuai": "ZHIPUAI_API_KEY",
-        "moonshot": "MOONSHOT_API_KEY",
-        "qwen": "DASHSCOPE_API_KEY",
-        "siliconflow": "SILICONFLOW_API_KEY",
-        "cohere": "COHERE_API_KEY",
-        "kimi": "KIMI_API_KEY",
-        "minimax": "MINIMAX_API_KEY",
-        "brave_search": "BRAVE_API_KEY",
-        "serpapi": "SERPAPI_API_KEY",
-        "serper": "SERPER_API_KEY",
-        "tavily": "TAVILY_API_KEY",
-    }
 
     @app.route("/api/config/llm-providers")
     @require_permissions("config.read")
@@ -3006,14 +2878,15 @@ sites:
                 })
 
             # Add providers configured via environment variables that aren't in DB
-            for provider, env_var in _PROVIDER_ENV_VARS.items():
+            for provider, env_var in PROVIDER_ENV_VARS.items():
                 if provider in db_provider_keys:
                     continue  # Already included from DB
                 api_key = os.getenv(env_var)
                 if api_key:
                     pinfo = KNOWN_LLM_PROVIDERS.get(provider, {})
-                    base_url_var = f"{provider.upper()}_BASE_URL"
-                    base_url = os.getenv(base_url_var) or None
+                    base_url_var = PROVIDER_BASE_URL_ENV_VARS.get(provider)
+                    base_url = os.getenv(base_url_var) if base_url_var else None
+                    base_url = base_url or None
                     result.append({
                         "provider": provider,
                         "display_name": pinfo.get("display_name", provider),
@@ -3054,7 +2927,11 @@ sites:
 
             provider = str(data.get("provider") or "").strip().lower()
             api_key = str(data.get("api_key") or "").strip()
-            base_url = str(data.get("api_base_url") or "").strip() or None
+            base_url = str(
+                data.get("api_base_url")
+                or data.get("base_url")
+                or ""
+            ).strip() or None
             notes = str(data.get("notes") or "").strip() or None
 
             if not provider:
@@ -3075,11 +2952,11 @@ sites:
             )
 
             # Also set env var in-process for immediate backward-compatible use
-            env_var = _PROVIDER_ENV_VARS.get(provider)
+            env_var = PROVIDER_ENV_VARS.get(provider)
             if env_var:
                 os.environ[env_var] = api_key
             if base_url:
-                _, base_url_env_var = _PROVIDER_STARTUP_ENV_MAP.get(provider, (None, None))
+                _, base_url_env_var = PROVIDER_STARTUP_ENV_MAP.get(provider, (None, None))
                 if base_url_env_var:
                     os.environ[base_url_env_var] = base_url
 
@@ -3111,7 +2988,7 @@ sites:
                 return _api_error("Provider not found", status_code=404)
             # Clear the corresponding env vars so the key is no longer usable
             # in the current process after deletion.
-            key_env, url_env = _PROVIDER_STARTUP_ENV_MAP.get(provider, (None, None))
+            key_env, url_env = PROVIDER_STARTUP_ENV_MAP.get(provider, (None, None))
             if key_env:
                 os.environ.pop(key_env, None)
             if url_env:

--- a/ai_actuarial/web/chat_routes.py
+++ b/ai_actuarial/web/chat_routes.py
@@ -838,7 +838,11 @@ def register_chat_routes(
                 logger.info(f"Document truncated from {original_length} to {MAX_DOC_LENGTH} chars")
             
             # Initialize LLM client
-            config = chatbot_config.ChatbotConfig.from_config()
+            storage = Storage(db_path)
+            try:
+                config = chatbot_config.ChatbotConfig.from_config(storage=storage)
+            finally:
+                storage.close()
             llm_client = chatbot_llm.LLMClient(config)
             
             # Build summarization prompt based on mode (load optional override from config)

--- a/ai_actuarial/web/chat_routes.py
+++ b/ai_actuarial/web/chat_routes.py
@@ -275,7 +275,10 @@ def register_chat_routes(
             
             # Initialize components
             storage = Storage(db_path)
-            config = chatbot_config.ChatbotConfig(default_mode=mode)
+            config = chatbot_config.ChatbotConfig.from_config(
+                storage=storage,
+                default_mode=mode,
+            )
             
             try:
                 retriever = chatbot_retrieval.RAGRetriever(storage, config)
@@ -547,7 +550,7 @@ def register_chat_routes(
         if request.method == "GET":
             try:
                 storage = Storage(db_path)
-                config = chatbot_config.ChatbotConfig()
+                config = chatbot_config.ChatbotConfig.from_config(storage=storage)
                 
                 try:
                     conv_manager = chatbot_conversation.ConversationManager(storage, config)
@@ -574,7 +577,7 @@ def register_chat_routes(
                 mode = data.get("mode", "expert")
                 
                 storage = Storage(db_path)
-                config = chatbot_config.ChatbotConfig()
+                config = chatbot_config.ChatbotConfig.from_config(storage=storage)
                 
                 try:
                     conv_manager = chatbot_conversation.ConversationManager(storage, config)
@@ -616,7 +619,7 @@ def register_chat_routes(
         
         try:
             storage = Storage(db_path)
-            config = chatbot_config.ChatbotConfig()
+            config = chatbot_config.ChatbotConfig.from_config(storage=storage)
             
             try:
                 conv_manager = chatbot_conversation.ConversationManager(storage, config)
@@ -835,7 +838,7 @@ def register_chat_routes(
                 logger.info(f"Document truncated from {original_length} to {MAX_DOC_LENGTH} chars")
             
             # Initialize LLM client
-            config = chatbot_config.ChatbotConfig()
+            config = chatbot_config.ChatbotConfig.from_config()
             llm_client = chatbot_llm.LLMClient(config)
             
             # Build summarization prompt based on mode (load optional override from config)

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -339,7 +339,7 @@ function AiConfigTab({ lang }: { lang: string }) {
       await apiPost("/api/config/llm-providers", {
         provider: providerName,
         api_key: apiKeyInput.trim(),
-        base_url: baseUrlInput.trim() || undefined,
+        api_base_url: baseUrlInput.trim() || undefined,
       });
       setToast({ message: t("settings.provider_saved"), type: "success" });
       setEditingProvider(null);

--- a/config/yaml_config.py
+++ b/config/yaml_config.py
@@ -65,11 +65,16 @@ def _safe_float(value: str, var_name: str) -> float:
 def _get_sites_config_path() -> Path:
     """Get the path to sites.yaml configuration file."""
     # Try multiple locations
-    locations = [
+    explicit = os.getenv("CONFIG_PATH")
+    locations = []
+    if explicit:
+        locations.append(Path(explicit))
+
+    locations.extend([
         Path("config/sites.yaml"),  # Development
         Path("/app/config/sites.yaml"),  # Docker
         Path(__file__).parent / "sites.yaml",  # Relative to this file
-    ]
+    ])
     
     for path in locations:
         if path.exists():
@@ -173,7 +178,7 @@ def _extract_ai_config_from_env() -> Dict[str, Any]:
             "similarity_threshold": _safe_float(os.getenv("RAG_SIMILARITY_THRESHOLD", "0.4"), "RAG_SIMILARITY_THRESHOLD"),
         },
         "chatbot": {
-            "provider": "openai",
+            "provider": os.getenv("CHATBOT_LLM_PROVIDER", "openai"),
             "model": os.getenv("CHATBOT_MODEL", "gpt-4-turbo"),
             "temperature": _safe_float(os.getenv("CHATBOT_TEMPERATURE", "0.7"), "CHATBOT_TEMPERATURE"),
             "max_tokens": _safe_int(os.getenv("CHATBOT_MAX_TOKENS", "1000"), "CHATBOT_MAX_TOKENS"),

--- a/doc_to_md/engines/deepseekocr.py
+++ b/doc_to_md/engines/deepseekocr.py
@@ -36,9 +36,15 @@ Multi-image batching is not supported; each page must be sent in a separate call
         },
     }
 
-    def __init__(self, model: str | None = None) -> None:
+    def __init__(
+        self,
+        model: str | None = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
         settings = get_settings()
-        if not settings.siliconflow_api_key:
+        resolved_api_key = api_key or settings.siliconflow_api_key
+        if not resolved_api_key:
             raise RuntimeError("SILICONFLOW_API_KEY missing (DeepSeek-OCR via SiliconFlow)")
 
         try:
@@ -47,12 +53,15 @@ Multi-image batching is not supported; each page must be sent in a separate call
             raise RuntimeError("DeepSeek-OCR engine requires `openai`. Install it via `pip install openai`.") from exc
 
         super().__init__(retry_attempts=settings.siliconflow_retry_attempts)
-        self.api_key = settings.siliconflow_api_key
+        self.api_key = resolved_api_key
         self.model = model or settings.siliconflow_default_model
         self.timeout = settings.siliconflow_timeout_seconds
         self.max_tokens = settings.siliconflow_max_input_tokens
         self.chunk_overlap = settings.siliconflow_chunk_overlap_tokens
-        self.client = OpenAI(api_key=self.api_key, base_url=settings.siliconflow_base_url)
+        self.client = OpenAI(
+            api_key=self.api_key,
+            base_url=base_url or settings.siliconflow_base_url,
+        )
 
     def convert(self, path: Path) -> EngineResponse:  # pragma: no cover - network call
         suffix = path.suffix.lower()

--- a/doc_to_md/engines/mistral.py
+++ b/doc_to_md/engines/mistral.py
@@ -32,13 +32,15 @@ class MistralEngine(Engine):
     def __init__(
         self,
         model: str | None = None,
+        api_key: str | None = None,
         include_images: bool = False,
         extract_footer: bool | None = None,
         extract_header: bool | None = None,
         **_kwargs,
     ) -> None:
         settings = get_settings()
-        if not settings.mistral_api_key:
+        resolved_api_key = api_key or settings.mistral_api_key
+        if not resolved_api_key:
             raise RuntimeError("MISTRAL_API_KEY missing")
 
         try:
@@ -46,7 +48,7 @@ class MistralEngine(Engine):
         except ImportError as exc:  # pragma: no cover
             raise RuntimeError("Mistral engine requires `mistralai`. Install via `pip install mistralai`.") from exc
 
-        self.api_key = settings.mistral_api_key
+        self.api_key = resolved_api_key
         self.model = model or settings.mistral_default_model
         self.include_images = include_images
         self.timeout_ms = int(settings.mistral_timeout_seconds * 1000)

--- a/doc_to_md/registry.py
+++ b/doc_to_md/registry.py
@@ -79,22 +79,43 @@ def convert_path(
     *,
     engine: EngineName = "auto",
     model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
 ) -> ConversionOutput:
     if engine == "auto":
         last_exc: Exception | None = None
         for candidate in _auto_candidates(path):
             try:
-                return convert_path(path, engine=candidate, model=model)
+                return convert_path(
+                    path,
+                    engine=candidate,
+                    model=model,
+                    api_key=api_key,
+                    base_url=base_url,
+                )
             except Exception as exc:  # noqa: BLE001 - auto mode tries fallbacks
                 last_exc = exc
                 continue
         raise RuntimeError(f"Auto conversion failed for {path.name}") from last_exc
 
     engine_cls = _import_engine(engine)
+    init_kwargs = {}
+    if model is not None:
+        init_kwargs["model"] = model
+    if api_key is not None:
+        init_kwargs["api_key"] = api_key
+    if base_url is not None:
+        init_kwargs["base_url"] = base_url
     try:
-        engine_instance = engine_cls(model=model) if model is not None else engine_cls()
+        engine_instance = engine_cls(**init_kwargs)
     except TypeError:
-        engine_instance = engine_cls()
+        try:
+            if model is not None:
+                engine_instance = engine_cls(model=model)
+            else:
+                engine_instance = engine_cls()
+        except TypeError:
+            engine_instance = engine_cls()
 
     response = engine_instance.convert(path)
     return ConversionOutput(markdown=response.markdown, engine=str(engine_instance.name), model=str(response.model))

--- a/docs/开发日志-2026-03-10-ai运行时review修复.md
+++ b/docs/开发日志-2026-03-10-ai运行时review修复.md
@@ -1,0 +1,73 @@
+# AI 运行时 Review 修复日志
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 本轮目标
+
+修复上一轮 review 中仍然有效的 3 类问题：
+
+1. `os.getenv(None)` 导致的非受控异常
+2. `storage` 没继续传给 `ChatbotConfig.from_config(...)`
+3. 文档总结接口和主聊天接口的 runtime 解析不一致
+
+## 实现内容
+
+### 1. 补齐 provider env 映射空值防护
+
+修改文件：
+- `ai_actuarial/ai_runtime.py`
+- `ai_actuarial/chatbot/config.py`
+
+修复点：
+- `resolve_provider_credentials()` 遇到未知 provider 时，不再直接 `os.getenv(None)`
+- `ChatbotConfig.__post_init__()` 和 `ChatbotConfig.from_env()` 在 `provider=local` 或未知 provider 时，不再因为 env 映射缺失而抛 `TypeError`
+
+结果：
+- 未知 provider 现在会回到“未配置”状态
+- 后续由显式校验逻辑给出受控错误，而不是在 `getenv` 这里提前炸掉
+
+### 2. 继续透传 storage
+
+修改文件：
+- `ai_actuarial/chatbot/router.py`
+- `ai_actuarial/chatbot/retrieval.py`
+- `ai_actuarial/chatbot/conversation.py`
+- `ai_actuarial/chatbot/llm.py`
+
+修复点：
+- 这些类在未显式传入 `config` 时，现在会调用 `ChatbotConfig.from_config(storage=storage)`
+- `LLMClient` 新增可选 `storage` 参数，避免默认构造时丢失 DB-backed provider 凭据
+
+结果：
+- 默认构造路径和主聊天路由的 runtime 解析语义对齐
+- provider store 中的 API key / base URL 不会只在主路由生效
+
+### 3. 修正文档总结接口
+
+修改文件：
+- `ai_actuarial/web/chat_routes.py`
+
+修复点：
+- `/api/chat/summarize-document` 现在会先创建 `Storage(db_path)`，再调用 `ChatbotConfig.from_config(storage=storage)`
+
+结果：
+- 文档总结接口和 `/api/chat/query` 一样，都会优先读取 DB-backed provider 配置
+
+## 新增测试
+
+修改文件：
+- `tests/test_ai_runtime.py`
+- `tests/test_chatbot_core.py`
+- `tests/test_chat_routes.py`
+
+覆盖点：
+- 未知 provider 不再导致 `resolve_provider_credentials()` 崩溃
+- `ChatbotConfig.from_env()` 在 `provider=local` 时不崩溃
+- `ChatbotConfig` 直接初始化未知 provider 时不崩溃
+- `QueryRouter / RAGRetriever / ConversationManager / LLMClient` 默认构造时会继续透传 `storage`
+- `/api/chat/summarize-document` 会通过 storage-backed runtime 加载配置
+
+## 本轮结果
+
+- review 中仍有效的问题已经补上
+- 主聊天、文档总结、类级默认构造三条路径现在统一使用同一套 runtime 解析语义

--- a/docs/开发日志-2026-03-10-ai运行时review补充修复.md
+++ b/docs/开发日志-2026-03-10-ai运行时review补充修复.md
@@ -1,0 +1,57 @@
+# AI 运行时 Review 补充修复日志
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 本轮目标
+
+补齐上一轮 review 的 3 个后续问题：
+
+1. catalog runtime 不应把 timeout 固定成 `60.0`
+2. chatbot / embeddings 的 env 路径应回退到 provider 默认 base URL
+3. `EmbeddingGenerator` 内部应统一使用归一化后的 provider
+
+## 实现内容
+
+### 1. catalog timeout 改为按配置解析
+
+修改文件：
+- `ai_actuarial/catalog_llm.py`
+
+修复点：
+- `catalog_with_openai()` 不再写死 `timeout=60.0`
+- 现在优先读取 `ai_config.catalog.timeout_seconds`
+- 若未配置，再回退到 `OPENAI_TIMEOUT_SECONDS`
+- 最后才回退到 `60.0`
+
+结果：
+- 线上已有的 catalog 超时配置不会在 runtime 重构后丢失
+
+### 2. 为 env 路径补 provider 默认 base URL
+
+修改文件：
+- `ai_actuarial/chatbot/config.py`
+- `ai_actuarial/rag/config.py`
+
+修复点：
+- `ChatbotConfig.__post_init__()` 与 `ChatbotConfig.from_env()` 在未设置 `*_BASE_URL` 时，会回退到 provider 默认 endpoint
+- `RAGConfig.from_env()` 同样会回退到 provider 默认 endpoint
+
+结果：
+- 只配置 API key、不配置 base URL 时，DeepSeek / SiliconFlow / Qwen 等 OpenAI-compatible provider 不会错误打到 OpenAI 官方 endpoint
+
+### 3. 统一 embeddings provider 归一化
+
+修改文件：
+- `ai_actuarial/rag/embeddings.py`
+
+修复点：
+- `EmbeddingGenerator` 现在保存归一化后的 `self.provider`
+- 初始化、批量生成、单次生成、dimension 判断都统一使用这个字段
+
+结果：
+- 即使调用方传入 `Local` / ` local ` 这类非规范值，也会稳定走本地 embedding 路径
+
+## 本轮结果
+
+- catalog timeout、chatbot/rag 默认 base URL、embeddings provider 归一化三项都已补上
+- 这批修复没有改动前端契约，也没有引入新的 API 路径

--- a/docs/开发日志-2026-03-10-ai运行时统一第二批.md
+++ b/docs/开发日志-2026-03-10-ai运行时统一第二批.md
@@ -1,0 +1,118 @@
+# AI 运行时统一 第二批开发日志
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 本轮目标
+
+1. 把 `catalog / embeddings / OCR` 三条链路接入统一 AI runtime
+2. 让 provider、model、api_key、base_url 不再由各模块各自读取
+3. 保持现有前端与任务接口不变，优先做运行时收口而不是改协议
+
+## 本轮实现
+
+### 1. 扩展统一运行时能力
+
+修改文件：
+- `ai_actuarial/ai_runtime.py`
+
+新增能力：
+- 为 `catalog` 和 `embeddings` 增加 provider 支持判断
+- 新增 `OCRRuntime`
+- 新增 `resolve_ocr_runtime()`
+- 支持按函数解析 `provider_override / model_override`
+- 补齐 OCR 的 `provider <-> engine` 映射
+
+这一步的目的，是让 `catalog / embeddings / OCR` 都能从同一入口拿到：
+- 最终 provider
+- 最终 model
+- DB 优先、`.env` 兜底的凭据
+- provider 对应的 base URL
+
+### 2. Catalog 改为使用统一 runtime
+
+修改文件：
+- `ai_actuarial/catalog_llm.py`
+- `ai_actuarial/catalog_incremental.py`
+
+调整内容：
+- `catalog_with_openai()` 不再直接依赖 `OPENAI_API_KEY`
+- 现在支持从 runtime 注入 `provider / model / api_key / base_url`
+- `run_incremental_catalog()` 和 `run_catalog_for_urls()` 会先解析一次 catalog runtime，再把运行时参数传给 worker
+
+结果：
+- catalog 不再只认 OpenAI
+- DeepSeek / Mistral / Qwen / SiliconFlow 等 OpenAI-compatible provider 可以复用同一套调用面
+
+### 3. Embeddings 改为使用统一 runtime
+
+修改文件：
+- `ai_actuarial/rag/config.py`
+- `ai_actuarial/rag/embeddings.py`
+- `ai_actuarial/rag/knowledge_base.py`
+- `ai_actuarial/chatbot/retrieval.py`
+
+调整内容：
+- `RAGConfig.from_yaml()` 改为直接读取 `ai_config.embeddings`
+- embeddings 的 provider/model/key/base URL 统一通过 runtime 解析
+- `EmbeddingGenerator` 对远端 provider 改为统一按 OpenAI-compatible client 初始化
+- `KnowledgeBaseManager` 和 `RAGRetriever` 现在会把 `Storage` 传进来，确保可以读取数据库中的 provider 凭据
+
+结果：
+- embeddings 不再只认 `OPENAI_API_KEY`
+- 只要后台 provider store 中配置了对应 provider，KB 构建和 RAG 查询都能复用这套配置
+
+### 4. OCR / Markdown 转换改为按 runtime 注入
+
+修改文件：
+- `ai_actuarial/web/app.py`
+- `doc_to_md/registry.py`
+- `doc_to_md/engines/deepseekocr.py`
+- `doc_to_md/engines/mistral.py`
+
+调整内容：
+- markdown conversion 任务开始时先解析 OCR runtime
+- 运行时日志里会明确记录 `engine / provider / model / credential_source`
+- `convert_file_to_markdown()` 现在支持显式传入 `model / api_key / base_url`
+- `doc_to_md.registry.convert_path()` 允许把这些运行时参数继续传给具体引擎
+- `DeepSeekOCREngine` 和 `MistralEngine` 支持直接接收运行时 API key
+
+这一步刻意没有把 provider 信息再写回全局环境变量，而是直接把运行时参数透传给引擎，避免并发任务互相污染。
+
+### 5. 修正 OCR engine override 的模型继承问题
+
+问题：
+- 如果 `sites.yaml` 里默认 OCR provider 是远端模型，而任务里手动选了 `marker` 或 `docling`
+- 旧逻辑会把不兼容的 model 一起带过去
+
+修复：
+- `resolve_ocr_runtime()` 在显式 engine override 时会重置不兼容的 model 继承
+
+结果：
+- 任务里手动切换 OCR engine 时，不会再错误沿用 YAML 中别的 provider 模型
+
+## 新增/更新测试
+
+修改/新增：
+- `tests/test_ai_runtime.py`
+- `tests/test_catalog_runtime.py`
+- `tests/test_rag_runtime.py`
+- `tests/test_markdown.py`
+
+覆盖点：
+- OCR runtime 的 provider/engine/model 映射
+- OCR engine override 时的模型重置
+- RAG embeddings 读取 DB provider 凭据
+- EmbeddingGenerator 传递 provider-specific base URL
+- catalog 调用使用 runtime 注入的 provider/base URL
+- markdown conversion 向 `doc_to_md` 透传 runtime 参数
+
+## 本轮结果
+
+- `catalog / embeddings / OCR` 已经接入统一 runtime
+- 聊天、catalog、embeddings、OCR 四块现在都走同一套 provider/model/credential 解析语义
+- `.env` 仍保留为兼容回退，但不再是主要配置源
+
+## 后续建议
+
+1. 可以考虑新增一个只读诊断接口，直接返回四个 AI function 的 effective runtime
+2. 如果后续还要支持更多 OCR provider，优先继续扩展 `ai_runtime.py` 的映射层，而不是把判断散回各模块

--- a/docs/开发日志-2026-03-10-ai配置单一来源治理第一批.md
+++ b/docs/开发日志-2026-03-10-ai配置单一来源治理第一批.md
@@ -1,0 +1,125 @@
+# AI 配置单一来源治理 第一批开发日志
+
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 本轮目标
+
+1. 建立统一 AI runtime 配置解析层
+2. 修复聊天 provider 配置不生效的问题
+3. 收敛 `.env` / `sites.yaml` / provider store 的职责边界
+4. 保持现有 Settings 页面继续可用
+
+## 已完成变更
+
+### 1. 新增统一 AI runtime 解析模块
+
+新增文件：
+
+- `ai_actuarial/ai_runtime.py`
+
+主要职责：
+
+- 统一维护 provider 元数据
+- 统一维护 provider API key / base URL env var 映射
+- 统一解析 `ai_config.<function>`
+- 统一解析 provider 凭据来源
+- 统一输出功能运行时的 `provider + model + api_key + base_url`
+
+### 2. 修复聊天配置链路
+
+修改文件：
+
+- `ai_actuarial/chatbot/config.py`
+- `ai_actuarial/chatbot/llm.py`
+- `ai_actuarial/web/chat_routes.py`
+- `ai_actuarial/chatbot/conversation.py`
+- `ai_actuarial/chatbot/retrieval.py`
+- `ai_actuarial/chatbot/router.py`
+
+修复点：
+
+- 支持读取 `ai_config.chatbot.provider`
+- 兼容旧字段 `ai_config.chatbot.llm_provider`
+- `ChatbotConfig.from_config()` 现在会按 `sites.yaml` 读取聊天 provider/model
+- 运行时会优先读取数据库 provider store，再回退到 `.env`
+- `LLMClient` 不再只支持 OpenAI
+- OpenAI-compatible provider 现在可以通过 `base_url` 初始化
+- `/api/chat/query` 不再强制要求 `OPENAI_API_KEY`
+
+### 3. 统一 Web 配置接口 provider 元数据
+
+修改文件：
+
+- `ai_actuarial/web/app.py`
+
+修复点：
+
+- `llm-providers` 管理接口改为复用统一 provider 常量
+- env provider 列表读取 base URL 时不再错误拼接 `${provider}_BASE_URL`
+- qwen / dashscope 这类特殊 env 名称现在能正确解析
+- 保存 provider 时同时兼容 `api_base_url` 和历史错误字段 `base_url`
+
+### 4. 修复 YAML 配置路径分裂
+
+修改文件：
+
+- `config/yaml_config.py`
+
+修复点：
+
+- `load_yaml_config()` 现在优先尊重 `CONFIG_PATH`
+- 避免 Flask app 和聊天配置读取不是同一个 `sites.yaml`
+- `CHATBOT_LLM_PROVIDER` 现在能正确映射到 `ai_config.chatbot.provider`
+
+### 5. 修复前端 Settings 的 provider base URL 提交字段
+
+修改文件：
+
+- `client/src/pages/Settings.tsx`
+
+修复点：
+
+- Settings AI 页面现在提交 `api_base_url`
+- 与后端字段对齐
+- 自定义 OpenAI-compatible endpoint 可以正确入库
+
+## 当前配置语义
+
+### 推荐管理方式
+
+日常管理建议只走后台 Settings。
+
+### 持久化职责
+
+- `sites.yaml`
+  - 保存各 AI 功能使用哪个 provider / model / prompt
+- `api_tokens`
+  - 保存 provider API key 和可选 base URL
+- `.env`
+  - 仅作为兼容回退和部署 bootstrap
+
+### 运行时优先级
+
+对于聊天 provider 凭据：
+
+1. 数据库 provider store
+2. `.env`
+3. 缺失时报清晰错误
+
+## 结果
+
+用户报错场景已经覆盖：
+
+- 当 chatbot provider 配置为 `deepseek` 等非 OpenAI provider 时
+- 即使没有 `OPENAI_API_KEY`
+- 只要对应 provider key 已配置，聊天接口即可正常初始化
+
+## 后续建议
+
+下一批建议继续做两件事：
+
+1. 把 catalog / embeddings / OCR 也接入 `ai_runtime.py`
+2. 新增一个合并视图接口，例如 `/api/config/ai-settings`
+   - 统一返回功能配置 + provider 配置状态
+   - 让前端真正只有一个配置读取入口

--- a/docs/测试指南-2026-03-10-ai运行时review修复.md
+++ b/docs/测试指南-2026-03-10-ai运行时review修复.md
@@ -1,0 +1,46 @@
+# AI 运行时 Review 修复测试指南
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 定向测试
+
+执行命令：
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests/test_ai_runtime.py tests/test_chatbot_core.py tests/test_chat_routes.py -o addopts=
+```
+
+结果：
+- `81 passed, 3 warnings, 4 subtests passed`
+
+## 全量测试
+
+执行命令：
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -o addopts=
+```
+
+结果：
+- `427 passed, 39 warnings, 4 subtests passed`
+
+## 本轮新增覆盖点
+
+### `tests/test_ai_runtime.py`
+
+- 未知 provider 不会让 `resolve_provider_credentials()` 在 `os.getenv(None)` 处崩溃
+
+### `tests/test_chatbot_core.py`
+
+- `ChatbotConfig.from_env()` 在 `provider=local` 时不崩溃
+- `ChatbotConfig` 直接初始化未知 provider 时不崩溃
+- `QueryRouter / ConversationManager / RAGRetriever / LLMClient` 默认构造时会继续透传 `storage`
+
+### `tests/test_chat_routes.py`
+
+- `/api/chat/summarize-document` 会通过 `storage` 解析运行时配置，而不是只读 `.env`
+
+## 已知非阻塞项
+
+1. warning 仍主要来自：
+   - SQLAlchemy 2.0 迁移提醒
+   - 第三方 Swig 相关 `DeprecationWarning`
+2. 这些 warning 与本轮 review 修复无直接功能冲突

--- a/docs/测试指南-2026-03-10-ai运行时review补充修复.md
+++ b/docs/测试指南-2026-03-10-ai运行时review补充修复.md
@@ -1,0 +1,43 @@
+# AI 运行时 Review 补充修复测试指南
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 定向测试
+
+执行命令：
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests/test_catalog_runtime.py tests/test_rag_runtime.py tests/test_chatbot_core.py -o addopts=
+```
+
+结果：
+- `59 passed, 3 warnings`
+
+## 全量测试
+
+执行命令：
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -o addopts=
+```
+
+结果：
+- `430 passed, 39 warnings, 4 subtests passed`
+
+## 本轮新增覆盖点
+
+### `tests/test_catalog_runtime.py`
+
+- catalog runtime 会读取 `ai_config.catalog.timeout_seconds`
+
+### `tests/test_chatbot_core.py`
+
+- `ChatbotConfig.from_env()` 在 DeepSeek provider 下会自动补默认 base URL
+
+### `tests/test_rag_runtime.py`
+
+- `RAGConfig.from_env()` 在 SiliconFlow provider 下会自动补默认 base URL
+- `EmbeddingGenerator` 在 `embedding_provider=" Local "` 这类输入下仍会稳定走本地路径
+
+## 已知非阻塞项
+
+1. warning 仍主要来自 SQLAlchemy 2.0 迁移提醒和第三方 Swig 依赖
+2. 这些 warning 与本轮补充修复无直接功能冲突

--- a/docs/测试指南-2026-03-10-ai运行时统一第二批.md
+++ b/docs/测试指南-2026-03-10-ai运行时统一第二批.md
@@ -1,0 +1,80 @@
+# AI 运行时统一 第二批测试指南
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 本轮测试目标
+
+1. 验证 catalog / embeddings / OCR 已切到统一 runtime
+2. 验证数据库 provider 凭据优先于 `.env`
+3. 验证 OCR 任务会把运行时参数透传到转换引擎
+4. 验证改动未破坏现有聊天、RAG、设置后台和 markdown 相关功能
+
+## 定向测试
+
+执行命令：
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests/test_ai_runtime.py tests/test_rag_runtime.py tests/test_markdown.py tests/test_catalog_runtime.py -o addopts=
+```
+
+结果：
+- `24 passed, 3 warnings`
+
+补充回归：
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests/test_llm_provider_management.py tests/test_web_settings.py -o addopts=
+```
+
+结果：
+- `31 passed, 3 warnings`
+
+## 全量测试
+
+执行命令：
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -o addopts=
+```
+
+结果：
+- `419 passed, 39 warnings, 4 subtests passed`
+
+## 前端构建验证
+
+执行目录：
+- `client/`
+
+执行命令：
+```powershell
+npm run build
+```
+
+结果：
+- 构建通过
+- Vite 仍有 bundle size warning，但不是本轮引入
+
+## 本轮新增覆盖点
+
+### `tests/test_ai_runtime.py`
+
+- `resolve_ocr_runtime()` 会把 `ai_config.ocr` 正确映射成 OCR engine/model
+- 手动指定 `marker` 这类本地引擎时，不会继承远端 provider 的 model
+
+### `tests/test_rag_runtime.py`
+
+- `RAGConfig.from_yaml()` 会优先读取数据库中的 provider 凭据
+- `EmbeddingGenerator` 会把 runtime 的 `api_key / base_url / timeout` 传给 OpenAI-compatible client
+
+### `tests/test_catalog_runtime.py`
+
+- catalog 运行时支持非 OpenAI provider
+- `catalog_with_openai()` 会正确使用 runtime 注入的 `model / api_key / base_url`
+
+### `tests/test_markdown.py`
+
+- `convert_file_to_markdown()` 会把 OCR runtime 的 `model / api_key / base_url` 透传给 `doc_to_md.registry.convert_path()`
+
+## 已知非阻塞项
+
+1. 全量 warning 仍主要来自：
+   - SQLAlchemy 2.0 迁移提醒
+   - 第三方 Swig 类型的 `DeprecationWarning`
+2. 这两类 warning 与本轮 AI runtime 统一无直接功能风险

--- a/docs/测试指南-2026-03-10-ai配置单一来源治理第一批.md
+++ b/docs/测试指南-2026-03-10-ai配置单一来源治理第一批.md
@@ -1,0 +1,90 @@
+# AI 配置单一来源治理 第一批测试指南
+
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 本轮测试目标
+
+1. 验证统一 AI runtime 配置解析层可用
+2. 验证聊天 provider 按 `sites.yaml` 正确生效
+3. 验证没有 `OPENAI_API_KEY` 时，非 OpenAI provider 聊天仍可工作
+4. 验证 Settings 的 provider base URL 保存链路正常
+
+## 定向测试
+
+执行命令：
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -o addopts= `
+  tests/test_ai_runtime.py `
+  tests/test_yaml_config.py `
+  tests/test_chatbot_core.py `
+  tests/test_chatbot_integration.py `
+  tests/test_chat_routes.py `
+  tests/test_llm_provider_management.py
+```
+
+结果：
+
+- `122 passed, 3 warnings, 4 subtests passed`
+
+## 全量测试
+
+执行命令：
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -o addopts=
+```
+
+结果：
+
+- `413 passed, 39 warnings, 4 subtests passed`
+
+## 前端构建验证
+
+执行命令：
+
+```powershell
+npm run build
+```
+
+执行目录：
+
+- `client/`
+
+结果：
+
+- 构建通过
+
+## 本轮新增覆盖点
+
+### `tests/test_ai_runtime.py`
+
+- `chatbot.provider` 字段能正确解析
+- provider 凭据解析优先使用数据库而不是 `.env`
+
+### `tests/test_chatbot_core.py`
+
+- `ChatbotConfig.from_env()` 支持 provider-specific API key
+- `ChatbotConfig.from_yaml()` 正确读取 `chatbot.provider`
+- provider-specific 缺 key 时，报错信息包含正确 env var 名称
+
+### `tests/test_chatbot_integration.py`
+
+- `LLMClient` 初始化时会把 provider base URL 传给 OpenAI-compatible client
+
+### `tests/test_chat_routes.py`
+
+- `/api/chat/query` 在 `deepseek` provider 场景下不再要求 `OPENAI_API_KEY`
+
+### `tests/test_yaml_config.py`
+
+- `CONFIG_PATH` 覆盖生效
+- `CHATBOT_LLM_PROVIDER` 能映射到 `ai_config.chatbot.provider`
+
+## 已知非阻塞项
+
+1. 目前全量测试 warning 仍然主要来自：
+   - SQLAlchemy 2.0 迁移提醒
+   - 第三方 Swig 类型的 `DeprecationWarning`
+2. 这些 warning 与本轮 AI 配置治理无直接功能性冲突

--- a/docs/规划文档-2026-03-10-ai运行时统一第二批Phase0.md
+++ b/docs/规划文档-2026-03-10-ai运行时统一第二批Phase0.md
@@ -1,0 +1,85 @@
+# AI 运行时统一 第二批 Phase 0
+
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 范围
+
+在第一批已完成 chatbot 统一解析的基础上，继续把以下三条链路接入统一 runtime：
+
+1. `catalog`
+2. `embeddings`
+3. `ocr`
+
+## 当前问题
+
+### catalog
+
+- `catalog_llm.py` 仍直接依赖 `config.settings`
+- 默认只认 `OPENAI_API_KEY`
+- `catalog_incremental.py` 仍把远端 provider 限死为 `openai`
+
+### embeddings
+
+- `RAGConfig` 和 `EmbeddingGenerator` 仍只按 OpenAI/local 二选一
+- 即使后台把 embeddings provider 切到其他 OpenAI-compatible provider，运行时也不会生效
+
+### ocr
+
+- `ai_config.ocr.provider/model` 与 `doc_to_md` 实际 engine 之间没有统一映射
+- `doc_to_md` 引擎还是直接从 `config.settings` 读 env
+- 当前 OCR model 选择并没有真正完整传到转换执行层
+
+## 目标
+
+1. `catalog` 使用统一 runtime 解析 provider/model/key/base_url
+2. `embeddings` 使用统一 runtime 解析 provider/model/key/base_url
+3. `OCR` 在 web 执行入口按统一 runtime 映射到正确 engine/model
+4. 不破坏现有 Settings UI 和现有任务 API
+
+## 设计决策
+
+### 1. catalog 直接切到 runtime 直连
+
+- `catalog_llm.py` 改成 provider-aware
+- 支持 OpenAI-compatible catalog provider
+- `catalog_incremental.py` 在批处理开始前解析一次 runtime，并传给 worker
+
+### 2. embeddings 改成 provider-aware OpenAI client
+
+- `RAGConfig` 增加统一字段：provider/model/api_key/base_url
+- `EmbeddingGenerator` 对远端 embeddings 统一走 OpenAI-compatible client
+- 本批支持当前可稳定落地的 OpenAI-compatible embedding provider
+
+### 3. OCR 采用入口映射，不重写 doc_to_md 引擎
+
+- 在 web OCR 入口把 `ai_config.ocr` 映射成实际 engine/model
+- 在调用引擎前统一注入 provider key/base_url/default model 到当前进程环境
+- 继续复用 `doc_to_md` 引擎，降低改动面
+
+## 分阶段实施
+
+### Phase 1
+
+- 扩展 `ai_runtime.py`
+- 加入 override / OCR engine 映射 / runtime env 注入能力
+
+### Phase 2
+
+- 改 `catalog_llm.py`
+- 改 `catalog_incremental.py`
+- 改 `RAGConfig` / `EmbeddingGenerator`
+
+### Phase 3
+
+- 改 OCR web 执行入口
+- 补测试
+- 全量验证
+- 补文档
+
+## 完成标准
+
+1. `catalog / embeddings / ocr` 都接到统一 runtime
+2. Settings 中配置的 provider/model 对应功能真实生效
+3. 不再依赖手工维护多处 `.env` 值来驱动运行时
+4. 全量 `pytest` 和前端构建通过

--- a/docs/规划文档-2026-03-10-ai配置单一来源治理Phase0.md
+++ b/docs/规划文档-2026-03-10-ai配置单一来源治理Phase0.md
@@ -1,0 +1,235 @@
+# AI 配置单一来源治理 Phase 0
+
+日期：2026-03-10
+分支：`feature/ai-config-single-source`
+
+## 背景
+
+当前 AI 配置实际分散在 4 条链路里：
+
+1. `config/sites.yaml`
+   - 保存各功能使用的 `provider` / `model`
+2. `.env`
+   - 保存历史遗留的 API key、base URL、默认模型等
+3. `api_tokens` 数据表
+   - 由后台 Settings 页面写入，保存 provider API key 和可选 base URL
+4. 各模块自己的配置读取逻辑
+   - `ai_actuarial/chatbot/config.py`
+   - `ai_actuarial/rag/config.py`
+   - `ai_actuarial/catalog_llm.py`
+   - `ai_actuarial/llm_models.py`
+
+这导致“后台设置已改，但运行时没按设置生效”的问题持续出现。
+
+## 当前已确认的问题
+
+### 1. 聊天配置读取存在字段错位
+
+- Settings 页面和 `/api/config/ai-models` 使用 `ai_config.chatbot.provider`
+- `ChatbotConfig.from_yaml()` 却读取 `ai_config.chatbot.llm_provider`
+
+结果：
+
+- 后台保存的聊天 provider 可能根本没有被读取到
+
+### 2. 聊天 API key 校验硬编码为 OpenAI
+
+`ChatbotConfig` 当前会：
+
+- 默认从 `OPENAI_API_KEY` 读取 `api_key`
+- `validate()` 只接受 `OPENAI_API_KEY`
+
+结果：
+
+- 即使后台把 chatbot provider 改成 `mistral` / `deepseek` / `moonshot` 等
+- `/api/chat/query` 仍会报 `OPENAI_API_KEY` 缺失
+
+### 3. 聊天运行时没有统一 provider 解析层
+
+`chat_routes.py` 当前直接 `ChatbotConfig(default_mode=mode)`，没有走：
+
+- `sites.yaml` 当前功能配置
+- 数据库中保存的 provider key / base URL
+- provider 默认 base URL
+
+### 4. AI provider 元数据重复散落
+
+至少以下信息现在重复维护：
+
+- provider 显示名
+- provider 默认 base URL
+- provider 对应 env var
+- provider 支持范围
+
+这些信息目前散落在：
+
+- `ai_actuarial/web/app.py`
+- `config/settings.py`
+- 各模块 `os.getenv(...)`
+
+## 目标
+
+本轮目标不是一次性重写所有 AI 模块，而是先建立统一解析层，并先修最常出错的聊天链路。
+
+### 本轮目标
+
+1. 建立统一 AI 配置解析模块
+2. 明确单一管理语义：
+   - 功能配置：`sites.yaml -> ai_config`
+   - provider 密钥 / base URL：数据库 `api_tokens`
+   - `.env`：仅保留兼容回退和本地 bootstrap
+3. 让聊天功能按选定 provider 正常工作
+4. 为后续 catalog / embeddings / OCR 收敛到同一解析层打基础
+
+### 本轮不做
+
+1. 不重做整个 Settings UI
+2. 不一次性重写所有 provider SDK 接入
+3. 不移除 `.env` 兼容逻辑
+4. 不在这轮里彻底统一 embeddings / OCR 运行时实现
+
+## 技术方案
+
+### 方案一：只修聊天判断
+
+做法：
+
+- 在 `ChatbotConfig` / `LLMClient` 里补几条 `if provider == ...`
+
+问题：
+
+- 无法解决配置分散
+- 其他模块仍各读各的配置
+- 后面继续迁 catalog / embeddings 时还会重复踩坑
+
+结论：
+
+- 不采用
+
+### 方案二：新增统一 AI 配置解析层
+
+做法：
+
+- 新增统一模块，集中维护：
+  - provider 元数据
+  - env var 映射
+  - 默认 base URL
+  - 功能配置解析
+  - provider 密钥解析
+  - 运行时有效配置组装
+- 聊天链路优先接入这个模块
+- Web 配置接口改为复用统一 provider 元数据
+
+结论：
+
+- 采用
+
+## 关键设计决策
+
+### 决策 1：单一管理入口定义
+
+对用户而言，单一管理入口定义为：
+
+- 后台 Settings -> AI 页面
+
+对后端而言，单一配置源定义为：
+
+- 非敏感 AI 功能配置：`sites.yaml`
+- 敏感 provider 凭据：数据库 `api_tokens`
+
+`.env` 不再作为常规主配置，只保留：
+
+- 初始部署
+- 本地开发
+- 兼容旧代码回退
+
+### 决策 2：聊天优先接入统一解析层
+
+本轮先把以下路径统一：
+
+- `ai_actuarial/chatbot/config.py`
+- `ai_actuarial/chatbot/llm.py`
+- `ai_actuarial/web/chat_routes.py`
+- `ai_actuarial/web/app.py` 中 provider 元数据
+
+### 决策 3：先支持当前可稳定落地的聊天 provider 运行时
+
+优先支持 OpenAI-compatible 模式的 provider：
+
+- `openai`
+- `mistral`
+- `deepseek`
+- `moonshot`
+- `kimi`
+- `qwen`
+- `zhipuai`
+- `siliconflow`
+- `minimax`
+
+对未实现专用 SDK 的 provider：
+
+- `anthropic`
+- `google`
+- `cohere`
+
+先给出明确错误信息，而不是继续误报 `OPENAI_API_KEY` 缺失。
+
+## 实施计划
+
+### Phase 1：统一配置解析层
+
+交付物：
+
+- 新增 AI 运行时配置模块
+- 提取 provider 常量和解析函数
+- Web 配置接口改为复用统一元数据
+
+### Phase 2：聊天链路接入
+
+交付物：
+
+- `ChatbotConfig` 改为从统一解析层读取
+- 修复 `provider` / `llm_provider` 字段兼容
+- `LLMClient` 支持按 provider 解析 key/base URL
+- `/api/chat/query` 使用有效运行时配置
+
+### Phase 3：测试与文档
+
+交付物：
+
+- 新增 provider 配置解析测试
+- 新增聊天 provider 选择测试
+- 全量 pytest
+- 开发日志和测试指南
+
+## 测试策略
+
+### 定向测试
+
+- `tests/test_chatbot_core.py`
+- `tests/test_chatbot_integration.py`
+- `tests/test_chat_routes.py`
+- `tests/test_llm_provider_management.py`
+- `tests/test_yaml_config.py`
+
+### 重点覆盖
+
+1. `sites.yaml` 里 `chatbot.provider` 能正确生效
+2. provider key 来自数据库时聊天能正常初始化
+3. provider key 来自 `.env` 时仍兼容
+4. 选择非 OpenAI provider 时，不再强制要求 `OPENAI_API_KEY`
+5. 不支持的 provider 返回清晰错误
+
+## 风险
+
+1. 旧测试大量直接实例化 `ChatbotConfig()`，修改默认加载路径时要保持兼容
+2. Web 配置接口和聊天链路共用 provider 常量后，现有测试快照可能需要同步
+3. 某些 provider 虽然在 UI 可配置，但并不完全兼容 OpenAI client，需要明确降级行为
+
+## 完成标准
+
+1. 聊天链路按当前后台选定 provider 工作
+2. 不再出现“配置了其他 provider，却要求 `OPENAI_API_KEY`”的错误
+3. provider 元数据不再在多个模块里手工重复维护
+4. 全量 `pytest` 通过
+5. 补齐开发日志和测试文档

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -11,6 +11,7 @@ import unittest
 from ai_actuarial.ai_runtime import (
     get_ai_function_section,
     resolve_ai_function_runtime,
+    resolve_ocr_runtime,
 )
 from ai_actuarial.services.token_encryption import TokenEncryption
 from ai_actuarial.storage import Storage
@@ -77,6 +78,51 @@ class TestAiRuntime(unittest.TestCase):
         self.assertEqual(runtime.api_key, "db-deepseek-key")
         self.assertEqual(runtime.base_url, "https://custom.deepseek.test/v1")
         self.assertEqual(runtime.credential_source, "db")
+
+    def test_resolve_ocr_runtime_uses_provider_mapping(self):
+        """OCR runtime should map ai_config provider to engine/model consistently."""
+        yaml_config = {
+            "ai_config": {
+                "ocr": {
+                    "provider": "mistral",
+                    "model": "mistral-ocr-latest",
+                }
+            }
+        }
+        encrypted = TokenEncryption().encrypt("db-mistral-key")
+        self.storage.upsert_llm_provider(
+            provider="mistral",
+            api_key_encrypted=encrypted,
+            base_url="https://api.mistral.ai/v1",
+        )
+
+        runtime = resolve_ocr_runtime(storage=self.storage, yaml_config=yaml_config)
+
+        self.assertEqual(runtime.provider, "mistral")
+        self.assertEqual(runtime.engine, "mistral")
+        self.assertEqual(runtime.model, "mistral-ocr-latest")
+        self.assertEqual(runtime.api_key, "db-mistral-key")
+
+    def test_resolve_ocr_runtime_engine_override_resets_model(self):
+        """Explicit OCR engine selection should not inherit an incompatible YAML model."""
+        yaml_config = {
+            "ai_config": {
+                "ocr": {
+                    "provider": "mistral",
+                    "model": "mistral-ocr-latest",
+                }
+            }
+        }
+
+        runtime = resolve_ocr_runtime(
+            storage=self.storage,
+            yaml_config=yaml_config,
+            engine_override="marker",
+        )
+
+        self.assertEqual(runtime.provider, "local")
+        self.assertEqual(runtime.engine, "marker")
+        self.assertEqual(runtime.model, "marker")
 
 
 if __name__ == "__main__":

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for unified AI runtime configuration resolution."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from ai_actuarial.ai_runtime import (
+    get_ai_function_section,
+    resolve_ai_function_runtime,
+)
+from ai_actuarial.services.token_encryption import TokenEncryption
+from ai_actuarial.storage import Storage
+
+
+class TestAiRuntime(unittest.TestCase):
+    """Test unified provider and AI function resolution."""
+
+    def setUp(self):
+        self.original_env = dict(os.environ)
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+        self.storage = Storage(self.db_path)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+        self.storage.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_get_ai_function_section_supports_chatbot_provider_key(self):
+        """chatbot.provider should normalize without legacy llm_provider."""
+        yaml_config = {
+            "ai_config": {
+                "chatbot": {
+                    "provider": "deepseek",
+                    "model": "deepseek-chat",
+                }
+            }
+        }
+
+        section = get_ai_function_section("chatbot", yaml_config=yaml_config)
+
+        self.assertEqual(section["provider"], "deepseek")
+        self.assertEqual(section["model"], "deepseek-chat")
+
+    def test_resolve_ai_function_runtime_prefers_db_credentials(self):
+        """DB provider credentials should override env fallback for runtime use."""
+        yaml_config = {
+            "ai_config": {
+                "chatbot": {
+                    "provider": "deepseek",
+                    "model": "deepseek-chat",
+                }
+            }
+        }
+        os.environ["DEEPSEEK_API_KEY"] = "env-deepseek-key"
+
+        encrypted = TokenEncryption().encrypt("db-deepseek-key")
+        self.storage.upsert_llm_provider(
+            provider="deepseek",
+            api_key_encrypted=encrypted,
+            base_url="https://custom.deepseek.test/v1",
+        )
+
+        runtime = resolve_ai_function_runtime(
+            "chatbot",
+            storage=self.storage,
+            yaml_config=yaml_config,
+        )
+
+        self.assertEqual(runtime.provider, "deepseek")
+        self.assertEqual(runtime.model, "deepseek-chat")
+        self.assertEqual(runtime.api_key, "db-deepseek-key")
+        self.assertEqual(runtime.base_url, "https://custom.deepseek.test/v1")
+        self.assertEqual(runtime.credential_source, "db")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -10,6 +10,7 @@ import unittest
 
 from ai_actuarial.ai_runtime import (
     get_ai_function_section,
+    resolve_provider_credentials,
     resolve_ai_function_runtime,
     resolve_ocr_runtime,
 )
@@ -123,6 +124,16 @@ class TestAiRuntime(unittest.TestCase):
         self.assertEqual(runtime.provider, "local")
         self.assertEqual(runtime.engine, "marker")
         self.assertEqual(runtime.model, "marker")
+
+    def test_resolve_provider_credentials_unknown_provider_does_not_crash(self):
+        """Unknown provider names should return an unconfigured runtime instead of crashing."""
+        credentials = resolve_provider_credentials("unknown-provider", storage=self.storage)
+
+        self.assertEqual(credentials.provider, "unknown-provider")
+        self.assertIsNone(credentials.api_key)
+        self.assertIsNone(credentials.base_url)
+        self.assertFalse(credentials.configured)
+        self.assertEqual(credentials.source, "missing")
 
 
 if __name__ == "__main__":

--- a/tests/test_catalog_runtime.py
+++ b/tests/test_catalog_runtime.py
@@ -47,6 +47,43 @@ class TestCatalogRuntime(unittest.TestCase):
         self.assertEqual(result.summary, "Summary")
         self.assertEqual(result.suggested_title, "Runtime Title")
 
+    def test_catalog_with_openai_uses_runtime_timeout_seconds(self):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content='{"summary":"Summary","keywords":["alpha"],"category":"Other"}'
+                    )
+                )
+            ]
+        )
+        mock_openai = MagicMock()
+        mock_openai.OpenAI.return_value = mock_client
+        mock_runtime = SimpleNamespace(
+            provider="deepseek",
+            model="deepseek-chat",
+            api_key="runtime-key",
+            base_url="https://api.deepseek.com/v1",
+            raw_config={"timeout_seconds": 12},
+        )
+
+        with patch.dict(sys.modules, {"openai": mock_openai}), patch(
+            "ai_actuarial.catalog_llm.resolve_ai_function_runtime",
+            return_value=mock_runtime,
+        ):
+            catalog_with_openai(
+                title="Document",
+                content="Sample content",
+                provider="deepseek",
+                model="deepseek-chat",
+                api_key="runtime-key",
+                base_url="https://api.deepseek.com/v1",
+            )
+
+        _, kwargs = mock_client.chat.completions.create.call_args
+        self.assertEqual(kwargs["timeout"], 12.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_catalog_runtime.py
+++ b/tests/test_catalog_runtime.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Tests for catalog runtime provider resolution."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ai_actuarial.catalog_llm import catalog_with_openai
+
+
+class TestCatalogRuntime(unittest.TestCase):
+    def test_catalog_with_openai_uses_runtime_provider_kwargs(self):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=(
+                            '{"summary":"Summary","keywords":["alpha","beta"],'
+                            '"category":"Other","suggested_title":"Runtime Title"}'
+                        )
+                    )
+                )
+            ]
+        )
+        mock_openai = MagicMock()
+        mock_openai.OpenAI.return_value = mock_client
+
+        with patch.dict(sys.modules, {"openai": mock_openai}):
+            result = catalog_with_openai(
+                title="Document",
+                content="Sample content",
+                provider="deepseek",
+                model="deepseek-chat",
+                api_key="runtime-key",
+                base_url="https://api.deepseek.com/v1",
+            )
+
+        mock_openai.OpenAI.assert_called_once_with(
+            api_key="runtime-key",
+            base_url="https://api.deepseek.com/v1",
+        )
+        self.assertEqual(result.model, "deepseek-chat")
+        self.assertEqual(result.summary, "Summary")
+        self.assertEqual(result.suggested_title, "Runtime Title")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -320,6 +320,34 @@ class TestChatRoutes(unittest.TestCase):
         kwargs = mock_openai_class.call_args.kwargs
         self.assertEqual(kwargs["api_key"], "deepseek-key-123")
         self.assertEqual(kwargs["base_url"], "https://api.deepseek.com/v1")
+
+    @patch('ai_actuarial.chatbot.llm.LLMClient')
+    @patch('ai_actuarial.chatbot.config.ChatbotConfig.from_config')
+    def test_summarize_document_uses_storage_backed_config(self, mock_from_config, mock_llm_class):
+        """Document summarization should resolve config through storage-backed runtime."""
+        mock_config = Mock()
+        mock_config.model = "deepseek-chat"
+        mock_from_config.return_value = mock_config
+
+        mock_llm = Mock()
+        mock_llm.generate.return_value = "Summary result"
+        mock_llm_class.return_value = mock_llm
+
+        response = self.client.post(
+            "/api/chat/summarize-document",
+            headers=self.auth_header,
+            json={
+                "document_content": "# Test\n\nDocument body.",
+                "document_title": "Test Doc",
+                "mode": "summary",
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(mock_from_config.called)
+        _, kwargs = mock_from_config.call_args
+        self.assertIn("storage", kwargs)
+        self.assertIsNotNone(kwargs["storage"])
     
     def test_chat_query_missing_message(self):
         """Test chat query with missing message."""

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -255,6 +255,71 @@ class TestChatRoutes(unittest.TestCase):
         self.assertIn("Solvency II", result["response"])
         self.assertEqual(len(result["citations"]), 1)
         self.assertEqual(result["citations"][0]["filename"], "regulation.pdf")
+
+    @patch('ai_actuarial.chatbot.retrieval.RAGRetriever')
+    @patch('openai.OpenAI')
+    def test_chat_query_uses_selected_provider_without_openai_key(self, mock_openai_class, mock_retriever_class):
+        """Chat queries should follow ai_config.chatbot.provider instead of forcing OpenAI."""
+        os.environ.pop("OPENAI_API_KEY", None)
+        os.environ["DEEPSEEK_API_KEY"] = "deepseek-key-123"
+
+        with open(self.config_path, "r", encoding="utf-8") as f:
+            config_data = yaml.safe_load(f) or {}
+        config_data.setdefault("ai_config", {})
+        config_data["ai_config"]["chatbot"] = {
+            "provider": "deepseek",
+            "model": "deepseek-chat",
+            "temperature": 0.7,
+            "max_tokens": 1000,
+        }
+        with open(self.config_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(config_data, f)
+
+        from config.yaml_config import invalidate_config_cache
+        invalidate_config_cache()
+
+        mock_retriever = Mock()
+        mock_retriever.retrieve.return_value = [
+            {
+                'content': 'DeepSeek can answer this question.',
+                'metadata': {
+                    'filename': 'deepseek.pdf',
+                    'kb_id': 'test_kb1',
+                    'kb_name': 'General KB',
+                    'similarity_score': 0.91,
+                    'chunk_id': 'chunk_1',
+                    'file_url': '/database/deepseek.pdf'
+                }
+            }
+        ]
+        mock_retriever_class.return_value = mock_retriever
+
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "DeepSeek answer [Source: deepseek.pdf]."
+        mock_response.usage.total_tokens = 88
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+
+        response = self.client.post(
+            "/api/chat/query",
+            headers=self.auth_header,
+            json={
+                "message": "Use deepseek provider",
+                "kb_ids": ["test_kb1"],
+                "mode": "expert"
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data["success"])
+        self.assertIn("DeepSeek answer", data["data"]["response"])
+
+        kwargs = mock_openai_class.call_args.kwargs
+        self.assertEqual(kwargs["api_key"], "deepseek-key-123")
+        self.assertEqual(kwargs["base_url"], "https://api.deepseek.com/v1")
     
     def test_chat_query_missing_message(self):
         """Test chat query with missing message."""

--- a/tests/test_chatbot_core.py
+++ b/tests/test_chatbot_core.py
@@ -28,6 +28,7 @@ from ai_actuarial.chatbot.exceptions import (
     InvalidKBException,
     InvalidModeException,
 )
+from ai_actuarial.chatbot.llm import LLMClient
 from ai_actuarial.chatbot.prompts import (
     BASE_INSTRUCTIONS,
     MODE_PROMPTS,
@@ -36,6 +37,7 @@ from ai_actuarial.chatbot.prompts import (
     format_user_query,
     get_system_prompt,
 )
+from ai_actuarial.chatbot.retrieval import RAGRetriever
 from ai_actuarial.chatbot.router import QueryRouter
 from ai_actuarial.storage import Storage
 
@@ -100,6 +102,24 @@ class TestChatbotConfig(unittest.TestCase):
         self.assertEqual(config.llm_provider, "deepseek")
         self.assertEqual(config.api_key, "deepseek-key-123")
         self.assertEqual(config.model, "deepseek-chat")
+
+    def test_from_env_local_provider_does_not_require_env_mapping(self):
+        """Local provider should not crash even though it has no API key env mapping."""
+        os.environ["CHATBOT_LLM_PROVIDER"] = "local"
+
+        config = ChatbotConfig.from_env()
+
+        self.assertEqual(config.llm_provider, "local")
+        self.assertIsNone(config.api_key)
+        self.assertIsNone(config.base_url)
+
+    def test_init_unknown_provider_does_not_call_getenv_with_none(self):
+        """Unknown providers should stay unconfigured instead of raising TypeError."""
+        config = ChatbotConfig(llm_provider="unknown-provider")
+
+        self.assertEqual(config.llm_provider, "unknown-provider")
+        self.assertIsNone(config.api_key)
+        self.assertIsNone(config.base_url)
 
     def test_from_yaml_reads_chatbot_provider(self):
         """sites.yaml chatbot.provider should be honored."""
@@ -557,6 +577,17 @@ class TestConversationManager(unittest.TestCase):
         self.assertEqual(stats["total_messages"], 3)
         self.assertEqual(stats["total_tokens"], 75)
 
+    def test_uses_storage_when_loading_default_config(self):
+        """Default config loading should receive storage for DB-backed credentials."""
+        with patch(
+            "ai_actuarial.chatbot.conversation.ChatbotConfig.from_config",
+            return_value=ChatbotConfig(api_key="test-key", _apply_env_defaults=False),
+        ) as mock_from_config:
+            manager = ConversationManager(self.storage, config=None)
+
+        mock_from_config.assert_called_once_with(storage=self.storage)
+        self.assertIsInstance(manager, ConversationManager)
+
 
 class TestQueryRouter(unittest.TestCase):
     """Test QueryRouter KB selection logic."""
@@ -637,7 +668,20 @@ class TestQueryRouter(unittest.TestCase):
         self.assertEqual(analysis["intent"], "explanatory")
         self.assertIn("regulation", analysis["categories"])
         self.assertTrue(analysis["has_question_mark"])
-    
+
+    def test_uses_storage_when_loading_default_config(self):
+        """Default router config loading should receive storage for DB-backed credentials."""
+        with patch(
+            "ai_actuarial.chatbot.router.ChatbotConfig.from_config",
+            return_value=ChatbotConfig(api_key="test-key", _apply_env_defaults=False),
+        ) as mock_from_config, patch(
+            "ai_actuarial.chatbot.router.KnowledgeBaseManager"
+        ):
+            router = QueryRouter(self.storage, config=None)
+
+        mock_from_config.assert_called_once_with(storage=self.storage)
+        self.assertIsInstance(router, QueryRouter)
+
     def test_analyze_query_comparative(self):
         """Test analyzing comparative query."""
         query = "Compare term life and whole life insurance"
@@ -710,6 +754,47 @@ class TestQueryRouter(unittest.TestCase):
         mode = self.router.recommend_mode(analysis)
         
         self.assertEqual(mode, "expert")
+
+
+class TestDefaultStoragePropagation(unittest.TestCase):
+    """Test default config construction for chatbot helper classes."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+        self.storage = Storage(self.db_path)
+
+    def tearDown(self):
+        self.storage.close()
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_retriever_uses_storage_when_loading_default_config(self):
+        with patch(
+            "ai_actuarial.chatbot.retrieval.ChatbotConfig.from_config",
+            return_value=ChatbotConfig(api_key="test-key", _apply_env_defaults=False),
+        ) as mock_from_config, patch(
+            "ai_actuarial.chatbot.retrieval.KnowledgeBaseManager"
+        ), patch(
+            "ai_actuarial.chatbot.retrieval.EmbeddingGenerator"
+        ):
+            retriever = RAGRetriever(self.storage, config=None)
+
+        mock_from_config.assert_called_once_with(storage=self.storage)
+        self.assertIsInstance(retriever, RAGRetriever)
+
+    def test_llm_client_uses_storage_when_loading_default_config(self):
+        with patch(
+            "ai_actuarial.chatbot.llm.ChatbotConfig.from_config",
+            return_value=ChatbotConfig(api_key="test-key", _apply_env_defaults=False),
+        ) as mock_from_config, patch(
+            "ai_actuarial.chatbot.llm.openai.OpenAI"
+        ):
+            client = LLMClient(config=None, storage=self.storage)
+
+        mock_from_config.assert_called_once_with(storage=self.storage)
+        self.assertIsInstance(client, LLMClient)
 
 
 if __name__ == "__main__":

--- a/tests/test_chatbot_core.py
+++ b/tests/test_chatbot_core.py
@@ -88,6 +88,38 @@ class TestChatbotConfig(unittest.TestCase):
         self.assertEqual(config.max_tokens, 500)
         self.assertEqual(config.top_k, 3)
         self.assertEqual(config.similarity_threshold, 0.6)
+
+    def test_from_env_uses_provider_specific_api_key(self):
+        """Provider-specific chatbot env config should not require OpenAI."""
+        os.environ["CHATBOT_LLM_PROVIDER"] = "deepseek"
+        os.environ["DEEPSEEK_API_KEY"] = "deepseek-key-123"
+        os.environ["CHATBOT_MODEL"] = "deepseek-chat"
+
+        config = ChatbotConfig.from_env()
+
+        self.assertEqual(config.llm_provider, "deepseek")
+        self.assertEqual(config.api_key, "deepseek-key-123")
+        self.assertEqual(config.model, "deepseek-chat")
+
+    def test_from_yaml_reads_chatbot_provider(self):
+        """sites.yaml chatbot.provider should be honored."""
+        yaml_config = {
+            "ai_config": {
+                "chatbot": {
+                    "provider": "deepseek",
+                    "model": "deepseek-chat",
+                    "temperature": 0.5,
+                }
+            }
+        }
+        os.environ["DEEPSEEK_API_KEY"] = "deepseek-key-456"
+
+        config = ChatbotConfig.from_yaml(yaml_config)
+
+        self.assertEqual(config.llm_provider, "deepseek")
+        self.assertEqual(config.api_key, "deepseek-key-456")
+        self.assertEqual(config.model, "deepseek-chat")
+        self.assertEqual(config.temperature, 0.5)
     
     def test_validation_success(self):
         """Test successful configuration validation."""
@@ -102,8 +134,21 @@ class TestChatbotConfig(unittest.TestCase):
         
         with self.assertRaises(ValueError) as ctx:
             config.validate()
-        
+
         self.assertIn("API key is required", str(ctx.exception))
+
+    def test_validation_missing_provider_specific_api_key(self):
+        """Validation error should mention the selected provider key name."""
+        config = ChatbotConfig(
+            llm_provider="deepseek",
+            api_key=None,
+            _apply_env_defaults=False,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            config.validate()
+
+        self.assertIn("DEEPSEEK_API_KEY", str(ctx.exception))
     
     def test_validation_invalid_temperature(self):
         """Test validation fails with invalid temperature."""

--- a/tests/test_chatbot_core.py
+++ b/tests/test_chatbot_core.py
@@ -102,6 +102,7 @@ class TestChatbotConfig(unittest.TestCase):
         self.assertEqual(config.llm_provider, "deepseek")
         self.assertEqual(config.api_key, "deepseek-key-123")
         self.assertEqual(config.model, "deepseek-chat")
+        self.assertEqual(config.base_url, "https://api.deepseek.com/v1")
 
     def test_from_env_local_provider_does_not_require_env_mapping(self):
         """Local provider should not crash even though it has no API key env mapping."""

--- a/tests/test_chatbot_integration.py
+++ b/tests/test_chatbot_integration.py
@@ -339,6 +339,25 @@ class TestChatbotIntegration(unittest.TestCase):
         
         # Verify API was called
         mock_client.chat.completions.create.assert_called_once()
+
+    @patch('openai.OpenAI')
+    def test_llm_client_uses_provider_base_url(self, mock_openai_class):
+        """OpenAI-compatible providers should initialize with their own base URL."""
+        config = ChatbotConfig(
+            llm_provider="deepseek",
+            model="deepseek-chat",
+            api_key="deepseek-key",
+            base_url="https://api.deepseek.com/v1",
+            _apply_env_defaults=False,
+        )
+
+        LLMClient(config)
+
+        mock_openai_class.assert_called_once_with(
+            api_key="deepseek-key",
+            base_url="https://api.deepseek.com/v1",
+            timeout=60.0,
+        )
     
     @patch('openai.OpenAI')
     def test_llm_generation_retry_on_rate_limit(self, mock_openai_class):

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -158,6 +159,37 @@ class TestMarkdownStorage(unittest.TestCase):
             
             markdown_data = self.storage.get_file_markdown(self.test_url)
             self.assertEqual(markdown_data['markdown_source'], source)
+
+
+class TestMarkdownConversionRuntime(unittest.TestCase):
+    def test_convert_file_to_markdown_passes_runtime_kwargs(self):
+        from doc_to_md.registry import ConversionOutput
+        from ai_actuarial.web.app import convert_file_to_markdown
+
+        with patch("doc_to_md.registry.convert_path") as mock_convert_path:
+            mock_convert_path.return_value = ConversionOutput(
+                markdown="# Converted",
+                engine="deepseekocr",
+                model="deepseek-ai/DeepSeek-OCR",
+            )
+
+            result = convert_file_to_markdown(
+                "C:/tmp/test.pdf",
+                "deepseekocr",
+                "application/pdf",
+                model="deepseek-ai/DeepSeek-OCR",
+                api_key="runtime-key",
+                base_url="https://custom.siliconflow.test/v1",
+            )
+
+        mock_convert_path.assert_called_once()
+        _, kwargs = mock_convert_path.call_args
+        self.assertEqual(kwargs["engine"], "deepseekocr")
+        self.assertEqual(kwargs["model"], "deepseek-ai/DeepSeek-OCR")
+        self.assertEqual(kwargs["api_key"], "runtime-key")
+        self.assertEqual(kwargs["base_url"], "https://custom.siliconflow.test/v1")
+        self.assertEqual(result["engine"], "deepseekocr")
+        self.assertEqual(result["model"], "deepseek-ai/DeepSeek-OCR")
 
 
 class TestMarkdownAPI(unittest.TestCase):

--- a/tests/test_rag_runtime.py
+++ b/tests/test_rag_runtime.py
@@ -64,6 +64,16 @@ class TestRagRuntime(unittest.TestCase):
         self.assertEqual(config.api_base_url, "https://custom.siliconflow.test/v1")
         self.assertEqual(config.openai_api_key, "db-siliconflow-key")
 
+    def test_rag_config_from_env_uses_provider_default_base_url(self):
+        os.environ["RAG_EMBEDDING_PROVIDER"] = "siliconflow"
+        os.environ["SILICONFLOW_API_KEY"] = "env-siliconflow-key"
+
+        config = RAGConfig.from_env()
+
+        self.assertEqual(config.embedding_provider, "siliconflow")
+        self.assertEqual(config.api_key, "env-siliconflow-key")
+        self.assertEqual(config.api_base_url, "https://api.siliconflow.cn/v1")
+
     @patch("ai_actuarial.rag.embeddings.OpenAI")
     def test_embedding_generator_uses_openai_compatible_runtime(self, mock_openai):
         config = RAGConfig(
@@ -82,6 +92,27 @@ class TestRagRuntime(unittest.TestCase):
             timeout=45,
         )
         self.assertIsNotNone(generator.openai_client)
+
+    def test_embedding_generator_normalizes_local_provider(self):
+        config = RAGConfig(
+            embedding_provider=" Local ",
+            embedding_model="local-model",
+            embedding_cache_enabled=False,
+        )
+
+        generator = EmbeddingGenerator(config)
+
+        self.assertEqual(generator.provider, "local")
+        self.assertIsNone(generator.openai_client)
+        with patch.object(
+            EmbeddingGenerator,
+            "_generate_local_embeddings",
+            return_value=[[0.1, 0.2, 0.3]],
+        ) as mock_local:
+            result = generator.generate_embeddings(["hello"])
+
+        mock_local.assert_called_once_with(["hello"])
+        self.assertEqual(result, [[0.1, 0.2, 0.3]])
 
 
 if __name__ == "__main__":

--- a/tests/test_rag_runtime.py
+++ b/tests/test_rag_runtime.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tests for RAG runtime configuration unification."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from ai_actuarial.rag.config import RAGConfig
+from ai_actuarial.rag.embeddings import EmbeddingGenerator
+from ai_actuarial.services.token_encryption import TokenEncryption
+from ai_actuarial.storage import Storage
+
+
+class TestRagRuntime(unittest.TestCase):
+    def setUp(self):
+        self.original_env = dict(os.environ)
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+        self.storage = Storage(self.db_path)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+        self.storage.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_rag_config_from_yaml_prefers_db_provider_credentials(self):
+        yaml_config = {
+            "ai_config": {
+                "embeddings": {
+                    "provider": "siliconflow",
+                    "model": "BAAI/bge-m3",
+                    "batch_size": 16,
+                    "cache_enabled": False,
+                    "similarity_threshold": 0.55,
+                }
+            },
+            "rag_config": {
+                "max_chunk_tokens": 900,
+                "min_chunk_tokens": 120,
+                "index_type": "HNSW",
+            },
+        }
+        encrypted = TokenEncryption().encrypt("db-siliconflow-key")
+        self.storage.upsert_llm_provider(
+            provider="siliconflow",
+            api_key_encrypted=encrypted,
+            base_url="https://custom.siliconflow.test/v1",
+        )
+
+        config = RAGConfig.from_yaml(yaml_config, storage=self.storage)
+
+        self.assertEqual(config.embedding_provider, "siliconflow")
+        self.assertEqual(config.embedding_model, "BAAI/bge-m3")
+        self.assertEqual(config.embedding_batch_size, 16)
+        self.assertFalse(config.embedding_cache_enabled)
+        self.assertEqual(config.similarity_threshold, 0.55)
+        self.assertEqual(config.index_type, "HNSW")
+        self.assertEqual(config.api_key, "db-siliconflow-key")
+        self.assertEqual(config.api_base_url, "https://custom.siliconflow.test/v1")
+        self.assertEqual(config.openai_api_key, "db-siliconflow-key")
+
+    @patch("ai_actuarial.rag.embeddings.OpenAI")
+    def test_embedding_generator_uses_openai_compatible_runtime(self, mock_openai):
+        config = RAGConfig(
+            embedding_provider="siliconflow",
+            embedding_model="BAAI/bge-m3",
+            api_key="runtime-key",
+            api_base_url="https://custom.siliconflow.test/v1",
+            openai_timeout=45,
+        )
+
+        generator = EmbeddingGenerator(config)
+
+        mock_openai.assert_called_once_with(
+            api_key="runtime-key",
+            base_url="https://custom.siliconflow.test/v1",
+            timeout=45,
+        )
+        self.assertIsNotNone(generator.openai_client)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -118,6 +118,14 @@ class TestYAMLConfigLoader:
             assert "defaults" in config
             assert "ai_config" in config
             assert config["defaults"]["user_agent"] == "test-agent"
+
+    def test_config_path_environment_override(self):
+        """CONFIG_PATH should be respected by the YAML loader."""
+        with patch.dict(os.environ, {"CONFIG_PATH": str(self.config_path)}, clear=False):
+            invalidate_config_cache()
+            config = load_yaml_config()
+
+        assert config["defaults"]["user_agent"] == "test-agent"
     
     def test_load_ai_config_from_yaml(self):
         """Test loading AI configuration from YAML."""
@@ -213,6 +221,7 @@ class TestYAMLConfigLoader:
         """Test extracting AI config from environment variables."""
         with patch.dict(os.environ, {
             'OPENAI_DEFAULT_MODEL': 'test-model',
+            'CHATBOT_LLM_PROVIDER': 'deepseek',
             'CHATBOT_MODEL': 'test-chatbot',
             'CHATBOT_TEMPERATURE': '0.9',
             'CHATBOT_MAX_TOKENS': '2000',
@@ -220,6 +229,7 @@ class TestYAMLConfigLoader:
             ai_config = _extract_ai_config_from_env()
             
             assert ai_config["catalog"]["model"] == "test-model"
+            assert ai_config["chatbot"]["provider"] == "deepseek"
             assert ai_config["chatbot"]["model"] == "test-chatbot"
             assert ai_config["chatbot"]["temperature"] == 0.9
             assert ai_config["chatbot"]["max_tokens"] == 2000


### PR DESCRIPTION
## Summary
- unify AI runtime/provider resolution across chatbot, catalog, embeddings, and OCR
- move RAG embeddings and markdown OCR conversion onto the shared runtime with provider-aware credentials
- add regression coverage and documentation for the second runtime unification batch

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest -q -o addopts=
- npm run build