### PR TITLE
fix: lock rag embedding metadata to kb indexes

### DIFF
--- a/ai_actuarial/ai_runtime.py
+++ b/ai_actuarial/ai_runtime.py
@@ -168,6 +168,34 @@ DEFAULT_AI_FUNCTION_CONFIG = {
     "ocr": {"provider": "local", "model": "docling"},
 }
 
+KNOWN_EMBEDDING_MODEL_DIMENSIONS = {
+    "text-embedding-3-large": 3072,
+    "text-embedding-3-small": 1536,
+    "text-embedding-ada-002": 1536,
+    "text-embedding-v3": 1024,
+    "text-embedding-004": 768,
+    "embed-multilingual-v3.0": 1024,
+    "all-MiniLM-L6-v2": 384,
+    "BAAI/bge-m3": 1024,
+    "BAAI/bge-large-zh-v1.5": 1024,
+    "sentence-transformers": 768,
+}
+
+KNOWN_EMBEDDING_MODEL_PROVIDERS = {
+    "text-embedding-3-large": "openai",
+    "text-embedding-3-small": "openai",
+    "text-embedding-ada-002": "openai",
+    "text-embedding-v3": "qwen",
+    "text-embedding-004": "google",
+    "embedding-3": "minimax",
+    "embo-01": "zhipuai",
+    "embed-multilingual-v3.0": "cohere",
+    "all-MiniLM-L6-v2": "local",
+    "BAAI/bge-m3": "local",
+    "BAAI/bge-large-zh-v1.5": "local",
+    "sentence-transformers": "local",
+}
+
 OCR_ENGINE_PROVIDER_MAP = {
     "docling": "local",
     "marker": "local",
@@ -537,3 +565,39 @@ def _reload_settings_if_available() -> None:
 def _normalize_provider(provider: str | None, *, default: str = "openai") -> str:
     normalized = str(provider or "").strip().lower()
     return normalized or default
+
+
+def infer_embedding_dimension(model: str | None) -> int | None:
+    """Infer embedding dimension for a known model identifier."""
+    normalized = str(model or "").strip()
+    if not normalized:
+        return None
+    if normalized in KNOWN_EMBEDDING_MODEL_DIMENSIONS:
+        return int(KNOWN_EMBEDDING_MODEL_DIMENSIONS[normalized])
+    lowered = normalized.lower()
+    if lowered.startswith("text-embedding-3-large"):
+        return 3072
+    if lowered.startswith("text-embedding-3-small") or "ada-002" in lowered:
+        return 1536
+    return None
+
+
+def infer_embedding_provider(
+    model: str | None,
+    *,
+    fallback: str | None = None,
+) -> str | None:
+    """Infer provider from an embedding model name when legacy rows lack it."""
+    normalized = str(model or "").strip()
+    if not normalized:
+        normalized_fallback = str(fallback or "").strip().lower()
+        return normalized_fallback or None
+    if normalized in KNOWN_EMBEDDING_MODEL_PROVIDERS:
+        return KNOWN_EMBEDDING_MODEL_PROVIDERS[normalized]
+    lowered = normalized.lower()
+    if lowered.startswith("text-embedding-3") or "ada-002" in lowered:
+        return "openai"
+    if normalized.startswith("BAAI/") or normalized == "sentence-transformers":
+        return "local"
+    normalized_fallback = str(fallback or "").strip().lower()
+    return normalized_fallback or None

--- a/ai_actuarial/chatbot/exceptions.py
+++ b/ai_actuarial/chatbot/exceptions.py
@@ -13,6 +13,33 @@ class RetrievalException(ChatbotException):
     pass
 
 
+class EmbeddingConfigurationMismatchException(RetrievalException):
+    """Raised when KB index embeddings are incompatible with current query embeddings."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        kb_id: str,
+        current_provider: str,
+        current_model: str,
+        current_dimension: int | None,
+        index_provider: str | None,
+        index_model: str | None,
+        index_dimension: int | None,
+        needs_reindex: bool = True,
+    ) -> None:
+        super().__init__(message)
+        self.kb_id = kb_id
+        self.current_provider = current_provider
+        self.current_model = current_model
+        self.current_dimension = current_dimension
+        self.index_provider = index_provider
+        self.index_model = index_model
+        self.index_dimension = index_dimension
+        self.needs_reindex = needs_reindex
+
+
 class LLMException(ChatbotException):
     """Exception raised when LLM API calls fail."""
     pass

--- a/ai_actuarial/chatbot/retrieval.py
+++ b/ai_actuarial/chatbot/retrieval.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional, Union
 import numpy as np
 
+from ai_actuarial.ai_runtime import infer_embedding_dimension, infer_embedding_provider
 from ai_actuarial.rag.knowledge_base import KnowledgeBaseManager
 from ai_actuarial.rag.embeddings import EmbeddingGenerator
 from ai_actuarial.rag.vector_store import VectorStore
@@ -19,6 +20,7 @@ from ai_actuarial.chatbot.exceptions import (
     RetrievalException,
     InvalidKBException,
     NoResultsException,
+    EmbeddingConfigurationMismatchException,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +55,14 @@ class RAGRetriever:
         
         # Cache for loaded vector stores
         self._vector_store_cache: Dict[str, VectorStore] = {}
+
+    def get_current_embedding_metadata(self) -> Dict[str, Any]:
+        """Return the current query embedding runtime used by chat retrieval."""
+        return {
+            "provider": str(self.embedding_generator.provider or "openai").strip().lower() or "openai",
+            "model": str(self.embedding_generator.config.embedding_model or "text-embedding-3-large").strip() or "text-embedding-3-large",
+            "dimension": self.embedding_generator.get_embedding_dimension(),
+        }
     
     def retrieve(
         self,
@@ -101,6 +111,13 @@ class RAGRetriever:
                 if not kb:
                     raise InvalidKBException(f"Knowledge base '{kb_id}' not found")
             
+            current_embedding = self.get_current_embedding_metadata()
+            for kb_id in kb_ids:
+                kb = self.kb_manager.get_kb(kb_id)
+                if not kb:
+                    raise InvalidKBException(f"Knowledge base '{kb_id}' not found")
+                self._ensure_kb_embedding_compatibility(kb, current_embedding)
+
             # Generate query embedding
             logger.info(f"Generating embedding for query: {query[:100]}...")
             query_embedding = self.embedding_generator.generate_single(query)
@@ -124,7 +141,7 @@ class RAGRetriever:
             logger.info(f"Retrieved {len(results)} chunks from {len(kb_ids)} KB(s)")
             return results
             
-        except (InvalidKBException, NoResultsException):
+        except (InvalidKBException, NoResultsException, EmbeddingConfigurationMismatchException):
             raise
         except Exception as e:
             logger.error(f"Retrieval failed: {e}")
@@ -403,11 +420,18 @@ class RAGRetriever:
             )
         
         # Load vector store
-        # Get embedding dimension from model
-        dimension = self._get_embedding_dimension(kb.embedding_model)
-        
+        composition = self.storage.get_kb_composition_status(kb_id)
+        latest_index = composition.get("latest_index") if isinstance(composition, dict) else None
+        dimension = None
+        if isinstance(latest_index, dict):
+            dimension = latest_index.get("embedding_dimension")
+        if dimension in (None, ""):
+            dimension = getattr(kb, "embedding_dimension", None) or infer_embedding_dimension(kb.embedding_model)
+        if dimension in (None, ""):
+            raise RetrievalException(f"Unable to determine index dimension for KB '{kb_id}'")
+
         vector_store = VectorStore(
-            dimension=dimension,
+            dimension=int(dimension),
             index_path=str(index_path)
         )
         
@@ -416,17 +440,57 @@ class RAGRetriever:
         
         return vector_store
     
-    def _get_embedding_dimension(self, model: str) -> int:
-        """Get embedding dimension for a model."""
-        # Common embedding dimensions
-        dimensions = {
-            'text-embedding-3-large': 3072,
-            'text-embedding-3-small': 1536,
-            'text-embedding-ada-002': 1536,
-            'all-MiniLM-L6-v2': 384,
-        }
-        
-        return dimensions.get(model, 1536)  # Default to 1536
+    def _ensure_kb_embedding_compatibility(
+        self,
+        kb,
+        current_embedding: Dict[str, Any],
+    ) -> None:
+        """Fail fast when a KB index was built with a different embedding runtime."""
+        composition = self.storage.get_kb_composition_status(kb.kb_id)
+        latest_index = composition.get("latest_index") if isinstance(composition, dict) else None
+
+        index_provider = None
+        index_model = None
+        index_dimension = None
+        if isinstance(latest_index, dict):
+            index_provider = latest_index.get("embedding_provider")
+            index_model = latest_index.get("embedding_model")
+            index_dimension = latest_index.get("embedding_dimension")
+
+        if not index_provider:
+            index_provider = getattr(kb, "embedding_provider", None) or infer_embedding_provider(
+                kb.embedding_model,
+                fallback=current_embedding.get("provider"),
+            )
+        if not index_model:
+            index_model = kb.embedding_model
+        if index_dimension in (None, ""):
+            index_dimension = getattr(kb, "embedding_dimension", None) or infer_embedding_dimension(index_model)
+
+        current_provider = str(current_embedding.get("provider") or "").strip().lower()
+        current_model = str(current_embedding.get("model") or "").strip()
+        current_dimension = current_embedding.get("dimension")
+
+        mismatch = False
+        if index_provider and current_provider and str(index_provider).strip().lower() != current_provider:
+            mismatch = True
+        if index_model and current_model and str(index_model).strip() != current_model:
+            mismatch = True
+        if index_dimension not in (None, "") and current_dimension not in (None, ""):
+            mismatch = mismatch or int(index_dimension) != int(current_dimension)
+
+        if mismatch:
+            raise EmbeddingConfigurationMismatchException(
+                "Knowledge base index is incompatible with the current embedding configuration. Rebuild the KB index before querying it.",
+                kb_id=kb.kb_id,
+                current_provider=current_provider,
+                current_model=current_model,
+                current_dimension=int(current_dimension) if current_dimension not in (None, "") else None,
+                index_provider=str(index_provider).strip().lower() if index_provider else None,
+                index_model=str(index_model).strip() if index_model else None,
+                index_dimension=int(index_dimension) if index_dimension not in (None, "") else None,
+                needs_reindex=True,
+            )
     
     def generate_citations(
         self,

--- a/ai_actuarial/db_models.py
+++ b/ai_actuarial/db_models.py
@@ -176,7 +176,9 @@ class KBIndexVersion(Base):
     
     index_version_id = Column(Text, primary_key=True)
     kb_id = Column(Text, nullable=False)
+    embedding_provider = Column(Text, nullable=False, default="openai")
     embedding_model = Column(Text, nullable=False)
+    embedding_dimension = Column(Integer)
     index_type = Column(Text, nullable=False)
     status = Column(Text, nullable=False)
     artifact_path = Column(Text)

--- a/ai_actuarial/rag/embeddings.py
+++ b/ai_actuarial/rag/embeddings.py
@@ -20,7 +20,7 @@ from typing import List, Optional
 
 from openai import OpenAI, APITimeoutError, RateLimitError, APIError
 
-from ai_actuarial.ai_runtime import is_embedding_provider_supported
+from ai_actuarial.ai_runtime import infer_embedding_dimension, is_embedding_provider_supported
 from ai_actuarial.rag.config import RAGConfig
 from ai_actuarial.rag.exceptions import EmbeddingException
 
@@ -308,16 +308,12 @@ class EmbeddingGenerator:
         """
         if self.provider != "local":
             # OpenAI-compatible embedding dimensions
-            if "text-embedding-3-large" in self.config.embedding_model:
-                return 3072
-            elif "text-embedding-3-small" in self.config.embedding_model:
-                return 1536
-            elif "ada-002" in self.config.embedding_model:
-                return 1536
-            else:
-                # Unknown model, generate test embedding to determine dimension
-                test_emb = self.generate_embeddings(["test"])
-                return len(test_emb[0]) if test_emb else 1536
+            inferred = infer_embedding_dimension(self.config.embedding_model)
+            if inferred is not None:
+                return inferred
+            # Unknown model, generate test embedding to determine dimension
+            test_emb = self.generate_embeddings(["test"])
+            return len(test_emb[0]) if test_emb else 1536
         else:
             # Local model - generate test embedding
             test_emb = self.generate_embeddings(["test"])

--- a/ai_actuarial/rag/indexing.py
+++ b/ai_actuarial/rag/indexing.py
@@ -82,6 +82,10 @@ class IndexingPipeline:
         kb = self.kb_manager.get_kb(kb_id)
         if not kb:
             raise RAGException(f"Knowledge base '{kb_id}' not found")
+        self.kb_manager.sync_kb_embedding_metadata(kb_id)
+        kb = self.kb_manager.get_kb(kb_id)
+        if not kb:
+            raise RAGException(f"Knowledge base '{kb_id}' not found")
 
         stats = {
             'total_files': len(file_urls),

--- a/ai_actuarial/rag/knowledge_base.py
+++ b/ai_actuarial/rag/knowledge_base.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
+from ai_actuarial.ai_runtime import infer_embedding_dimension, infer_embedding_provider
 from ai_actuarial.rag.config import RAGConfig
 from ai_actuarial.rag.exceptions import KnowledgeBaseException
 from ai_actuarial.rag.semantic_chunking import SemanticChunker
@@ -38,7 +39,9 @@ class KnowledgeBase:
         name: str,
         description: str = "",
         kb_mode: str = "category",  # "category" (auto-sync) or "manual" (explicit selection)
+        embedding_provider: str = "openai",
         embedding_model: str = "text-embedding-3-large",
+        embedding_dimension: Optional[int] = None,
         chunk_size: int = 800,
         chunk_overlap: int = 100,
         index_type: str = "Flat",
@@ -52,7 +55,9 @@ class KnowledgeBase:
         self.name = name
         self.description = description
         self.kb_mode = kb_mode
+        self.embedding_provider = str(embedding_provider or "openai").strip().lower() or "openai"
         self.embedding_model = embedding_model
+        self.embedding_dimension = int(embedding_dimension) if embedding_dimension not in (None, "") else None
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
         self.index_type = index_type
@@ -73,7 +78,9 @@ class KnowledgeBase:
             'name': self.name,
             'description': self.description,
             'kb_mode': self.kb_mode,
+            'embedding_provider': self.embedding_provider,
             'embedding_model': self.embedding_model,
+            'embedding_dimension': self.embedding_dimension,
             'chunk_size': self.chunk_size,
             'chunk_overlap': self.chunk_overlap,
             'index_type': self.index_type,
@@ -152,7 +159,9 @@ class KnowledgeBaseManager:
                 name TEXT NOT NULL,
                 description TEXT,
                 kb_mode TEXT DEFAULT 'category',
+                embedding_provider TEXT DEFAULT 'openai',
                 embedding_model TEXT NOT NULL,
+                embedding_dimension INTEGER,
                 chunk_size INTEGER NOT NULL,
                 chunk_overlap INTEGER NOT NULL,
                 index_type TEXT NOT NULL,
@@ -169,7 +178,9 @@ class KnowledgeBaseManager:
             {
                 "description": "TEXT DEFAULT ''",
                 "kb_mode": "TEXT DEFAULT 'category'",
+                "embedding_provider": "TEXT NOT NULL DEFAULT 'openai'",
                 "embedding_model": "TEXT NOT NULL DEFAULT 'text-embedding-3-large'",
+                "embedding_dimension": "INTEGER",
                 "chunk_size": "INTEGER NOT NULL DEFAULT 800",
                 "chunk_overlap": "INTEGER NOT NULL DEFAULT 100",
                 "index_type": "TEXT NOT NULL DEFAULT 'Flat'",
@@ -202,6 +213,34 @@ class KnowledgeBaseManager:
                 "indexed_at": "TEXT",
             },
         )
+
+        rows = conn.execute(
+            """
+            SELECT kb_id, embedding_provider, embedding_model, embedding_dimension
+            FROM rag_knowledge_bases
+            """
+        ).fetchall()
+        for row in rows:
+            kb_id, provider, model, dimension = row
+            resolved_provider = (
+                str(provider or "").strip().lower()
+                or infer_embedding_provider(model, fallback=self.config.embedding_provider)
+                or "openai"
+            )
+            resolved_dimension = (
+                int(dimension)
+                if dimension not in (None, "")
+                else infer_embedding_dimension(model)
+            )
+            if resolved_provider != str(provider or "").strip().lower() or resolved_dimension != dimension:
+                conn.execute(
+                    """
+                    UPDATE rag_knowledge_bases
+                    SET embedding_provider = ?, embedding_dimension = ?
+                    WHERE kb_id = ?
+                    """,
+                    (resolved_provider, resolved_dimension, kb_id),
+                )
 
         # rag_chunks table (for debugging and granular tracking)
         conn.execute("""
@@ -301,14 +340,18 @@ class KnowledgeBaseManager:
         existing = self.get_kb(kb_id)
         if existing:
             raise KnowledgeBaseException(f"Knowledge base '{kb_id}' already exists")
-        
+
+        current_embedding = self.get_current_embedding_metadata()
+
         # Create KB object with defaults from config
         kb = KnowledgeBase(
             kb_id=kb_id,
             name=name,
             description=description,
             kb_mode=kb_mode,
-            embedding_model=embedding_model or self.config.embedding_model,
+            embedding_provider=current_embedding["provider"],
+            embedding_model=current_embedding["model"],
+            embedding_dimension=current_embedding["dimension"],
             chunk_size=chunk_size or self.config.max_chunk_tokens,
             chunk_overlap=chunk_overlap or 100,
             index_type=index_type or self.config.index_type
@@ -322,12 +365,12 @@ class KnowledgeBaseManager:
         conn = self.storage._conn
         conn.execute("""
             INSERT INTO rag_knowledge_bases 
-            (kb_id, name, description, kb_mode, embedding_model, chunk_size, chunk_overlap, 
+            (kb_id, name, description, kb_mode, embedding_provider, embedding_model, embedding_dimension, chunk_size, chunk_overlap,
              index_type, created_at, updated_at, file_count, chunk_count,
              index_path, metadata_path)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
-            kb.kb_id, kb.name, kb.description, kb.kb_mode, kb.embedding_model,
+            kb.kb_id, kb.name, kb.description, kb.kb_mode, kb.embedding_provider, kb.embedding_model, kb.embedding_dimension,
             kb.chunk_size, kb.chunk_overlap, kb.index_type,
             kb.created_at, kb.updated_at, kb.file_count, kb.chunk_count,
             str(kb_dir / "index.faiss"),
@@ -341,7 +384,7 @@ class KnowledgeBaseManager:
         """Get knowledge base by ID."""
         conn = self.storage._conn
         cursor = conn.execute("""
-            SELECT kb_id, name, description, kb_mode, embedding_model, chunk_size, chunk_overlap,
+            SELECT kb_id, name, description, kb_mode, embedding_provider, embedding_model, embedding_dimension, chunk_size, chunk_overlap,
                    index_type, created_at, updated_at, file_count, chunk_count
             FROM rag_knowledge_bases
             WHERE kb_id = ?
@@ -354,16 +397,19 @@ class KnowledgeBaseManager:
         return KnowledgeBase(
             kb_id=row[0], name=row[1], description=row[2],
             kb_mode=row[3] or "category",  # Default to "category" for existing KBs
-            embedding_model=row[4], chunk_size=row[5], chunk_overlap=row[6],
-            index_type=row[7], created_at=row[8], updated_at=row[9],
-            file_count=row[10], chunk_count=row[11]
+            embedding_provider=row[4] or infer_embedding_provider(row[5], fallback=self.config.embedding_provider) or "openai",
+            embedding_model=row[5],
+            embedding_dimension=row[6] if row[6] not in (None, "") else infer_embedding_dimension(row[5]),
+            chunk_size=row[7], chunk_overlap=row[8],
+            index_type=row[9], created_at=row[10], updated_at=row[11],
+            file_count=row[12], chunk_count=row[13]
         )
     
     def list_kbs(self) -> List[KnowledgeBase]:
         """List all knowledge bases."""
         conn = self.storage._conn
         cursor = conn.execute("""
-            SELECT kb_id, name, description, kb_mode, embedding_model, chunk_size, chunk_overlap,
+            SELECT kb_id, name, description, kb_mode, embedding_provider, embedding_model, embedding_dimension, chunk_size, chunk_overlap,
                    index_type, created_at, updated_at, file_count, chunk_count
             FROM rag_knowledge_bases
             ORDER BY created_at DESC
@@ -374,9 +420,12 @@ class KnowledgeBaseManager:
             kbs.append(KnowledgeBase(
                 kb_id=row[0], name=row[1], description=row[2],
                 kb_mode=row[3] or "category",  # Default to "category" for existing KBs
-                embedding_model=row[4], chunk_size=row[5], chunk_overlap=row[6],
-                index_type=row[7], created_at=row[8], updated_at=row[9],
-                file_count=row[10], chunk_count=row[11]
+                embedding_provider=row[4] or infer_embedding_provider(row[5], fallback=self.config.embedding_provider) or "openai",
+                embedding_model=row[5],
+                embedding_dimension=row[6] if row[6] not in (None, "") else infer_embedding_dimension(row[5]),
+                chunk_size=row[7], chunk_overlap=row[8],
+                index_type=row[9], created_at=row[10], updated_at=row[11],
+                file_count=row[12], chunk_count=row[13]
             ))
         
         return kbs
@@ -419,6 +468,44 @@ class KnowledgeBaseManager:
         conn.commit()
         
         return True
+
+    def get_current_embedding_metadata(self) -> Dict[str, Any]:
+        """Return the runtime embedding metadata that new indexes should use."""
+        provider = str(self.config.embedding_provider or "openai").strip().lower() or "openai"
+        model = str(self.config.embedding_model or "text-embedding-3-large").strip() or "text-embedding-3-large"
+        dimension = infer_embedding_dimension(model)
+        if self.embedding_generator is not None:
+            provider = str(self.embedding_generator.provider or provider).strip().lower() or provider
+            try:
+                dimension = self.embedding_generator.get_embedding_dimension()
+            except Exception:
+                logger.warning("Failed to determine embedding dimension from generator; using inferred value", exc_info=True)
+        return {
+            "provider": provider,
+            "model": model,
+            "dimension": dimension,
+        }
+
+    def sync_kb_embedding_metadata(self, kb_id: str) -> Dict[str, Any]:
+        """Persist the currently configured embedding runtime onto a KB row."""
+        metadata = self.get_current_embedding_metadata()
+        timestamp = KnowledgeBase._get_timestamp()
+        self.storage._conn.execute(
+            """
+            UPDATE rag_knowledge_bases
+            SET embedding_provider = ?, embedding_model = ?, embedding_dimension = ?, updated_at = ?
+            WHERE kb_id = ?
+            """,
+            (
+                metadata["provider"],
+                metadata["model"],
+                metadata["dimension"],
+                timestamp,
+                kb_id,
+            ),
+        )
+        self.storage._conn.commit()
+        return metadata
     
     def delete_kb(self, kb_id: str) -> bool:
         """
@@ -632,7 +719,9 @@ class KnowledgeBaseManager:
             'total_chunks': kb.chunk_count,
             'created_at': kb.created_at,
             'updated_at': kb.updated_at,
+            'embedding_provider': kb.embedding_provider,
             'embedding_model': kb.embedding_model,
+            'embedding_dimension': kb.embedding_dimension,
             'chunk_size': kb.chunk_size,
             'index_type': kb.index_type
         }

--- a/ai_actuarial/storage.py
+++ b/ai_actuarial/storage.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any, Iterable
 import hashlib
 
+from ai_actuarial.ai_runtime import infer_embedding_dimension, infer_embedding_provider
+
 
 def _is_internal_category_label(category: str) -> bool:
     value = str(category or "").strip()
@@ -429,7 +431,9 @@ class Storage:
             CREATE TABLE IF NOT EXISTS kb_index_versions (
                 index_version_id TEXT PRIMARY KEY,
                 kb_id TEXT NOT NULL,
+                embedding_provider TEXT NOT NULL DEFAULT 'openai',
                 embedding_model TEXT NOT NULL,
+                embedding_dimension INTEGER,
                 index_type TEXT NOT NULL,
                 status TEXT NOT NULL,
                 artifact_path TEXT,
@@ -486,6 +490,40 @@ class Storage:
             ON kb_index_versions(kb_id)
             """
         )
+        self._ensure_columns(
+            "kb_index_versions",
+            {
+                "embedding_provider": "TEXT NOT NULL DEFAULT 'openai'",
+                "embedding_dimension": "INTEGER",
+            },
+        )
+        rows = self._conn.execute(
+            """
+            SELECT index_version_id, embedding_provider, embedding_model, embedding_dimension
+            FROM kb_index_versions
+            """
+        ).fetchall()
+        for row in rows:
+            index_version_id, provider, model, dimension = row
+            resolved_provider = (
+                str(provider or "").strip().lower()
+                or infer_embedding_provider(model, fallback="openai")
+                or "openai"
+            )
+            resolved_dimension = (
+                int(dimension)
+                if dimension not in (None, "")
+                else infer_embedding_dimension(model)
+            )
+            if resolved_provider != str(provider or "").strip().lower() or resolved_dimension != dimension:
+                self._conn.execute(
+                    """
+                    UPDATE kb_index_versions
+                    SET embedding_provider = ?, embedding_dimension = ?
+                    WHERE index_version_id = ?
+                    """,
+                    (resolved_provider, resolved_dimension, index_version_id),
+                )
         self._ensure_columns(
             "kb_chunk_bindings",
             {
@@ -2343,12 +2381,26 @@ class Storage:
                 b.kb_id,
                 COUNT(DISTINCT b.chunk_set_id) AS chunk_set_count,
                 COALESCE((
+                    SELECT iv.embedding_provider
+                    FROM kb_index_versions iv
+                    WHERE iv.kb_id = b.kb_id
+                    ORDER BY COALESCE(iv.built_at, iv.created_at) DESC
+                    LIMIT 1
+                ), '') AS embedding_provider,
+                COALESCE((
                     SELECT iv.embedding_model
                     FROM kb_index_versions iv
                     WHERE iv.kb_id = b.kb_id
                     ORDER BY COALESCE(iv.built_at, iv.created_at) DESC
                     LIMIT 1
                 ), '') AS embedding_model,
+                (
+                    SELECT iv.embedding_dimension
+                    FROM kb_index_versions iv
+                    WHERE iv.kb_id = b.kb_id
+                    ORDER BY COALESCE(iv.built_at, iv.created_at) DESC
+                    LIMIT 1
+                ) AS embedding_dimension,
                 (
                     SELECT COALESCE(iv.built_at, iv.created_at)
                     FROM kb_index_versions iv
@@ -2376,9 +2428,11 @@ class Storage:
                 {
                     "kb_id": row[0],
                     "chunk_set_count": row[1] or 0,
-                    "embedding_model": row[2] or "",
-                    "indexed_at": row[3],
-                    "indexed_chunk_count": row[4] or 0,
+                    "embedding_provider": row[2] or "",
+                    "embedding_model": row[3] or "",
+                    "embedding_dimension": row[4],
+                    "indexed_at": row[5],
+                    "indexed_chunk_count": row[6] or 0,
                 }
             )
         return out
@@ -2400,7 +2454,7 @@ class Storage:
         )
         latest = self._conn.execute(
             """
-            SELECT embedding_model, index_type, status, chunk_count, built_at, created_at
+            SELECT embedding_provider, embedding_model, embedding_dimension, index_type, status, chunk_count, built_at, created_at
             FROM kb_index_versions
             WHERE kb_id = ?
             ORDER BY COALESCE(built_at, created_at) DESC
@@ -2450,7 +2504,7 @@ class Storage:
             or 0
         )
         has_index = bool(latest)
-        latest_index_time = (latest[4] or latest[5]) if latest else None
+        latest_index_time = (latest[6] or latest[7]) if latest else None
         needs_reindex = bool(file_count > 0 and (not has_index or (latest_binding_at and latest_index_time and latest_binding_at > latest_index_time)))
         return {
             "kb_id": kb_id,
@@ -2466,11 +2520,13 @@ class Storage:
             "new_chunk_versions_available": outdated_binding_count > 0,
             "needs_reindex": needs_reindex,
             "latest_index": {
-                "embedding_model": latest[0],
-                "index_type": latest[1],
-                "status": latest[2],
-                "chunk_count": latest[3] or 0,
-                "built_at": latest[4] or latest[5],
+                "embedding_provider": latest[0] or infer_embedding_provider(latest[1], fallback="openai") or "openai",
+                "embedding_model": latest[1],
+                "embedding_dimension": latest[2] if latest[2] not in (None, "") else infer_embedding_dimension(latest[1]),
+                "index_type": latest[3],
+                "status": latest[4],
+                "chunk_count": latest[5] or 0,
+                "built_at": latest[6] or latest[7],
             }
             if latest
             else None,
@@ -2537,6 +2593,8 @@ class Storage:
         embedding_model: str,
         index_type: str,
         chunk_count: int,
+        embedding_provider: str = "openai",
+        embedding_dimension: int | None = None,
         status: str = "ready",
         artifact_path: str = "",
         chunk_ids: list[str] | None = None,
@@ -2565,15 +2623,17 @@ class Storage:
             self._conn.execute(
                 """
                 INSERT INTO kb_index_versions (
-                    index_version_id, kb_id, embedding_model, index_type, status,
+                    index_version_id, kb_id, embedding_provider, embedding_model, embedding_dimension, index_type, status,
                     artifact_path, chunk_count, built_at, created_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     index_version_id,
                     kb_id,
+                    str(embedding_provider or "openai").strip().lower() or "openai",
                     embedding_model,
+                    embedding_dimension,
                     index_type,
                     status,
                     artifact_path,
@@ -2594,7 +2654,9 @@ class Storage:
         return {
             "index_version_id": index_version_id,
             "kb_id": kb_id,
+            "embedding_provider": str(embedding_provider or "openai").strip().lower() or "openai",
             "embedding_model": embedding_model,
+            "embedding_dimension": embedding_dimension,
             "index_type": index_type,
             "status": status,
             "artifact_path": artifact_path,

--- a/ai_actuarial/storage_v2_rag.py
+++ b/ai_actuarial/storage_v2_rag.py
@@ -341,7 +341,9 @@ class StorageV2RAGMixin:
             ).order_by(func.coalesce(KBIndexVersion.built_at, KBIndexVersion.created_at).desc()).first()
             
             out.append({"kb_id": kb_id, "chunk_set_count": chunk_set_count or 0,
+                       "embedding_provider": latest_idx.embedding_provider if latest_idx else "",
                        "embedding_model": latest_idx.embedding_model if latest_idx else "",
+                       "embedding_dimension": latest_idx.embedding_dimension if latest_idx else None,
                        "indexed_at": (latest_idx.built_at or latest_idx.created_at) if latest_idx else None,
                        "indexed_chunk_count": latest_idx.chunk_count if latest_idx else 0})
         return out
@@ -377,7 +379,9 @@ class StorageV2RAGMixin:
                "binding_mode_counts": {"follow_latest": follow_latest_count, "pin": pin_count},
                "outdated_binding_count": 0, "new_chunk_versions_available": False,
                "needs_reindex": needs_reindex,
-               "latest_index": {"embedding_model": latest.embedding_model if latest else None,
+               "latest_index": {"embedding_provider": latest.embedding_provider if latest else None,
+                              "embedding_model": latest.embedding_model if latest else None,
+                              "embedding_dimension": latest.embedding_dimension if latest else None,
                               "index_type": latest.index_type if latest else None,
                               "status": latest.status if latest else None,
                               "chunk_count": latest.chunk_count if latest else 0,
@@ -431,7 +435,7 @@ class StorageV2RAGMixin:
         return out
 
     def create_kb_index_version(self, *, kb_id: str, embedding_model: str, index_type: str,
-                              chunk_count: int, status: str = "ready", artifact_path: str = "",
+                              chunk_count: int, embedding_provider: str = "openai", embedding_dimension: int = None, status: str = "ready", artifact_path: str = "",
                               chunk_ids: list = None, built_at: str = None) -> dict:
         now = self._utcnow_iso()
         index_version_id = f"idxv_{uuid.uuid4().hex}"
@@ -446,7 +450,7 @@ class StorageV2RAGMixin:
                 self._session.query(KBIndexVersion).filter(KBIndexVersion.kb_id == kb_id).delete()
 
             index_version = KBIndexVersion(index_version_id=index_version_id, kb_id=kb_id,
-                                          embedding_model=embedding_model, index_type=index_type,
+                                          embedding_provider=embedding_provider, embedding_model=embedding_model, embedding_dimension=embedding_dimension, index_type=index_type,
                                           status=status, artifact_path=artifact_path,
                                           chunk_count=int(chunk_count), built_at=built_time, created_at=now)
             self._session.add(index_version)
@@ -455,7 +459,8 @@ class StorageV2RAGMixin:
                 for chunk_id in chunk_ids:
                     self._session.add(KBIndexItem(index_version_id=index_version_id, chunk_id=chunk_id))
         
-        return {"index_version_id": index_version_id, "kb_id": kb_id, "embedding_model": embedding_model,
+        return {"index_version_id": index_version_id, "kb_id": kb_id, "embedding_provider": embedding_provider,
+               "embedding_model": embedding_model, "embedding_dimension": embedding_dimension,
                "index_type": index_type, "status": status, "artifact_path": artifact_path,
                "chunk_count": int(chunk_count), "built_at": built_time, "created_at": now}
 

--- a/ai_actuarial/web/app.py
+++ b/ai_actuarial/web/app.py
@@ -3104,6 +3104,7 @@ sites:
 
             config_data = _load_yaml(_get_sites_config_path(), default={})
             config_data.setdefault("ai_config", {})
+            previous_embeddings = dict(config_data["ai_config"].get("embeddings") or {})
             
             # Update each AI function configuration with validation
             for function in ["catalog", "embeddings", "chatbot", "ocr"]:
@@ -3195,7 +3196,41 @@ sites:
                     logger.error(f"Failed to invalidate config cache: {cache_err}")
                     raise
             
-            return jsonify({"success": True})
+            current_embeddings = dict(config_data["ai_config"].get("embeddings") or {})
+            embeddings_changed = (
+                str(previous_embeddings.get("provider") or "").strip().lower()
+                != str(current_embeddings.get("provider") or "").strip().lower()
+                or str(previous_embeddings.get("model") or "").strip()
+                != str(current_embeddings.get("model") or "").strip()
+            )
+            response_payload: dict[str, Any] = {"success": True}
+            if embeddings_changed:
+                affected_kb_ids: list[str] = []
+                try:
+                    storage = Storage(db_path)
+                    try:
+                        rows = storage._conn.execute(
+                            """
+                            SELECT DISTINCT kb_id
+                            FROM rag_knowledge_bases
+                            WHERE COALESCE(file_count, 0) > 0
+                               OR COALESCE(chunk_count, 0) > 0
+                            """
+                        ).fetchall()
+                        affected_kb_ids = [str(row[0]) for row in rows if row and row[0]]
+                    finally:
+                        storage.close()
+                except Exception:
+                    logger.warning("Failed to enumerate KBs affected by embeddings config change", exc_info=True)
+                response_payload.update(
+                    {
+                        "rebuild_required": True,
+                        "affected_kb_count": len(affected_kb_ids),
+                        "affected_kb_ids": affected_kb_ids,
+                        "message": "Embeddings configuration changed. Rebuild all existing knowledge base indexes.",
+                    }
+                )
+            return jsonify(response_payload)
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
         except Exception as e:
@@ -4549,6 +4584,19 @@ sites:
                     if message:
                         _append_task_log(task_id, "INFO", message)
 
+                current_embedding = kb_manager.sync_kb_embedding_metadata(kb_id)
+                kb = kb_manager.get_kb(kb_id)
+                if kb:
+                    _append_task_log(
+                        task_id,
+                        "INFO",
+                        (
+                            "Using embeddings "
+                            f"{current_embedding['provider']}/{current_embedding['model']} "
+                            f"(dim={current_embedding['dimension']}) for KB {kb_id}"
+                        ),
+                    )
+
                 pipeline = IndexingPipeline(
                     kb_manager,
                     progress_callback=rag_progress,
@@ -4566,7 +4614,9 @@ sites:
                         index_path = str(Path(kb_manager.config.data_dir) / kb_id / "index.faiss")
                         storage.create_kb_index_version(
                             kb_id=kb_id,
+                            embedding_provider=kb.embedding_provider,
                             embedding_model=kb.embedding_model,
+                            embedding_dimension=kb.embedding_dimension,
                             index_type=kb.index_type,
                             chunk_count=int(stats.get("total_chunks", 0) or 0),
                             status="ready",

--- a/ai_actuarial/web/chat_routes.py
+++ b/ai_actuarial/web/chat_routes.py
@@ -526,6 +526,38 @@ def register_chat_routes(
             finally:
                 storage.close()
         
+        except chatbot_exceptions.EmbeddingConfigurationMismatchException as e:
+            logger.warning(
+                "Chat query blocked by embedding mismatch for KB %s: current=%s/%s/%s index=%s/%s/%s",
+                e.kb_id,
+                e.current_provider,
+                e.current_model,
+                e.current_dimension,
+                e.index_provider,
+                e.index_model,
+                e.index_dimension,
+            )
+            return jsonify(
+                {
+                    "success": False,
+                    "code": "KB_EMBEDDING_MISMATCH",
+                    "error": "知识库索引与当前 embedding 配置不兼容，请先重建索引。",
+                    "data": {
+                        "kb_id": e.kb_id,
+                        "current_embedding": {
+                            "provider": e.current_provider,
+                            "model": e.current_model,
+                            "dimension": e.current_dimension,
+                        },
+                        "index_embedding": {
+                            "provider": e.index_provider,
+                            "model": e.index_model,
+                            "dimension": e.index_dimension,
+                        },
+                        "needs_reindex": e.needs_reindex,
+                    },
+                }
+            ), 409
         except Exception as e:
             logger.exception("Error processing chat query")
             return _api_error(
@@ -986,17 +1018,66 @@ def register_chat_routes(
             try:
                 kb_manager = rag_knowledge_base.KnowledgeBaseManager(storage)
                 kbs = kb_manager.list_kbs()
+                current_embedding = kb_manager.get_current_embedding_metadata()
                 
                 # Format for frontend
-                kb_list = [{
-                    "kb_id": kb.kb_id,
-                    "name": kb.name,
-                    "description": kb.description,
-                    "file_count": kb.file_count,
-                    "chunk_count": kb.chunk_count
-                } for kb in kbs]
+                kb_list = []
+                for kb in kbs:
+                    composition = storage.get_kb_composition_status(kb.kb_id)
+                    latest_index = composition.get("latest_index") if isinstance(composition, dict) else None
+                    index_provider = kb.embedding_provider
+                    index_model = kb.embedding_model
+                    index_dimension = kb.embedding_dimension
+                    index_status = ""
+                    index_built_at = None
+                    if isinstance(latest_index, dict):
+                        index_provider = latest_index.get("embedding_provider") or index_provider
+                        index_model = latest_index.get("embedding_model") or index_model
+                        index_dimension = latest_index.get("embedding_dimension")
+                        index_status = latest_index.get("status") or ""
+                        index_built_at = latest_index.get("built_at")
+
+                    embedding_compatible = True
+                    if index_provider and current_embedding.get("provider"):
+                        embedding_compatible = (
+                            str(index_provider).strip().lower()
+                            == str(current_embedding["provider"]).strip().lower()
+                        )
+                    if embedding_compatible and index_model and current_embedding.get("model"):
+                        embedding_compatible = (
+                            str(index_model).strip() == str(current_embedding["model"]).strip()
+                        )
+                    if (
+                        embedding_compatible
+                        and index_dimension not in (None, "")
+                        and current_embedding.get("dimension") not in (None, "")
+                    ):
+                        embedding_compatible = int(index_dimension) == int(current_embedding["dimension"])
+
+                    kb_list.append({
+                        "kb_id": kb.kb_id,
+                        "name": kb.name,
+                        "description": kb.description,
+                        "file_count": kb.file_count,
+                        "chunk_count": kb.chunk_count,
+                        "embedding_provider": kb.embedding_provider,
+                        "embedding_model": kb.embedding_model,
+                        "embedding_dimension": kb.embedding_dimension,
+                        "index_embedding_provider": index_provider,
+                        "index_embedding_model": index_model,
+                        "index_embedding_dimension": index_dimension,
+                        "index_status": index_status,
+                        "index_built_at": index_built_at,
+                        "needs_reindex": bool(composition.get("needs_reindex")) or not embedding_compatible,
+                        "embedding_compatible": embedding_compatible,
+                    })
                 
-                return _api_success({"knowledge_bases": kb_list})
+                return _api_success(
+                    {
+                        "knowledge_bases": kb_list,
+                        "current_embeddings": current_embedding,
+                    }
+                )
                 
             finally:
                 storage.close()

--- a/ai_actuarial/web/rag_routes.py
+++ b/ai_actuarial/web/rag_routes.py
@@ -96,7 +96,9 @@ def register_rag_routes(
             "name": kb.name,
             "description": kb.description,
             "kb_mode": kb.kb_mode,
+            "embedding_provider": getattr(kb, "embedding_provider", "openai"),
             "embedding_model": kb.embedding_model,
+            "embedding_dimension": getattr(kb, "embedding_dimension", None),
             "chunk_size": kb.chunk_size,
             "chunk_overlap": kb.chunk_overlap,
             "index_type": kb.index_type,
@@ -504,7 +506,7 @@ def register_rag_routes(
             def _run(storage):
                 conn = storage._conn
                 cursor = conn.execute("""
-                    SELECT kb_id, name, description, kb_mode, embedding_model, chunk_size, chunk_overlap,
+                    SELECT kb_id, name, description, kb_mode, embedding_provider, embedding_model, embedding_dimension, chunk_size, chunk_overlap,
                            index_type, created_at, updated_at, file_count, chunk_count
                     FROM rag_knowledge_bases
                     ORDER BY created_at DESC
@@ -514,9 +516,11 @@ def register_rag_routes(
                     kb = KnowledgeBase(
                         kb_id=row[0], name=row[1], description=row[2],
                         kb_mode=row[3] or "category",
-                        embedding_model=row[4], chunk_size=row[5], chunk_overlap=row[6],
-                        index_type=row[7], created_at=row[8], updated_at=row[9],
-                        file_count=row[10], chunk_count=row[11]
+                        embedding_provider=row[4] or "openai",
+                        embedding_model=row[5], embedding_dimension=row[6],
+                        chunk_size=row[7], chunk_overlap=row[8],
+                        index_type=row[9], created_at=row[10], updated_at=row[11],
+                        file_count=row[12], chunk_count=row[13]
                     )
                     if kb_mode and kb.kb_mode != kb_mode:
                         continue
@@ -562,12 +566,13 @@ def register_rag_routes(
             def _run(kb_manager, _storage):
                 if kb_manager.get_kb(kb_id):
                     return _api_error(f"Knowledge base '{kb_id}' already exists", status_code=409)
+                runtime_embedding = kb_manager.get_current_embedding_metadata()
                 kb_manager.create_kb(
                     kb_id=kb_id,
                     name=name,
                     description=_norm(data.get("description")),
                     kb_mode=kb_mode,
-                    embedding_model=_norm(data.get("embedding_model") or "text-embedding-3-large"),
+                    embedding_model=runtime_embedding["model"],
                     chunk_size=chunk_size,
                     chunk_overlap=chunk_overlap,
                 )

--- a/ai_actuarial/web/static/js/rag.js
+++ b/ai_actuarial/web/static/js/rag.js
@@ -917,47 +917,27 @@
             const sel = document.getElementById('rag-create-embedding-model');
             if (!sel) return;
             try {
-                const [modelsPayload, providersPayload] = await Promise.all([
-                    fetch('/api/config/ai-models').then(r => { if (!r.ok) throw new Error(`ai-models: ${r.status}`); return r.json(); }),
-                    fetch('/api/config/llm-providers').then(r => { if (!r.ok) throw new Error(`llm-providers: ${r.status}`); return r.json(); }),
-                ]);
-                const configured = new Set(['local']);
-                (providersPayload.providers || []).forEach(p => configured.add(p.provider));
-
-                const available = modelsPayload.available || {};
-                const currentEmbedModel = modelsPayload.current?.embeddings?.model || '';
-                // Restrict to the active embeddings provider so the model list
-                // matches what the indexing pipeline will actually use.
-                const activeEmbedProvider = modelsPayload.current?.embeddings?.provider || '';
-
-                const embeddingModels = [];
-                Object.keys(available).forEach(provider => {
-                    if (!configured.has(provider)) return;
-                    // When an active embeddings provider is known, only show its models.
-                    if (activeEmbedProvider && provider !== activeEmbedProvider) return;
-                    (available[provider] || []).forEach(m => {
-                        if ((m.types || []).includes('embeddings')) {
-                            embeddingModels.push({ value: m.name, label: m.display_name || m.name });
-                        }
-                    });
-                });
-
-                if (embeddingModels.length === 0) {
-                    embeddingModels.push({ value: 'text-embedding-3-large', label: 'text-embedding-3-large' });
-                }
-
+                const modelsPayload = await fetch('/api/config/ai-models').then(r => { if (!r.ok) throw new Error(`ai-models: ${r.status}`); return r.json(); });
+                const currentEmbedProvider = modelsPayload.current?.embeddings?.provider || 'openai';
+                const currentEmbedModel = modelsPayload.current?.embeddings?.model || 'text-embedding-3-large';
+                const embeddingModels = [
+                    {
+                        value: currentEmbedModel,
+                        label: `${currentEmbedProvider} / ${currentEmbedModel}`,
+                    },
+                ];
                 sel.innerHTML = '';
                 embeddingModels.forEach(m => {
                     const opt = document.createElement('option');
                     opt.value = m.value;
                     opt.textContent = m.label;
-                    if (m.value === currentEmbedModel) opt.selected = true;
+                    opt.selected = true;
                     sel.appendChild(opt);
                 });
             } catch (err) {
                 console.error('Failed to load embedding models:', err);
                 // Always replace the placeholder so the UI is not stuck.
-                sel.innerHTML = '<option value="text-embedding-3-large">text-embedding-3-large</option><option value="text-embedding-3-small">text-embedding-3-small</option>';
+                sel.innerHTML = '<option value="text-embedding-3-large">openai / text-embedding-3-large</option>';
             }
         };
 

--- a/ai_actuarial/web/templates/chat.html
+++ b/ai_actuarial/web/templates/chat.html
@@ -353,6 +353,27 @@
         border-color: var(--primary-color);
     }
 
+    .chat-kb-info {
+        min-width: 260px;
+        max-width: 360px;
+        padding: 0.7rem 0.85rem;
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        background: rgba(148, 163, 184, 0.08);
+        font-size: var(--text-sm);
+        line-height: 1.45;
+        color: var(--text-secondary);
+    }
+
+    .chat-kb-info strong {
+        color: var(--text-primary);
+    }
+
+    .chat-kb-info-warning {
+        border-color: rgba(220, 38, 38, 0.28);
+        background: rgba(220, 38, 38, 0.08);
+    }
+
     .chat-messages {
         flex: 1;
         overflow-y: auto;
@@ -691,6 +712,12 @@
             min-width: 0;
         }
 
+        .chat-kb-info {
+            min-width: 0;
+            max-width: none;
+            width: 100%;
+        }
+
         .chat-control-group {
             width: 100%;
             min-width: 0;
@@ -824,6 +851,7 @@
                         </select>
                     </div>
                 </div>
+                <div class="chat-kb-info" id="kb-embedding-info">Loading KB embedding status...</div>
             </div>
         </div>
         
@@ -865,6 +893,7 @@
     let currentConversationId = null;
     let conversations = [];
     let knowledgeBases = [];
+    let currentEmbeddingRuntime = null;
     let isLoading = false;
     let availableDocuments = [];
     let filteredDocuments = [];
@@ -879,6 +908,7 @@
     const modeSelector = document.getElementById('mode-selector');
     const chatTitle = document.getElementById('chat-title');
     const chatSubtitle = document.getElementById('chat-subtitle');
+    const kbEmbeddingInfo = document.getElementById('kb-embedding-info');
     
     // Document Explorer elements
     const docExplorer = document.getElementById('doc-explorer');
@@ -923,6 +953,7 @@
         
         // New conversation
         newConvBtn.addEventListener('click', startNewConversation);
+        kbSelector.addEventListener('change', updateKbEmbeddingInfo);
         
         // Document Explorer events
         docLoadBtn.addEventListener('click', loadAvailableDocuments);
@@ -956,7 +987,9 @@
             
             if (result.success && result.data.knowledge_bases) {
                 knowledgeBases = result.data.knowledge_bases;
+                currentEmbeddingRuntime = result.data.current_embeddings || null;
                 populateKBSelector();
+                updateKbEmbeddingInfo();
             }
         } catch (error) {
             console.error('Error loading knowledge bases:', error);
@@ -986,6 +1019,53 @@
             option.textContent = `${kb.name} (${kb.chunk_count} chunks)`;
             kbSelector.appendChild(option);
         });
+    }
+
+    function formatEmbeddingLabel(provider, model, dimension) {
+        const providerLabel = String(provider || '-').trim() || '-';
+        const modelLabel = String(model || '-').trim() || '-';
+        const dimLabel = dimension === null || dimension === undefined || dimension === '' ? '-' : dimension;
+        return `${providerLabel} / ${modelLabel} / dim ${dimLabel}`;
+    }
+
+    function updateKbEmbeddingInfo() {
+        if (!kbEmbeddingInfo) return;
+        const currentLabel = currentEmbeddingRuntime
+            ? formatEmbeddingLabel(
+                currentEmbeddingRuntime.provider,
+                currentEmbeddingRuntime.model,
+                currentEmbeddingRuntime.dimension,
+            )
+            : '-';
+        const selected = kbSelector?.value || 'auto';
+        if (selected === 'auto' || selected === 'all') {
+            kbEmbeddingInfo.classList.remove('chat-kb-info-warning');
+            kbEmbeddingInfo.innerHTML =
+                `<strong>Current embeddings</strong>: ${escapeHtml(currentLabel)}<br>` +
+                `<strong>KB selection</strong>: ${escapeHtml(selected === 'auto' ? 'Auto' : 'All')}`;
+            return;
+        }
+
+        const kb = knowledgeBases.find(item => item.kb_id === selected);
+        if (!kb) {
+            kbEmbeddingInfo.classList.remove('chat-kb-info-warning');
+            kbEmbeddingInfo.innerHTML = `<strong>Current embeddings</strong>: ${escapeHtml(currentLabel)}`;
+            return;
+        }
+
+        const indexLabel = formatEmbeddingLabel(
+            kb.index_embedding_provider,
+            kb.index_embedding_model,
+            kb.index_embedding_dimension,
+        );
+        const statusLabel = kb.needs_reindex || !kb.embedding_compatible
+            ? 'Rebuild required'
+            : (kb.index_status || 'ready');
+        kbEmbeddingInfo.classList.toggle('chat-kb-info-warning', !!(kb.needs_reindex || !kb.embedding_compatible));
+        kbEmbeddingInfo.innerHTML =
+            `<strong>Current embeddings</strong>: ${escapeHtml(currentLabel)}<br>` +
+            `<strong>KB index</strong>: ${escapeHtml(indexLabel)}<br>` +
+            `<strong>Status</strong>: ${escapeHtml(statusLabel)}`;
     }
     
     async function loadConversations() {
@@ -1170,7 +1250,18 @@
                 // Reload conversation list to update counts
                 await loadConversations();
             } else {
-                showError(result.error || 'Failed to get response');
+                if (result.code === 'KB_EMBEDDING_MISMATCH' && result.data) {
+                    const indexEmbedding = result.data.index_embedding || {};
+                    const currentEmbedding = result.data.current_embedding || {};
+                    showError(
+                        `KB ${result.data.kb_id || ''} needs reindex: ` +
+                        `${formatEmbeddingLabel(indexEmbedding.provider, indexEmbedding.model, indexEmbedding.dimension)} ` +
+                        `-> ${formatEmbeddingLabel(currentEmbedding.provider, currentEmbedding.model, currentEmbedding.dimension)}`
+                    );
+                    await loadKnowledgeBases();
+                } else {
+                    showError(result.error || 'Failed to get response');
+                }
             }
         } catch (error) {
             console.error('Error sending message:', error);

--- a/ai_actuarial/web/templates/settings.html
+++ b/ai_actuarial/web/templates/settings.html
@@ -167,6 +167,7 @@
         </div>
         <div>
           <label for="ai-embeddings-model" data-i18n="stg.embed_model">Embeddings Model</label>
+          <p class="field-help">Changing embeddings requires rebuilding all existing KB indexes.</p>
           <select id="ai-embeddings-model" class="module-field" data-module="ai_models">
             <!-- Populated dynamically -->
           </select>
@@ -1283,6 +1284,17 @@ async function saveAiModelsConfig() {
       },
     };
 
+    const currentEmbeddings = aiModelsData?.current?.embeddings || {};
+    const embeddingsChanged =
+      String(currentEmbeddings.provider || '').trim().toLowerCase() !== String(config.embeddings.provider || '').trim().toLowerCase() ||
+      String(currentEmbeddings.model || '').trim() !== String(config.embeddings.model || '').trim();
+    if (embeddingsChanged) {
+      const confirmed = window.confirm(
+        'Changing embeddings requires rebuilding all existing KB indexes. Continue saving this change?'
+      );
+      if (!confirmed) return;
+    }
+
     const token = window.AUTH_TOKEN || '';
     const resp = await fetch('/api/config/ai-models', {
       method: 'POST',
@@ -1295,7 +1307,11 @@ async function saveAiModelsConfig() {
     const data = await resp.json();
     if (!resp.ok) throw new Error(data.error || 'Save failed');
 
-    notifySuccess('AI models configuration saved');
+    if (data.rebuild_required) {
+      notifySuccess(`AI models configuration saved. Rebuild required for ${Number(data.affected_kb_count || 0)} KB(s).`);
+    } else {
+      notifySuccess('AI models configuration saved');
+    }
     await loadAiModelsConfig();
   } catch (err) {
     notifyError('Failed to save: ' + (err.message || String(err)));

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -24,7 +24,10 @@ if "schedule" not in sys.modules:
     sys.modules["schedule"] = types.ModuleType("schedule")
 
 from ai_actuarial.web.app import FLASK_AVAILABLE, create_app
-from ai_actuarial.chatbot.exceptions import NoResultsException
+from ai_actuarial.chatbot.exceptions import (
+    EmbeddingConfigurationMismatchException,
+    NoResultsException,
+)
 
 
 class TestChatRoutes(unittest.TestCase):
@@ -190,6 +193,13 @@ class TestChatRoutes(unittest.TestCase):
         self.assertIn("description", kb1)
         self.assertIn("file_count", kb1)
         self.assertIn("chunk_count", kb1)
+        self.assertIn("embedding_provider", kb1)
+        self.assertIn("embedding_model", kb1)
+        self.assertIn("embedding_dimension", kb1)
+        self.assertIn("index_embedding_provider", kb1)
+        self.assertIn("index_embedding_model", kb1)
+        self.assertIn("index_embedding_dimension", kb1)
+        self.assertIn("current_embeddings", data["data"])
     
     def test_get_knowledge_bases_no_auth(self):
         """Test knowledge bases endpoint requires authentication."""
@@ -648,6 +658,42 @@ class TestChatRoutes(unittest.TestCase):
         data = json.loads(response.data)
         self.assertFalse(data["success"])
         self.assertIn("error", data)
+
+    @patch('ai_actuarial.chatbot.retrieval.RAGRetriever')
+    @patch('ai_actuarial.chatbot.llm.LLMClient')
+    def test_chat_query_embedding_mismatch_returns_409(self, mock_llm_class, mock_retriever_class):
+        """Embedding mismatch should become a business error instead of a 500."""
+        mock_retriever = Mock()
+        mock_retriever.retrieve.side_effect = EmbeddingConfigurationMismatchException(
+            "Knowledge base index is incompatible with the current embedding configuration.",
+            kb_id="test_kb1",
+            current_provider="openai",
+            current_model="text-embedding-3-large",
+            current_dimension=3072,
+            index_provider="qwen",
+            index_model="text-embedding-v3",
+            index_dimension=1024,
+            needs_reindex=True,
+        )
+        mock_retriever_class.return_value = mock_retriever
+        mock_llm = Mock()
+        mock_llm_class.return_value = mock_llm
+
+        response = self.client.post(
+            "/api/chat/query",
+            headers=self.auth_header,
+            json={
+                "message": "Test query",
+                "kb_ids": ["test_kb1"]
+            }
+        )
+
+        self.assertEqual(response.status_code, 409)
+        data = json.loads(response.data)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["code"], "KB_EMBEDDING_MISMATCH")
+        self.assertEqual(data["data"]["kb_id"], "test_kb1")
+        self.assertTrue(data["data"]["needs_reindex"])
 
     @patch('ai_actuarial.chatbot.retrieval.RAGRetriever.retrieve')
     @patch('ai_actuarial.chatbot.llm.LLMClient.generate_response')

--- a/tests/test_chatbot_integration.py
+++ b/tests/test_chatbot_integration.py
@@ -83,7 +83,10 @@ class TestChatbotIntegration(unittest.TestCase):
         
         # Now we can create retriever - KBmanager and Embeddings won't actually initialize
         self.retriever = RAGRetriever(self.storage, self.config)
-        
+        self.retriever.embedding_generator.provider = "openai"
+        self.retriever.embedding_generator.config.embedding_model = "text-embedding-3-small"
+        self.retriever.embedding_generator.get_embedding_dimension.return_value = 1536
+
         # Mock the kb_manager instance methods we need
         from ai_actuarial.rag.knowledge_base import KnowledgeBase
         self.mock_kb1 = KnowledgeBase(


### PR DESCRIPTION
## Summary
- persist embedding provider/model/dimension on KB rows and KB index versions
- return explicit `KB_EMBEDDING_MISMATCH` errors and surface index embedding info in AI Chat
- warn when global embeddings change, require reindex, and align KB creation/indexing with the fixed global embedding runtime

## Validation
- `.venv\Scripts\python.exe -m pytest -o addopts= tests/test_chat_routes.py tests/test_chatbot_integration.py tests/test_global_chunk_phasea.py tests/test_rag_web_integration.py tests/test_storage_v2.py -q`
- `python -m compileall ai_actuarial`
- `npm run build`
