### PR TITLE
fix: audit react fastapi gaps and task stop handling

### DIFF
--- a/ai_actuarial/catalog_incremental.py
+++ b/ai_actuarial/catalog_incremental.py
@@ -725,13 +725,18 @@ def run_incremental_catalog(
             seen_urls.add(r["url"])
         
         stop_requested = False
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        shutdown_without_wait = False
+        executor = ThreadPoolExecutor(max_workers=max_workers)
+        try:
             future_to_url = {}
             for r in row_dicts:
                 if stop_check and stop_check():
                     logger.info("Catalog stop requested before submitting more items")
                     stats["stopped"] = True
                     stop_requested = True
+                    if future_to_url:
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        shutdown_without_wait = True
                     break
                 future = executor.submit(
                     _process_single_row,
@@ -757,9 +762,8 @@ def run_incremental_catalog(
                     logger.info("Catalog stop requested while workers are running")
                     stats["stopped"] = True
                     stop_requested = True
-                    for pending in future_to_url:
-                        if not pending.done():
-                            pending.cancel()
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    shutdown_without_wait = True
                     break
                 try:
                     r_data, item, status, suggested_title = future.result()
@@ -851,14 +855,17 @@ def run_incremental_catalog(
                     stats["errors"] += 1
                     if len(stats["error_samples"]) < 20:
                         stats["error_samples"].append(str(e))
-        if stop_requested:
-            break
+        finally:
+            if not shutdown_without_wait:
+                executor.shutdown(wait=True)
         
         # Append outputs incrementally
         if batch_items:
             _append_jsonl(out_jsonl, batch_jsonl)
             write_catalog_md(out_md, batch_items, append=out_md.exists())
             stats["written"] += len(batch_items)
+        if stop_requested:
+            break
             
         logger.info(
             "Batch done: scanned=%d processed=%d written=%d skipped_ai=%d errors=%d missing=%d",
@@ -1024,13 +1031,18 @@ def run_catalog_for_urls(
     batch_jsonl: list[dict] = []
 
     stop_requested = False
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    shutdown_without_wait = False
+    executor = ThreadPoolExecutor(max_workers=max_workers)
+    try:
         future_to_url = {}
         for r in candidates:
             if stop_check and stop_check():
                 logger.info("Catalog stop requested before submitting more explicit file URLs")
                 stats["stopped"] = True
                 stop_requested = True
+                if future_to_url:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    shutdown_without_wait = True
                 break
             future = executor.submit(
                 _process_single_row,
@@ -1052,9 +1064,8 @@ def run_catalog_for_urls(
                 logger.info("Catalog stop requested while explicit file URL workers are running")
                 stats["stopped"] = True
                 stop_requested = True
-                for pending in future_to_url:
-                    if not pending.done():
-                        pending.cancel()
+                executor.shutdown(wait=False, cancel_futures=True)
+                shutdown_without_wait = True
                 break
             url = future_to_url[future]
             try:
@@ -1114,6 +1125,9 @@ def run_catalog_for_urls(
                 stats["errors"] += 1
                 if len(stats["error_samples"]) < 20:
                     stats["error_samples"].append(str(e))
+    finally:
+        if not shutdown_without_wait:
+            executor.shutdown(wait=True)
     if stop_requested:
         logger.info("Catalog processing stopped for explicit file URL run")
 

--- a/ai_actuarial/catalog_incremental.py
+++ b/ai_actuarial/catalog_incremental.py
@@ -589,6 +589,7 @@ def run_incremental_catalog(
     catalog_system_prompt: str | None = None,
     output_language: str = "auto",
     progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    stop_check: Optional[Callable[[], bool]] = None,
 ) -> dict:
     """Run incremental catalog processing.
     
@@ -651,6 +652,7 @@ def run_incremental_catalog(
         "errors": 0,
         "missing_files": 0,
         "error_samples": [],
+        "stopped": False,
     }
     
     seen_urls = set()
@@ -674,6 +676,11 @@ def run_incremental_catalog(
 
     remaining_offset = max(0, int(candidate_offset or 0))
     while True:
+        if stop_check and stop_check():
+            logger.info("Catalog stop requested before next batch")
+            stats["stopped"] = True
+            break
+
         # Check global limit
         if limit > 0 and stats["processed"] >= limit:
             logger.info(f"Reached limit of {limit} items")
@@ -717,9 +724,16 @@ def run_incremental_catalog(
         for r in row_dicts:
             seen_urls.add(r["url"])
         
+        stop_requested = False
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_url = {
-                executor.submit(
+            future_to_url = {}
+            for r in row_dicts:
+                if stop_check and stop_check():
+                    logger.info("Catalog stop requested before submitting more items")
+                    stats["stopped"] = True
+                    stop_requested = True
+                    break
+                future = executor.submit(
                     _process_single_row,
                     r,
                     ai_only,
@@ -732,14 +746,21 @@ def run_incremental_catalog(
                     input_source=input_source,
                     catalog_system_prompt=catalog_system_prompt,
                     output_language=output_language,
-                ): r["url"]
-                for r in row_dicts
-            }
+                )
+                future_to_url[future] = r["url"]
             
             # We will batch writes at the end of the batch processing to keep DB logic simple
             # Or writing as they complete? Batch write is safer for transaction.
             
             for future in as_completed(future_to_url):
+                if stop_check and stop_check():
+                    logger.info("Catalog stop requested while workers are running")
+                    stats["stopped"] = True
+                    stop_requested = True
+                    for pending in future_to_url:
+                        if not pending.done():
+                            pending.cancel()
+                    break
                 try:
                     r_data, item, status, suggested_title = future.result()
                     processed_at = datetime.now(timezone.utc).isoformat()
@@ -830,6 +851,8 @@ def run_incremental_catalog(
                     stats["errors"] += 1
                     if len(stats["error_samples"]) < 20:
                         stats["error_samples"].append(str(e))
+        if stop_requested:
+            break
         
         # Append outputs incrementally
         if batch_items:
@@ -851,6 +874,16 @@ def run_incremental_catalog(
     )
     if progress_callback:
         completed = stats["processed"] + stats["skipped_ai"] + stats["errors"]
+        if stats["stopped"]:
+            progress_callback(
+                completed,
+                max(total_candidates, completed, 1),
+                (
+                    f"Catalog stopped: processed={stats['processed']} "
+                    f"skipped={stats['skipped_ai']} errors={stats['errors']}"
+                ),
+            )
+            return stats
         progress_callback(
             max(total_candidates, completed, 1),
             max(total_candidates, completed, 1),
@@ -877,6 +910,7 @@ def run_catalog_for_urls(
     catalog_system_prompt: str | None = None,
     output_language: str = "auto",
     progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    stop_check: Optional[Callable[[], bool]] = None,
 ) -> dict:
     """Catalog a specific list of file URLs (used by File Details actions)."""
     conn = _connect(db_path)
@@ -918,6 +952,7 @@ def run_catalog_for_urls(
         "errors": 0,
         "missing_files": 0,
         "error_samples": [],
+        "stopped": False,
     }
 
     urls = [u for u in (file_urls or []) if isinstance(u, str) and u.strip()]
@@ -988,9 +1023,16 @@ def run_catalog_for_urls(
     batch_items: list[CatalogItem] = []
     batch_jsonl: list[dict] = []
 
+    stop_requested = False
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_url = {
-            executor.submit(
+        future_to_url = {}
+        for r in candidates:
+            if stop_check and stop_check():
+                logger.info("Catalog stop requested before submitting more explicit file URLs")
+                stats["stopped"] = True
+                stop_requested = True
+                break
+            future = executor.submit(
                 _process_single_row,
                 r,
                 ai_only,
@@ -1003,10 +1045,17 @@ def run_catalog_for_urls(
                 input_source=input_source,
                 catalog_system_prompt=catalog_system_prompt,
                 output_language=output_language,
-            ): r["url"]
-            for r in candidates
-        }
+            )
+            future_to_url[future] = r["url"]
         for future in as_completed(future_to_url):
+            if stop_check and stop_check():
+                logger.info("Catalog stop requested while explicit file URL workers are running")
+                stats["stopped"] = True
+                stop_requested = True
+                for pending in future_to_url:
+                    if not pending.done():
+                        pending.cancel()
+                break
             url = future_to_url[future]
             try:
                 r_data, item, status, suggested_title = future.result()
@@ -1065,6 +1114,8 @@ def run_catalog_for_urls(
                 stats["errors"] += 1
                 if len(stats["error_samples"]) < 20:
                     stats["error_samples"].append(str(e))
+    if stop_requested:
+        logger.info("Catalog processing stopped for explicit file URL run")
 
     if batch_items:
         _append_jsonl(out_jsonl, batch_jsonl)
@@ -1074,6 +1125,16 @@ def run_catalog_for_urls(
     conn.close()
     if progress_callback:
         completed = stats["processed"] + stats["skipped_ai"] + stats["errors"]
+        if stats["stopped"]:
+            progress_callback(
+                completed,
+                max(len(candidates), completed, 1),
+                (
+                    f"Catalog stopped: processed={stats['processed']} "
+                    f"skipped={stats['skipped_ai']} errors={stats['errors']}"
+                ),
+            )
+            return stats
         progress_callback(
             max(len(candidates), completed, 1),
             max(len(candidates), completed, 1),

--- a/ai_actuarial/rag/indexing.py
+++ b/ai_actuarial/rag/indexing.py
@@ -41,7 +41,8 @@ class IndexingPipeline:
     def __init__(
         self,
         kb_manager: KnowledgeBaseManager,
-        progress_callback: Optional[Callable[[str, int, int], None]] = None
+        progress_callback: Optional[Callable[[str, int, int], None]] = None,
+        stop_check: Optional[Callable[[], bool]] = None,
     ):
         """
         Initialize indexing pipeline.
@@ -55,6 +56,7 @@ class IndexingPipeline:
         self.storage = kb_manager.storage
         self.config = kb_manager.config
         self.progress_callback = progress_callback
+        self.stop_check = stop_check
         
         # Components
         self.chunker = kb_manager.chunker
@@ -108,10 +110,19 @@ class IndexingPipeline:
             'skipped_files': 0,
             'error_files': 0,
             'total_chunks': 0,
-            'errors': []
+            'errors': [],
+            'stopped': False,
         }
         
         for i, file_url in enumerate(file_urls):
+            if self.stop_check and self.stop_check():
+                stats['stopped'] = True
+                self._log_progress(
+                    f"Stop requested for KB '{kb.name}'",
+                    i,
+                    len(file_urls),
+                )
+                break
             try:
                 self._log_progress(f"Indexing file {i+1}/{len(file_urls)}", i+1, len(file_urls))
                 
@@ -152,8 +163,18 @@ class IndexingPipeline:
         # Update KB statistics
         self._update_kb_stats(kb_id)
         
-        self._log_progress(f"Indexing complete: {stats['indexed_files']} files indexed", 
-                          len(file_urls), len(file_urls))
+        if stats['stopped']:
+            self._log_progress(
+                f"Indexing stopped: {stats['indexed_files']} files indexed",
+                stats['indexed_files'] + stats['skipped_files'] + stats['error_files'],
+                len(file_urls),
+            )
+        else:
+            self._log_progress(
+                f"Indexing complete: {stats['indexed_files']} files indexed",
+                len(file_urls),
+                len(file_urls),
+            )
         
         return stats
     

--- a/ai_actuarial/rag/indexing.py
+++ b/ai_actuarial/rag/indexing.py
@@ -82,8 +82,27 @@ class IndexingPipeline:
         kb = self.kb_manager.get_kb(kb_id)
         if not kb:
             raise RAGException(f"Knowledge base '{kb_id}' not found")
+
+        stats = {
+            'total_files': len(file_urls),
+            'indexed_files': 0,
+            'skipped_files': 0,
+            'error_files': 0,
+            'total_chunks': 0,
+            'errors': [],
+            'stopped': False,
+        }
         
         self._log_progress(f"Starting indexing for KB '{kb.name}'", 0, len(file_urls))
+
+        if self.stop_check and self.stop_check():
+            stats['stopped'] = True
+            self._log_progress(
+                f"Stop requested for KB '{kb.name}' before indexing started",
+                0,
+                len(file_urls),
+            )
+            return stats
         
         # Load or create vector store
         kb_dir = Path(self.config.data_dir) / kb_id
@@ -95,6 +114,14 @@ class IndexingPipeline:
         # If force_reindex is requested, ensure any existing index file is removed
         # so that the VectorStore starts from a clean state instead of appending.
         if force_reindex and index_path.exists():
+            if self.stop_check and self.stop_check():
+                stats['stopped'] = True
+                self._log_progress(
+                    f"Stop requested for KB '{kb.name}' before resetting index",
+                    0,
+                    len(file_urls),
+                )
+                return stats
             index_path.unlink()
         
         vector_store = VectorStore(
@@ -102,17 +129,6 @@ class IndexingPipeline:
             config=self.config,
             index_path=str(index_path)
         )
-        
-        # Process files
-        stats = {
-            'total_files': len(file_urls),
-            'indexed_files': 0,
-            'skipped_files': 0,
-            'error_files': 0,
-            'total_chunks': 0,
-            'errors': [],
-            'stopped': False,
-        }
         
         for i, file_url in enumerate(file_urls):
             if self.stop_check and self.stop_check():
@@ -151,6 +167,14 @@ class IndexingPipeline:
                     'file_url': file_url,
                     'error': str(e)
                 })
+
+        if (
+            stats['stopped']
+            and stats['indexed_files'] == 0
+            and stats['skipped_files'] == 0
+            and stats['error_files'] == 0
+        ):
+            return stats
         
         # Save vector store
         try:

--- a/ai_actuarial/storage.py
+++ b/ai_actuarial/storage.py
@@ -55,6 +55,7 @@ class Storage:
         self.db_path = db_path
         Path(os.path.dirname(db_path)).mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(db_path)
+        self._conn.execute("PRAGMA foreign_keys=ON;")
         self._conn.execute("PRAGMA journal_mode=WAL;")
         self._tx_depth = 0
         self._init_schema()

--- a/ai_actuarial/storage.py
+++ b/ai_actuarial/storage.py
@@ -1932,6 +1932,46 @@ class Storage:
             "updated_at": row[10],
         }
 
+    def delete_chunk_profile(self, profile_id: str) -> dict[str, Any] | None:
+        existing = self.get_chunk_profile(profile_id)
+        if not existing:
+            return None
+
+        chunk_set_count = int(
+            self._conn.execute(
+                "SELECT COUNT(*) FROM file_chunk_sets WHERE profile_id = ?",
+                (profile_id,),
+            ).fetchone()[0]
+        )
+        binding_count = int(
+            self._conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM kb_chunk_bindings
+                WHERE chunk_set_id IN (
+                    SELECT chunk_set_id
+                    FROM file_chunk_sets
+                    WHERE profile_id = ?
+                )
+                """,
+                (profile_id,),
+            ).fetchone()[0]
+        )
+
+        self._conn.execute(
+            "DELETE FROM chunk_profiles WHERE profile_id = ?",
+            (profile_id,),
+        )
+        self._maybe_commit()
+
+        return {
+            "profile_id": profile_id,
+            "name": existing["name"],
+            "deleted": True,
+            "deleted_chunk_sets": chunk_set_count,
+            "deleted_bindings": binding_count,
+        }
+
     def get_or_create_file_chunk_set(
         self,
         *,

--- a/ai_actuarial/web/app.py
+++ b/ai_actuarial/web/app.py
@@ -3918,6 +3918,7 @@ sites:
                         catalog_system_prompt=_catalog_system_prompt,
                         output_language=output_language,
                         progress_callback=progress_callback,
+                        stop_check=stop_check,
                     )
                 else:
                     stats = run_incremental_catalog(
@@ -3936,6 +3937,7 @@ sites:
                         catalog_system_prompt=_catalog_system_prompt,
                         output_language=output_language,
                         progress_callback=progress_callback,
+                        stop_check=stop_check,
                     )
                 
                 # Mock result for catalog
@@ -3952,7 +3954,14 @@ sites:
                         self.items_skipped = self.catalog_skipped
                 
                 result = CatalogResult(True)
-                progress_callback(100, 100, f"Cataloging complete. Processed {stats.get('processed')} items.")
+                if stats.get("stopped"):
+                    progress_callback(
+                        stats.get("processed", 0) + stats.get("skipped_ai", 0) + stats.get("errors", 0),
+                        max(stats.get("scanned", 0), 1),
+                        f"Cataloging stopped. Processed {stats.get('processed')} items.",
+                    )
+                else:
+                    progress_callback(100, 100, f"Cataloging complete. Processed {stats.get('processed')} items.")
 
             elif collection_type == "markdown_conversion":
                 # Markdown conversion task
@@ -4540,20 +4549,31 @@ sites:
                     if message:
                         _append_task_log(task_id, "INFO", message)
 
-                pipeline = IndexingPipeline(kb_manager, progress_callback=rag_progress)
+                pipeline = IndexingPipeline(
+                    kb_manager,
+                    progress_callback=rag_progress,
+                    stop_check=stop_check,
+                )
                 stats = pipeline.index_files(kb_id=kb_id, file_urls=file_urls, force_reindex=force_reindex)
-                try:
-                    index_path = str(Path(kb_manager.config.data_dir) / kb_id / "index.faiss")
-                    storage.create_kb_index_version(
-                        kb_id=kb_id,
-                        embedding_model=kb.embedding_model,
-                        index_type=kb.index_type,
-                        chunk_count=int(stats.get("total_chunks", 0) or 0),
-                        status="ready",
-                        artifact_path=index_path,
+                if stats.get("stopped"):
+                    _append_task_log(
+                        task_id,
+                        "WARNING",
+                        f"{task_label} stopped before completion; skipped recording KB index version",
                     )
-                except Exception as exc:  # noqa: BLE001
-                    _append_task_log(task_id, "WARNING", f"Failed recording KB index version: {exc}")
+                else:
+                    try:
+                        index_path = str(Path(kb_manager.config.data_dir) / kb_id / "index.faiss")
+                        storage.create_kb_index_version(
+                            kb_id=kb_id,
+                            embedding_model=kb.embedding_model,
+                            index_type=kb.index_type,
+                            chunk_count=int(stats.get("total_chunks", 0) or 0),
+                            status="ready",
+                            artifact_path=index_path,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        _append_task_log(task_id, "WARNING", f"Failed recording KB index version: {exc}")
 
                 class RagIndexResult:
                     def __init__(self, payload: dict[str, Any]):
@@ -4879,6 +4899,7 @@ sites:
         with _task_lock:
             if task_id in _active_tasks:
                 _active_tasks[task_id]["stop_requested"] = True
+                _active_tasks[task_id]["current_activity"] = "Stop requested"
                 logger.info(f"Stop requested for task {task_id}")
                 return jsonify({"success": True, "message": "Stop signal sent"})
             return jsonify({"error": "Task not found or not active"}), 404

--- a/ai_actuarial/web/rag_routes.py
+++ b/ai_actuarial/web/rag_routes.py
@@ -181,6 +181,27 @@ def register_rag_routes(
             logger.exception("Error creating chunk profile")
             return _api_error("Internal server error", status_code=500, detail=str(exc))
 
+    @app.route("/api/chunk/profiles/<profile_id>", methods=["DELETE"])
+    @require_permissions("config.write")
+    def api_chunk_profiles_delete(profile_id: str):
+        if (r := _check_config_write_auth()) is not None:
+            return r
+        try:
+            normalized_profile_id = _norm(profile_id)
+            if not normalized_profile_id:
+                return _api_error("profile_id is required", status_code=400)
+
+            def _run(storage):
+                deleted = storage.delete_chunk_profile(normalized_profile_id)
+                if not deleted:
+                    return _api_error("chunk profile not found", status_code=404)
+                return _api_success(deleted)
+
+            return _with_storage(_run)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error deleting chunk profile %s", profile_id)
+            return _api_error("Internal server error", status_code=500, detail=str(exc))
+
     @app.route("/api/files/<path:file_url>/chunk-sets", methods=["GET"])
     @require_permissions("files.read")
     def api_file_chunk_sets(file_url: str):

--- a/docs/规划文档-2026-03-11-react-fastapi-gap-audit-phase0.md
+++ b/docs/规划文档-2026-03-11-react-fastapi-gap-audit-phase0.md
@@ -1,0 +1,170 @@
+# React / FastAPI Gap Audit Phase 0
+
+Date: 2026-03-11
+Branch: `review/fastapi-ui-gap-20260311`
+
+## Scope
+
+This audit focused on four questions:
+
+1. Why active tasks appeared impossible to stop.
+2. Whether current React buttons have valid code paths.
+3. Which backend capabilities still do not line up cleanly with the frontend.
+4. How much FastAPI migration work remains after the recent read-endpoint work.
+
+## Current Verification
+
+- `npm run build`: passed
+- targeted backend regression: passed
+- full backend regression: `435 passed`
+- React button/test-id audit:
+  - `button/tab/toggle` controls found across page components: `101`
+- React API coverage audit:
+  - native FastAPI endpoints used by React: `5`
+  - legacy Flask endpoints used by React: `70`
+  - missing React API paths after this audit: `0`
+
+## Findings
+
+### 1. Task stop support was inconsistent
+
+Before this audit, stop requests were wired through `_active_tasks[task_id]["stop_requested"]`,
+but only some task types actually checked that flag while running.
+
+Observed/confirmed behavior:
+
+- already stop-aware:
+  - crawler-backed tasks (`url`, `search`, `scheduled`, `quick_check`)
+  - `markdown_conversion`
+  - `chunk_generation`
+- missing stop propagation before this audit:
+  - `catalog`
+  - `rag_indexing`
+  - `kb_index_build`
+- still not stop-aware after this audit:
+  - local `file` import
+
+### 2. One frontend button was genuinely broken
+
+The Knowledge page deletes chunk profiles via:
+
+- `DELETE /api/chunk/profiles/{profile_id}`
+
+But the backend previously exposed only:
+
+- `GET /api/chunk/profiles`
+- `POST /api/chunk/profiles`
+
+That meant the chunk-profile delete button had no matching backend route.
+
+### 3. FastAPI migration is still in an early phase
+
+React is no longer blocked by missing API paths, but almost all non-read behavior still runs
+through legacy Flask.
+
+Native FastAPI endpoints currently cover only:
+
+- `/api/stats`
+- `/api/sources`
+- `/api/categories`
+- `/api/files`
+- `/api/files/detail`
+- `/api/files/{file_url}/markdown`
+- plus gateway/meta endpoints such as `/api/health` and `/api/migration/status`
+
+High-click pages still mostly depend on Flask:
+
+- `Tasks`
+- `Settings`
+- `Knowledge`
+- `KBDetail`
+- `Chat`
+- `Logs`
+- `Users`
+- `Profile`
+- write actions in `FileDetail`
+
+## Changes Made In This Audit
+
+### Task stop improvements
+
+- catalog task runners now accept and honor `stop_check`
+- RAG indexing pipeline now accepts and honors `stop_check`
+- stop requests now update active-task activity text to `Stop requested`
+- stopped RAG index runs no longer record a misleading ready index version
+
+### Button-path fix
+
+- added backend support for `DELETE /api/chunk/profiles/{profile_id}`
+- added storage-layer deletion support for chunk profiles
+- added regression coverage for chunk-profile deletion
+
+### Regression coverage
+
+- added tests for chunk-profile delete API
+- added tests covering catalog immediate-stop handling
+- added tests covering RAG indexing stop behavior
+
+## Remaining Work Plan
+
+### Phase 1: finish task-stop semantics
+
+- add stop support to local file import tasks
+- add explicit frontend `stopping` UX state instead of only changing activity text
+- add API-level tests for `/api/tasks/stop/{id}` across representative task types
+
+### Phase 2: migrate task center endpoints to FastAPI
+
+Priority:
+- `/api/tasks/active`
+- `/api/tasks/history`
+- `/api/tasks/log/{task_id}`
+- `/api/tasks/stop/{task_id}`
+- `/api/collections/run`
+- task stats endpoints used by `Tasks.tsx`
+
+Reason:
+- highest click density
+- directly related to the user-visible “task cannot stop” problem
+- removes reliance on Flask for the operational center of the app
+
+### Phase 3: migrate RAG management endpoints
+
+Priority:
+- `/api/chunk/profiles`
+- `/api/files/{file_url}/chunk-sets`
+- `/api/files/{file_url}/chunk-sets/generate`
+- `/api/rag/knowledge-bases*`
+- `/api/chunk-sets/cleanup`
+
+Reason:
+- powers `Knowledge`, `KBDetail`, and part of `FileDetail`
+- currently one of the heaviest frontend/backend interaction areas
+
+### Phase 4: migrate settings/config write APIs
+
+Priority:
+- `/api/config/llm-providers*`
+- `/api/config/ai-models`
+- `/api/config/backend-settings`
+- `/api/config/categories`
+- `/api/config/search-engines`
+- `/api/auth/tokens*`
+
+Reason:
+- central admin workflows still sit on Flask
+- this is also the dependency root for task-option forms
+
+### Phase 5: migrate chat and admin surfaces
+
+- `/api/chat/*`
+- `/api/admin/users*`
+- `/api/user/*`
+- `/api/logs/global`
+
+## Exit Criteria For The Next Round
+
+1. React task-center flows no longer rely on Flask routes.
+2. Stop/cancel behavior is verified for all long-running task classes.
+3. Knowledge/chunk-profile/file-detail write operations have matching FastAPI-native APIs.
+4. React-to-backend API audit shows the legacy count materially reduced from `70`.

--- a/tests/test_global_chunk_phasea.py
+++ b/tests/test_global_chunk_phasea.py
@@ -210,6 +210,14 @@ class TestGlobalChunkPhaseA(unittest.TestCase):
         self.assertEqual(profile_resp.status_code, 201)
         profile_id = profile_resp.get_json()["data"]["profile_id"]
 
+        encoded_file_url = quote(self.file_url, safe="")
+        gen_resp = self.client.post(
+            f"/api/files/{encoded_file_url}/chunk-sets/generate",
+            headers=self.auth_header,
+            json={"profile_id": profile_id, "overwrite_same_profile": True},
+        )
+        self.assertIn(gen_resp.status_code, [200, 201])
+
         delete_resp = self.client.delete(
             f"/api/chunk/profiles/{profile_id}",
             headers=self.auth_header,
@@ -224,6 +232,13 @@ class TestGlobalChunkPhaseA(unittest.TestCase):
         self.assertEqual(list_resp.status_code, 200)
         profiles = list_resp.get_json()["data"]["profiles"]
         self.assertFalse(any(item["profile_id"] == profile_id for item in profiles))
+
+        chunk_sets_resp = self.client.get(
+            f"/api/files/{encoded_file_url}/chunk-sets",
+            headers=self.auth_header,
+        )
+        self.assertEqual(chunk_sets_resp.status_code, 200)
+        self.assertEqual(chunk_sets_resp.get_json()["data"]["count"], 0)
 
     def test_follow_latest_binding_auto_sync_on_new_chunk(self):
         profile_resp = self.client.post(

--- a/tests/test_global_chunk_phasea.py
+++ b/tests/test_global_chunk_phasea.py
@@ -192,6 +192,39 @@ class TestGlobalChunkPhaseA(unittest.TestCase):
         self.assertEqual(status_data["data"]["file_count"], 1)
         self.assertGreaterEqual(status_data["data"]["chunk_set_count"], 1)
 
+    def test_chunk_profile_delete_endpoint_removes_profile(self):
+        profile_resp = self.client.post(
+            "/api/chunk/profiles",
+            headers=self.auth_header,
+            json={
+                "name": "Delete Me",
+                "chunk_size": 256,
+                "chunk_overlap": 32,
+                "splitter": "semantic",
+                "tokenizer": "cl100k_base",
+                "version": "v1",
+            },
+        )
+        if profile_resp.status_code == 503:
+            self.skipTest("RAG functionality not available")
+        self.assertEqual(profile_resp.status_code, 201)
+        profile_id = profile_resp.get_json()["data"]["profile_id"]
+
+        delete_resp = self.client.delete(
+            f"/api/chunk/profiles/{profile_id}",
+            headers=self.auth_header,
+        )
+        self.assertEqual(delete_resp.status_code, 200)
+        delete_data = delete_resp.get_json()
+        self.assertTrue(delete_data["success"])
+        self.assertEqual(delete_data["data"]["profile_id"], profile_id)
+        self.assertTrue(delete_data["data"]["deleted"])
+
+        list_resp = self.client.get("/api/chunk/profiles", headers=self.auth_header)
+        self.assertEqual(list_resp.status_code, 200)
+        profiles = list_resp.get_json()["data"]["profiles"]
+        self.assertFalse(any(item["profile_id"] == profile_id for item in profiles))
+
     def test_follow_latest_binding_auto_sync_on_new_chunk(self):
         profile_resp = self.client.post(
             "/api/chunk/profiles",

--- a/tests/test_task_stop_support.py
+++ b/tests/test_task_stop_support.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from ai_actuarial.catalog_incremental import run_catalog_for_urls
+from ai_actuarial.catalog import CatalogItem
+from ai_actuarial.catalog_incremental import run_catalog_for_urls, run_incremental_catalog
 from ai_actuarial.rag.indexing import IndexingPipeline
 from ai_actuarial.storage import Storage
 
 
-def test_run_catalog_for_urls_respects_immediate_stop(tmp_path) -> None:
-    db_path = tmp_path / "catalog-stop.db"
+def _seed_catalog_files(db_path, count: int = 2) -> list[str]:
     storage = Storage(str(db_path))
-    file_urls = []
+    urls = []
     try:
-        for idx in range(2):
+        for idx in range(count):
             file_url = f"https://example.com/catalog-stop-{idx}.pdf"
-            file_urls.append(file_url)
+            urls.append(file_url)
             storage.insert_file(
                 url=file_url,
                 sha256=f"sha-{idx}",
@@ -29,6 +29,12 @@ def test_run_catalog_for_urls_respects_immediate_stop(tmp_path) -> None:
             )
     finally:
         storage.close()
+    return urls
+
+
+def test_run_catalog_for_urls_respects_immediate_stop(tmp_path) -> None:
+    db_path = tmp_path / "catalog-stop.db"
+    file_urls = _seed_catalog_files(db_path)
 
     stats = run_catalog_for_urls(
         db_path=str(db_path),
@@ -42,6 +48,44 @@ def test_run_catalog_for_urls_respects_immediate_stop(tmp_path) -> None:
     assert stats["stopped"] is True
     assert stats["processed"] == 0
     assert stats["written"] == 0
+
+
+def test_run_incremental_catalog_flushes_partial_batch_before_stop(tmp_path) -> None:
+    db_path = tmp_path / "catalog-incremental-stop.db"
+    _seed_catalog_files(db_path)
+
+    responses = iter([False, False, True, False])
+
+    def stop_check() -> bool:
+        return next(responses, False)
+
+    def fake_process(row, *args, **kwargs):
+        item = CatalogItem(
+            source_site=row["source_site"],
+            title=row["title"],
+            original_filename=row["original_filename"],
+            url=row["url"],
+            local_path=row["local_path"],
+            keywords=["ai"],
+            summary="summary",
+            category="AI",
+        )
+        return row, item, "ok", None
+
+    with patch("ai_actuarial.catalog_incremental._process_single_row", side_effect=fake_process):
+        stats = run_incremental_catalog(
+            db_path=str(db_path),
+            out_jsonl=tmp_path / "catalog.jsonl",
+            out_md=tmp_path / "catalog.md",
+            batch=10,
+            limit=10,
+            stop_check=stop_check,
+        )
+
+    assert stats["stopped"] is True
+    assert stats["processed"] == 1
+    assert stats["written"] == 1
+    assert (tmp_path / "catalog.jsonl").exists()
 
 
 def test_indexing_pipeline_stops_before_second_file(tmp_path) -> None:
@@ -86,3 +130,39 @@ def test_indexing_pipeline_stops_before_second_file(tmp_path) -> None:
     assert stats["indexed_files"] == 1
     assert processed_files == ["file-1"]
     mock_vector_store.return_value.save_index.assert_called_once()
+
+
+def test_indexing_pipeline_immediate_stop_preserves_existing_index(tmp_path) -> None:
+    kb_id = "kb-stop-test"
+    kb_dir = tmp_path / kb_id
+    kb_dir.mkdir(parents=True, exist_ok=True)
+    index_path = kb_dir / "index.faiss"
+    index_path.write_text("existing-index", encoding="utf-8")
+
+    embedding_generator = MagicMock()
+    embedding_generator.get_embedding_dimension.return_value = 3
+    kb_manager = SimpleNamespace(
+        storage=SimpleNamespace(),
+        config=SimpleNamespace(data_dir=str(tmp_path)),
+        chunker=object(),
+        embedding_generator=embedding_generator,
+        get_kb=MagicMock(
+            return_value=SimpleNamespace(
+                name="Stop Test KB",
+                embedding_model="text-embedding-3-small",
+                index_type="Flat",
+            )
+        ),
+    )
+
+    with patch("ai_actuarial.rag.indexing.VectorStore") as mock_vector_store:
+        pipeline = IndexingPipeline(kb_manager, stop_check=lambda: True)
+        stats = pipeline.index_files(
+            kb_id=kb_id,
+            file_urls=["file-1"],
+            force_reindex=True,
+        )
+
+    assert stats["stopped"] is True
+    assert index_path.read_text(encoding="utf-8") == "existing-index"
+    mock_vector_store.assert_not_called()

--- a/tests/test_task_stop_support.py
+++ b/tests/test_task_stop_support.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ai_actuarial.catalog_incremental import run_catalog_for_urls
+from ai_actuarial.rag.indexing import IndexingPipeline
+from ai_actuarial.storage import Storage
+
+
+def test_run_catalog_for_urls_respects_immediate_stop(tmp_path) -> None:
+    db_path = tmp_path / "catalog-stop.db"
+    storage = Storage(str(db_path))
+    file_urls = []
+    try:
+        for idx in range(2):
+            file_url = f"https://example.com/catalog-stop-{idx}.pdf"
+            file_urls.append(file_url)
+            storage.insert_file(
+                url=file_url,
+                sha256=f"sha-{idx}",
+                title=f"Catalog Stop {idx}",
+                source_site="example.com",
+                source_page_url="https://example.com",
+                original_filename=f"catalog-stop-{idx}.pdf",
+                local_path=f"/tmp/catalog-stop-{idx}.pdf",
+                bytes=1024,
+                content_type="application/pdf",
+            )
+    finally:
+        storage.close()
+
+    stats = run_catalog_for_urls(
+        db_path=str(db_path),
+        file_urls=file_urls,
+        out_jsonl=tmp_path / "catalog.jsonl",
+        out_md=tmp_path / "catalog.md",
+        max_workers=1,
+        stop_check=lambda: True,
+    )
+
+    assert stats["stopped"] is True
+    assert stats["processed"] == 0
+    assert stats["written"] == 0
+
+
+def test_indexing_pipeline_stops_before_second_file(tmp_path) -> None:
+    embedding_generator = MagicMock()
+    embedding_generator.get_embedding_dimension.return_value = 3
+    kb_manager = SimpleNamespace(
+        storage=SimpleNamespace(),
+        config=SimpleNamespace(data_dir=str(tmp_path)),
+        chunker=object(),
+        embedding_generator=embedding_generator,
+        get_kb=MagicMock(
+            return_value=SimpleNamespace(
+                name="Stop Test KB",
+                embedding_model="text-embedding-3-small",
+                index_type="Flat",
+            )
+        ),
+    )
+
+    processed_files: list[str] = []
+
+    def stop_check() -> bool:
+        return len(processed_files) >= 1
+
+    def fake_index_single_file(self, kb_id: str, file_url: str, vector_store) -> dict[str, object]:
+        processed_files.append(file_url)
+        return {"success": True, "chunk_count": 2}
+
+    with patch("ai_actuarial.rag.indexing.VectorStore") as mock_vector_store, patch.object(
+        IndexingPipeline,
+        "_index_single_file",
+        fake_index_single_file,
+    ), patch.object(IndexingPipeline, "_update_kb_stats"):
+        pipeline = IndexingPipeline(kb_manager, stop_check=stop_check)
+        stats = pipeline.index_files(
+            kb_id="kb-stop-test",
+            file_urls=["file-1", "file-2", "file-3"],
+            force_reindex=True,
+        )
+
+    assert stats["stopped"] is True
+    assert stats["indexed_files"] == 1
+    assert processed_files == ["file-1"]
+    mock_vector_store.return_value.save_index.assert_called_once()


### PR DESCRIPTION
## Summary
- audit React button/API coverage and document the current FastAPI migration gap
- restore chunk profile delete support so the Knowledge page delete action has a backend route
- propagate stop handling into catalog and RAG indexing tasks and avoid recording a ready index version when a task is stopped

## Testing
- npm run build
- .\\.venv\\Scripts\\python.exe -m pytest -q -o addopts=