### PR TITLE
fix: align task history, KB status, and chat explain flows

### DIFF
--- a/ai_actuarial/storage.py
+++ b/ai_actuarial/storage.py
@@ -2438,7 +2438,7 @@ class Storage:
         return out
 
     def get_kb_composition_status(self, kb_id: str) -> dict[str, Any]:
-        file_count = int(
+        binding_file_count = int(
             self._conn.execute(
                 "SELECT COUNT(DISTINCT file_url) FROM kb_chunk_bindings WHERE kb_id = ?",
                 (kb_id,),
@@ -2503,12 +2503,109 @@ class Storage:
             ).fetchone()[0]
             or 0
         )
+        kb_row = self._conn.execute(
+            """
+            SELECT embedding_provider, embedding_model, embedding_dimension, chunk_count, updated_at
+            FROM rag_knowledge_bases
+            WHERE kb_id = ?
+            """,
+            (kb_id,),
+        ).fetchone()
+        kb_provider = ""
+        kb_model = ""
+        kb_dimension = None
+        kb_chunk_count = 0
+        kb_updated_at = None
+        if kb_row:
+            kb_provider = kb_row[0] or infer_embedding_provider(kb_row[1], fallback="openai") or "openai"
+            kb_model = kb_row[1] or ""
+            kb_dimension = kb_row[2] if kb_row[2] not in (None, "") else infer_embedding_dimension(kb_row[1])
+            kb_chunk_count = int((kb_row[3] or 0) or 0)
+            kb_updated_at = kb_row[4]
+
+        kb_file_count_row = self._conn.execute(
+            "SELECT COUNT(*) FROM rag_kb_files WHERE kb_id = ?",
+            (kb_id,),
+        ).fetchone()
+        kb_file_count = int((kb_file_count_row[0] if kb_file_count_row else 0) or 0)
+
+        indexed_stats = self._conn.execute(
+            """
+            SELECT
+                SUM(CASE WHEN indexed_at IS NOT NULL AND indexed_at != '' THEN 1 ELSE 0 END),
+                MAX(indexed_at)
+            FROM rag_kb_files
+            WHERE kb_id = ?
+            """,
+            (kb_id,),
+        ).fetchone()
+        indexed_file_count = int((indexed_stats[0] or 0) if indexed_stats else 0)
+        legacy_index_time = indexed_stats[1] if indexed_stats else None
+
+        pending_file_count_row = self._conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM rag_kb_files kf
+            LEFT JOIN catalog_items c ON c.file_url = kf.file_url
+            WHERE kf.kb_id = ?
+              AND (
+                kf.indexed_at IS NULL
+                OR kf.indexed_at = ''
+                OR (
+                    c.markdown_updated_at IS NOT NULL
+                    AND c.markdown_updated_at > kf.indexed_at
+                )
+              )
+            """,
+            (kb_id,),
+        ).fetchone()
+        pending_file_count = int((pending_file_count_row[0] if pending_file_count_row else 0) or 0)
+
         has_index = bool(latest)
         latest_index_time = (latest[6] or latest[7]) if latest else None
-        needs_reindex = bool(file_count > 0 and (not has_index or (latest_binding_at and latest_index_time and latest_binding_at > latest_index_time)))
+        if not has_index and (indexed_file_count > 0 or kb_chunk_count > 0):
+            has_index = True
+            latest_index_time = legacy_index_time or kb_updated_at
+
+        effective_file_count = max(binding_file_count, kb_file_count)
+        needs_reindex = bool(
+            effective_file_count > 0
+            and (
+                pending_file_count > 0
+                or outdated_binding_count > 0
+                or not has_index
+                or (latest_binding_at and latest_index_time and latest_binding_at > latest_index_time)
+            )
+        )
+        latest_index_payload = None
+        if latest:
+            latest_index_payload = {
+                "embedding_provider": latest[0] or infer_embedding_provider(latest[1], fallback="openai") or "openai",
+                "embedding_model": latest[1],
+                "embedding_dimension": latest[2] if latest[2] not in (None, "") else infer_embedding_dimension(latest[1]),
+                "index_type": latest[3],
+                "status": latest[4],
+                "chunk_count": latest[5] or 0,
+                "built_at": latest[6] or latest[7],
+            }
+        elif has_index:
+            latest_index_payload = {
+                "embedding_provider": kb_provider or "openai",
+                "embedding_model": kb_model,
+                "embedding_dimension": kb_dimension,
+                "index_type": "Flat",
+                "status": "ready",
+                "chunk_count": kb_chunk_count,
+                "built_at": latest_index_time,
+                "source": "legacy",
+            }
         return {
             "kb_id": kb_id,
-            "file_count": file_count,
+            "file_count": effective_file_count,
+            "binding_file_count": binding_file_count,
+            "kb_file_count": kb_file_count,
+            "indexed_file_count": indexed_file_count,
+            "pending_file_count": pending_file_count,
             "chunk_set_count": chunk_set_count,
             "has_index": has_index,
             "latest_binding_at": latest_binding_at,
@@ -2519,17 +2616,7 @@ class Storage:
             "outdated_binding_count": outdated_binding_count,
             "new_chunk_versions_available": outdated_binding_count > 0,
             "needs_reindex": needs_reindex,
-            "latest_index": {
-                "embedding_provider": latest[0] or infer_embedding_provider(latest[1], fallback="openai") or "openai",
-                "embedding_model": latest[1],
-                "embedding_dimension": latest[2] if latest[2] not in (None, "") else infer_embedding_dimension(latest[1]),
-                "index_type": latest[3],
-                "status": latest[4],
-                "chunk_count": latest[5] or 0,
-                "built_at": latest[6] or latest[7],
-            }
-            if latest
-            else None,
+            "latest_index": latest_index_payload,
         }
 
     def list_kb_chunk_bindings(self, kb_id: str) -> list[dict[str, Any]]:

--- a/ai_actuarial/web/app.py
+++ b/ai_actuarial/web/app.py
@@ -3978,7 +3978,7 @@ sites:
                 # Mock result for catalog
                 class CatalogResult:
                     def __init__(self, s):
-                        self.success = s
+                        self.success = s and stats.get("errors", 0) == 0
                         self.errors = stats.get('error_samples', [])
                         self.catalog_scanned = stats.get('scanned', 0)
                         self.catalog_ok = stats.get('processed', 0)
@@ -4226,7 +4226,7 @@ sites:
                 # Create result object
                 class MarkdownConversionResult:
                     def __init__(self):
-                        self.success = True
+                        self.success = error_count == 0
                         self.items_found = len(file_urls)
                         self.items_downloaded = converted_count
                         self.items_skipped = skipped_count
@@ -4500,7 +4500,7 @@ sites:
 
                 class ChunkGenerationResult:
                     def __init__(self):
-                        self.success = True
+                        self.success = len(errors) == 0
                         self.items_found = total_files
                         self.items_downloaded = processed_count
                         self.items_skipped = reused_count + no_markdown_count
@@ -4658,8 +4658,9 @@ sites:
             with _task_lock:
                 if task_id in _active_tasks:
                     task_data = _active_tasks.pop(task_id)
+                    final_status = _derive_task_final_status(task_data, result)
                     task_data.update({
-                        "status": "completed" if result and result.success else "failed",
+                        "status": final_status,
                         "completed_at": completed_at,
                         "progress": 100,
                         "current_activity": "Finished",
@@ -4667,17 +4668,15 @@ sites:
                         "items_downloaded": result.items_downloaded if result else 0,
                         "items_skipped": getattr(result, "items_skipped", 0),
                         "errors": result.errors if result else [],
+                        "error_count": len(result.errors) if result and isinstance(getattr(result, "errors", None), list) else 0,
                         "catalog_scanned": getattr(result, "catalog_scanned", None),
                         "catalog_ok": getattr(result, "catalog_ok", None),
                         "catalog_skipped": getattr(result, "catalog_skipped", None),
                         "catalog_errors": getattr(result, "catalog_errors", None),
                         "rag_total_chunks": getattr(result, "rag_total_chunks", None),
                         "rag_error_files": getattr(result, "rag_error_files", None),
+                        "rag_auto_synced_bindings": getattr(result, "rag_auto_synced_bindings", None),
                     })
-                    # Check if stopped
-                    if task_data.get("stop_requested"):
-                         task_data["status"] = "stopped"
-                         
                     _task_history.append(task_data)
                     _append_history_to_disk(task_data)
                     
@@ -4691,7 +4690,8 @@ sites:
                         "status": "error",
                         "completed_at": datetime.now().isoformat(),
                         "progress": 100,
-                        "errors": ["Task failed"]
+                        "errors": ["Task failed"],
+                        "error_count": 1,
                     })
                     _task_history.append(task_data)
                     _append_history_to_disk(task_data)
@@ -4818,13 +4818,13 @@ sites:
         """Get active and history task rows for one KB's indexing jobs."""
         with _task_lock:
             active = [
-                dict(task)
+                _serialize_task_for_api(dict(task))
                 for task in _active_tasks.values()
                 if task.get("type") in {"rag_indexing", "kb_index_build"}
                 and task.get("kb_id") == kb_id
             ]
             history = [
-                dict(task)
+                _serialize_task_for_api(dict(task))
                 for task in _task_history
                 if task.get("type") in {"rag_indexing", "kb_index_build"}
                 and task.get("kb_id") == kb_id
@@ -4942,6 +4942,147 @@ sites:
         except Exception as e:
             logger.error(f"Failed to save task history: {e}")
 
+    def _task_int(value: Any, default: int = 0) -> int:
+        try:
+            if value in (None, ""):
+                return default
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _task_error_count(task_data: dict[str, Any]) -> int:
+        explicit = task_data.get("error_count")
+        if explicit not in (None, ""):
+            return _task_int(explicit, 0)
+        errors = task_data.get("errors")
+        if isinstance(errors, list):
+            return len(errors)
+        return 0
+
+    def _task_metric(label_key: str, label: str, value: Any) -> dict[str, Any]:
+        return {
+            "label_key": label_key,
+            "label": label,
+            "value": _task_int(value, 0),
+        }
+
+    def _build_task_display_summary(task_data: dict[str, Any]) -> dict[str, Any]:
+        task_type = str(task_data.get("type") or "").strip().lower()
+        items_processed = _task_int(task_data.get("items_processed"))
+        items_downloaded = _task_int(task_data.get("items_downloaded"))
+        items_skipped = _task_int(task_data.get("items_skipped"))
+        error_count = _task_error_count(task_data)
+
+        if task_type == "catalog":
+            primary = _task_metric(
+                "tasks.metric_scanned",
+                "Scanned",
+                task_data.get("catalog_scanned", items_processed),
+            )
+            secondary = [
+                _task_metric(
+                    "tasks.metric_categorized",
+                    "Categorized",
+                    task_data.get("catalog_ok", items_downloaded),
+                ),
+                _task_metric(
+                    "tasks.metric_skipped",
+                    "Skipped",
+                    task_data.get("catalog_skipped", items_skipped),
+                ),
+                _task_metric(
+                    "tasks.metric_errors",
+                    "Errors",
+                    task_data.get("catalog_errors", error_count),
+                ),
+            ]
+        elif task_type == "markdown_conversion":
+            primary = _task_metric("tasks.metric_converted", "Converted", items_downloaded)
+            secondary = [
+                _task_metric("tasks.metric_skipped", "Skipped", items_skipped),
+                _task_metric("tasks.metric_errors", "Errors", error_count),
+            ]
+        elif task_type == "chunk_generation":
+            primary = _task_metric("tasks.metric_chunked_files", "Chunked Files", items_downloaded)
+            secondary = [
+                _task_metric("tasks.metric_skipped", "Skipped", items_skipped),
+                _task_metric("tasks.metric_errors", "Errors", error_count),
+            ]
+            auto_synced = task_data.get("rag_auto_synced_bindings")
+            if auto_synced not in (None, ""):
+                secondary.append(
+                    _task_metric(
+                        "tasks.metric_auto_synced",
+                        "Auto-Synced",
+                        auto_synced,
+                    )
+                )
+        elif task_type in {"rag_indexing", "kb_index_build"}:
+            primary = _task_metric("tasks.metric_indexed_files", "Indexed Files", items_downloaded)
+            secondary = [
+                _task_metric("tasks.metric_skipped", "Skipped", items_skipped),
+                _task_metric(
+                    "tasks.metric_error_files",
+                    "Error Files",
+                    task_data.get("rag_error_files", error_count),
+                ),
+                _task_metric(
+                    "tasks.metric_chunks",
+                    "Chunks",
+                    task_data.get("rag_total_chunks", 0),
+                ),
+            ]
+        elif task_type == "search":
+            primary = _task_metric("tasks.metric_found", "Found", items_processed)
+            secondary = [
+                _task_metric("tasks.metric_downloaded", "Downloaded", items_downloaded),
+                _task_metric("tasks.metric_errors", "Errors", error_count),
+            ]
+        elif task_type in {"url", "file", "scheduled", "adhoc", "quick_check"}:
+            primary = _task_metric("tasks.metric_found", "Found", items_processed)
+            secondary = [
+                _task_metric("tasks.metric_downloaded", "Downloaded", items_downloaded),
+                _task_metric("tasks.metric_skipped", "Skipped", items_skipped),
+                _task_metric("tasks.metric_errors", "Errors", error_count),
+            ]
+        else:
+            primary = _task_metric("tasks.metric_processed", "Processed", items_processed)
+            secondary = [
+                _task_metric("tasks.metric_completed", "Completed", items_downloaded),
+                _task_metric("tasks.metric_skipped", "Skipped", items_skipped),
+                _task_metric("tasks.metric_errors", "Errors", error_count),
+            ]
+
+        return {
+            "primary": primary,
+            "secondary": secondary,
+            "error_count": error_count,
+        }
+
+    def _derive_task_final_status(task_data: dict[str, Any], result: Any) -> str:
+        if task_data.get("stop_requested"):
+            return "stopped"
+        if result is None:
+            return "error"
+
+        items_downloaded = _task_int(getattr(result, "items_downloaded", 0))
+        items_skipped = _task_int(getattr(result, "items_skipped", 0))
+        errors = getattr(result, "errors", None)
+        error_count = len(errors) if isinstance(errors, list) else 0
+        success = bool(getattr(result, "success", True))
+
+        if success:
+            return "completed"
+        if error_count and (items_downloaded > 0 or items_skipped > 0):
+            return "partial"
+        return "failed"
+
+    def _serialize_task_for_api(task_data: dict[str, Any]) -> dict[str, Any]:
+        row = dict(task_data)
+        row["error_count"] = _task_error_count(row)
+        row["display_summary"] = _build_task_display_summary(row)
+        return row
+
     @app.route("/api/tasks/stop/<task_id>", methods=["POST"])
     @require_permissions("tasks.stop")
     def api_tasks_stop(task_id):
@@ -4959,7 +5100,7 @@ sites:
     def api_tasks_active():
         """Get active tasks."""
         with _task_lock:
-            tasks = list(_active_tasks.values())
+            tasks = [_serialize_task_for_api(task) for task in _active_tasks.values()]
         return jsonify({"tasks": tasks})
     
     @app.route("/api/tasks/history")
@@ -4969,7 +5110,10 @@ sites:
         limit = _parse_int_clamped(request.args.get("limit", 10), default=10, min_value=1, max_value=200)
         with _task_lock:
             # Sort by started_at desc
-            tasks = sorted(_task_history, key=lambda x: x.get('started_at', ''), reverse=True)[:limit]
+            tasks = [
+                _serialize_task_for_api(task)
+                for task in sorted(_task_history, key=lambda x: x.get('started_at', ''), reverse=True)[:limit]
+            ]
         return jsonify({"tasks": tasks})
 
     @app.route("/api/markdown_conversion/stats")

--- a/ai_actuarial/web/chat_routes.py
+++ b/ai_actuarial/web/chat_routes.py
@@ -1,4 +1,4 @@
-﻿"""Chat API routes for AI chatbot interface."""
+"""Chat API routes for AI chatbot interface."""
 
 from __future__ import annotations
 

--- a/ai_actuarial/web/chat_routes.py
+++ b/ai_actuarial/web/chat_routes.py
@@ -1,4 +1,4 @@
-"""Chat API routes for AI chatbot interface."""
+﻿"""Chat API routes for AI chatbot interface."""
 
 from __future__ import annotations
 
@@ -261,6 +261,27 @@ def register_chat_routes(
             document_content = data.get("document_content", "").strip()
             document_filename = data.get("document_filename", "document").strip()
             document_file_url = data.get("document_file_url", "").strip()
+            document_sources = []
+            raw_document_sources = data.get("document_sources")
+            if isinstance(raw_document_sources, list):
+                for idx, item in enumerate(raw_document_sources, start=1):
+                    if not isinstance(item, dict):
+                        continue
+                    source_content = str(item.get("content", "")).strip()
+                    if not source_content:
+                        continue
+                    source_filename = (
+                        str(item.get("filename") or item.get("title") or f"document_{idx}").strip()
+                        or f"document_{idx}"
+                    )
+                    source_file_url = str(item.get("file_url", "")).strip()
+                    document_sources.append(
+                        {
+                            "content": source_content,
+                            "filename": source_filename,
+                            "file_url": source_file_url,
+                        }
+                    )
             
             # Validate mode
             valid_modes = ["expert", "summary", "tutorial", "comparison"]
@@ -325,27 +346,48 @@ def register_chat_routes(
                 
                 # If document content is provided, use it instead of RAG retrieval
                 if document_content:
-                    # Truncate document if too long (max ~15K characters, ~4K tokens)
+                    # Truncate each document if too long (max ~15K characters, ~4K tokens).
                     MAX_DOC_LENGTH = 15000
-                    truncated = False
-                    if len(document_content) > MAX_DOC_LENGTH:
-                        document_content = document_content[:MAX_DOC_LENGTH]
-                        truncated = True
-                    
-                    # Create a special chunk with the full document content
-                    chunks = [{
-                        "content": document_content,
-                        "metadata": {
-                            "filename": document_filename,
-                            "file_url": document_file_url,
-                            "kb_id": "document_explanation",
-                            "kb_name": "Full Document",
-                            "chunk_id": "full_document",
-                            "similarity_score": 1.0,
-                            "is_full_document": True,
-                            "truncated": truncated
-                        }
-                    }]
+                    chunks = []
+                    if document_sources:
+                        for idx, source in enumerate(document_sources, start=1):
+                            source_content = source["content"]
+                            truncated = False
+                            if len(source_content) > MAX_DOC_LENGTH:
+                                source_content = source_content[:MAX_DOC_LENGTH]
+                                truncated = True
+                            chunks.append({
+                                "content": source_content,
+                                "metadata": {
+                                    "filename": source["filename"],
+                                    "file_url": source["file_url"],
+                                    "kb_id": "document_explanation",
+                                    "kb_name": "Full Document",
+                                    "chunk_id": f"full_document_{idx}",
+                                    "similarity_score": 1.0,
+                                    "is_full_document": True,
+                                    "truncated": truncated,
+                                }
+                            })
+                    else:
+                        truncated = False
+                        if len(document_content) > MAX_DOC_LENGTH:
+                            document_content = document_content[:MAX_DOC_LENGTH]
+                            truncated = True
+
+                        chunks = [{
+                            "content": document_content,
+                            "metadata": {
+                                "filename": document_filename,
+                                "file_url": document_file_url,
+                                "kb_id": "document_explanation",
+                                "kb_name": "Full Document",
+                                "chunk_id": "full_document",
+                                "similarity_score": 1.0,
+                                "is_full_document": True,
+                                "truncated": truncated
+                            }
+                        }]
                     no_results = False
                     used_threshold = 1.0
                 else:
@@ -450,6 +492,10 @@ def register_chat_routes(
                     filename = metadata.get("filename", "unknown")
                     score = float(metadata.get("similarity_score", 0.0) or 0.0)
                     links = _build_file_links(metadata.get("file_url", ""))
+                    chunk_text = str(chunk.get("content", "") or "").strip()
+                    quote_text = chunk_text[:280].rstrip()
+                    if chunk_text and len(chunk_text) > 280:
+                        quote_text += "..."
 
                     retrieved_blocks.append({
                         "filename": filename,
@@ -461,12 +507,14 @@ def register_chat_routes(
                         "source_url": links["source_url"],
                         "file_detail_url": links["file_detail_url"],
                         "file_preview_url": links["file_preview_url"],
+                        "quote": quote_text,
                     })
                     
                     # Avoid duplicate citations
-                    if filename in seen_files:
+                    citation_key = links["source_url"] or filename
+                    if citation_key in seen_files:
                         continue
-                    seen_files.add(filename)
+                    seen_files.add(citation_key)
                     
                     citations.append({
                         "filename": filename,
@@ -479,6 +527,7 @@ def register_chat_routes(
                         "file_url": links["file_detail_url"],
                         "file_detail_url": links["file_detail_url"],
                         "file_preview_url": links["file_preview_url"],
+                        "quote": quote_text,
                     })
                 
                 # Add assistant message
@@ -541,7 +590,7 @@ def register_chat_routes(
                 {
                     "success": False,
                     "code": "KB_EMBEDDING_MISMATCH",
-                    "error": "知识库索引与当前 embedding 配置不兼容，请先重建索引。",
+                    "error": "Knowledge base index is incompatible with the current embedding configuration. Rebuild the index first.",
                     "data": {
                         "kb_id": e.kb_id,
                         "current_embedding": {
@@ -776,10 +825,19 @@ def register_chat_routes(
                 for row in rows:
                     file_url, filename, title, category, keywords_str = row
                     
-                    # Parse keywords (stored as comma-separated string)
+                    # Parse keywords from either JSON arrays or legacy comma-separated strings.
                     keywords = []
                     if keywords_str:
-                        keywords = [k.strip() for k in keywords_str.split(",") if k.strip()]
+                        raw_keywords = str(keywords_str).strip()
+                        if raw_keywords.startswith("["):
+                            try:
+                                parsed_keywords = json.loads(raw_keywords)
+                            except json.JSONDecodeError:
+                                parsed_keywords = []
+                            if isinstance(parsed_keywords, list):
+                                keywords = [str(k).strip() for k in parsed_keywords if str(k).strip()]
+                        if not keywords:
+                            keywords = [k.strip() for k in raw_keywords.split(",") if k.strip()]
                     
                     documents.append({
                         "file_url": file_url or "",

--- a/ai_actuarial/web/static/css/style.css
+++ b/ai_actuarial/web/static/css/style.css
@@ -734,6 +734,11 @@ select:hover {
     color: #991b1b;
 }
 
+.status-partial, .status-warning, .status-stopped {
+    background-color: #fef3c7;
+    color: #92400e;
+}
+
 .status-pending {
     background-color: #fef3c7;
     color: #92400e;

--- a/ai_actuarial/web/static/js/rag.js
+++ b/ai_actuarial/web/static/js/rag.js
@@ -113,6 +113,13 @@
         return `Profile: ${profile.name || profile.profile_id} | model=${model} | size=${profile.chunk_size} | overlap=${profile.chunk_overlap} | ${profile.splitter}/${profile.tokenizer}`;
     }
 
+    function formatEmbeddingSummary(provider, model, dimension) {
+        const providerLabel = String(provider || '-').trim() || '-';
+        const modelLabel = String(model || '-').trim() || '-';
+        const dimLabel = dimension === null || dimension === undefined || dimension === '' ? '-' : dimension;
+        return `${providerLabel} / ${modelLabel} / dim ${dimLabel}`;
+    }
+
     function getWriteHeaders() {
         const headers = { 'Content-Type': 'application/json' };
         const token =
@@ -1162,6 +1169,7 @@
         const hasIndex = !!composition.has_index;
         const latestIndex = composition.latest_index || null;
         const latestIndexBuiltAt = latestIndex ? formatDate(latestIndex.built_at || latestIndex.created_at || '') : '-';
+        state.detailPendingFiles = Math.max(Number(state.detailPendingFiles || 0), Number(composition.pending_file_count || 0));
 
         syncSummaryEl.textContent = window.I18n
             ? window.I18n.t('rag.index_status')
@@ -1214,14 +1222,21 @@
         document.getElementById('rag-detail-description').textContent = kb.description || '';
         document.getElementById('rag-meta-kb-id').textContent = kb.kb_id || '-';
         document.getElementById('rag-meta-mode').textContent = getKbModeBadge(kb.kb_mode);
-        document.getElementById('rag-meta-embedding').textContent = kb.embedding_model || '-';
+        document.getElementById('rag-meta-embedding').textContent = formatEmbeddingSummary(
+            kb.embedding_provider,
+            kb.embedding_model,
+            kb.embedding_dimension,
+        );
         document.getElementById('rag-meta-chunk-profile').textContent = state.detailProfileSummary || '-';
         document.getElementById('rag-meta-chunk-size').textContent = kb.chunk_size || '-';
         document.getElementById('rag-meta-chunk-overlap').textContent = kb.chunk_overlap || '-';
         document.getElementById('rag-meta-updated').textContent = formatDate(kb.updated_at);
 
         const stats = kb.stats || {};
-        const pendingFiles = Number(stats.pending_files ?? 0);
+        const pendingFiles = Math.max(
+            Number(stats.pending_files ?? 0),
+            Number(state.detailComposition?.pending_file_count ?? 0),
+        );
         state.detailPendingFiles = pendingFiles;
         document.getElementById('rag-stat-total-files').textContent = stats.total_files ?? kb.file_count ?? 0;
         document.getElementById('rag-stat-indexed-files').textContent = stats.indexed_files ?? 0;

--- a/ai_actuarial/web/templates/chat.html
+++ b/ai_actuarial/web/templates/chat.html
@@ -498,6 +498,19 @@
         background: var(--primary-800);
     }
 
+    .chat-citation-item {
+        margin-bottom: 0.5rem;
+    }
+
+    .chat-citation-quote {
+        margin-top: 0.3rem;
+        padding-left: 0.6rem;
+        border-left: 2px solid var(--border-color);
+        font-size: var(--text-xs);
+        color: var(--text-secondary);
+        white-space: pre-wrap;
+    }
+
     .chat-retrieved-blocks {
         margin-top: 0.75rem;
     }
@@ -928,6 +941,7 @@
         loadConversations();
         // Load category filter on init
         populateCategoryFilter();
+        loadAvailableDocuments();
         setupEventListeners();
         autoResizeTextarea();
         
@@ -1210,11 +1224,15 @@
                 requestBody.document_content = window.explainDocumentContent;
                 requestBody.document_filename = window.explainDocumentFilename || 'document';
                 requestBody.document_file_url = window.explainDocumentFileUrl || '';
+                if (Array.isArray(window.explainDocumentSources) && window.explainDocumentSources.length) {
+                    requestBody.document_sources = window.explainDocumentSources;
+                }
                 
                 // Clear the temporary storage
                 delete window.explainDocumentContent;
                 delete window.explainDocumentFilename;
                 delete window.explainDocumentFileUrl;
+                delete window.explainDocumentSources;
             }
             
             const response = await fetch('/api/chat/query', {
@@ -1311,10 +1329,12 @@
                     const basename = extractBasename(rawFilename);
                     const label = escapeHtml(basename);
                     const title = escapeHtml(rawFilename); // Full path in tooltip
+                    const quote = escapeHtml(String(citation.quote || '').trim());
+                    const quoteHtml = quote ? `<div class="chat-citation-quote">${quote}</div>` : '';
                     if (!href) {
-                        return `<span class="chat-citation" title="${title}">${label}</span>`;
+                        return `<div class="chat-citation-item"><span class="chat-citation" title="${title}">${label}</span>${quoteHtml}</div>`;
                     }
-                    return `<a href="${escapeHtml(href)}" class="chat-citation" target="_blank" rel="noopener noreferrer" title="${title}">${label}</a>`;
+                    return `<div class="chat-citation-item"><a href="${escapeHtml(href)}" class="chat-citation" target="_blank" rel="noopener noreferrer" title="${title}">${label}</a>${quoteHtml}</div>`;
                 }).join('')}
             </div>
         ` : '';
@@ -1753,7 +1773,13 @@
                 // Store combined content for the API
                 window.explainDocumentContent = combinedContent;
                 window.explainDocumentFilename = `Comparison of ${documentContents.length} documents`;
-                window.explainDocumentFileUrl = documentContents.map(d => d.url).join('|');
+                window.explainDocumentFileUrl = '';
+                window.explainDocumentSources = documentContents.map((doc) => ({
+                    file_url: doc.url,
+                    filename: doc.filename,
+                    title: doc.title,
+                    content: doc.content,
+                }));
                 
                 // Set input and send
                 chatInput.value = prompt;
@@ -1766,6 +1792,12 @@
                 window.explainDocumentContent = doc.content;
                 window.explainDocumentFilename = doc.filename;
                 window.explainDocumentFileUrl = doc.url;
+                window.explainDocumentSources = [{
+                    file_url: doc.url,
+                    filename: doc.filename,
+                    title: doc.title,
+                    content: doc.content,
+                }];
                 
                 // Set input and send
                 chatInput.value = prompt;

--- a/ai_actuarial/web/templates/settings.html
+++ b/ai_actuarial/web/templates/settings.html
@@ -464,7 +464,7 @@ function historyReload() {
                   <td>${escapeHtml(t.name || '')}</td>
                   <td>${escapeHtml(t.type || '')}</td>
                   <td><span class="status-badge status-${escapeHtml(t.status || 'unknown')}">${escapeHtml(t.status || 'unknown')}</span></td>
-                  <td>${t.items_processed || 0}</td>
+                  <td>${historySummaryText(t)}</td>
                   <td>${formatDate(t.started_at)}</td>
                   <td><button class="btn-small" onclick='historyShowLog(${JSON.stringify(t).replace(/'/g, "&#39;")})'>${_t('tasks.hist_view_log')}</button></td>
                 </tr>
@@ -479,16 +479,45 @@ function historyReload() {
     });
 }
 
+function historyMetricLabel(metric, fallback) {
+  if (!metric || typeof metric !== 'object') return fallback;
+  const key = String(metric.label_key || '').trim();
+  if (key && window.I18n) {
+    const translated = window.I18n.t(key);
+    if (translated && translated !== key) return translated;
+  }
+  return metric.label || fallback;
+}
+
+function historyTaskSummary(task) {
+  if (task && task.display_summary) return task.display_summary;
+  return {
+    primary: { label: 'Processed', value: task.items_processed || 0 },
+    secondary: [
+      { label: 'Completed', value: task.items_downloaded || 0 },
+      { label: 'Skipped', value: task.items_skipped || 0 },
+      { label: 'Errors', value: task.error_count || ((task.errors || []).length) },
+    ],
+  };
+}
+
+function historySummaryText(task) {
+  const summary = historyTaskSummary(task);
+  const primary = summary.primary || { label: 'Processed', value: 0 };
+  return `${historyMetricLabel(primary, 'Processed')}: ${Number(primary.value || 0)}`;
+}
+
 function historyShowLog(task) {
   const body = document.getElementById('settings-history-log-body');
   if (!body) return;
   const _t = k => window.I18n ? window.I18n.t(k) : k;
-  const mainStats = `
-    <li><strong>${_t('stg.log_items_processed')}</strong> ${task.items_processed || 0}</li>
-    <li><strong>${_t('stg.log_new_updated')}</strong> ${task.items_downloaded || 0}</li>
-    <li><strong>${_t('stg.log_skipped')}</strong> ${task.items_skipped || 0}</li>
-    <li><strong>${_t('stg.log_errors')}</strong> ${task.errors ? task.errors.length : 0}</li>
-  `;
+  const summary = historyTaskSummary(task);
+  const mainStats = [
+    `<li><strong>${escapeHtml(historyMetricLabel(summary.primary, 'Processed'))}</strong> ${Number(summary.primary?.value || 0)}</li>`,
+    ...(Array.isArray(summary.secondary) ? summary.secondary : []).map((metric) =>
+      `<li><strong>${escapeHtml(historyMetricLabel(metric, 'Value'))}</strong> ${Number(metric.value || 0)}</li>`
+    ),
+  ].join('');
   body.innerHTML = `
     <div style="padding: 10px;">
       <h4>${_t('stg.task_log_title')} ${escapeHtml(task.name || '')}</h4>

--- a/ai_actuarial/web/templates/tasks.html
+++ b/ai_actuarial/web/templates/tasks.html
@@ -2020,6 +2020,9 @@ function loadActiveTasks() {
                                     if (status === 'failed' || status === 'error') {
                                         message = `Task failed: ${completedTask.name}`;
                                         type = 'error';
+                                    } else if (status === 'partial' || status === 'warning') {
+                                        message = `Task completed with warnings: ${completedTask.name}`;
+                                        type = 'warning';
                                     } else if (status === 'stopped') {
                                         message = `Task stopped: ${completedTask.name}`;
                                         type = 'warning';
@@ -2040,6 +2043,65 @@ function loadActiveTasks() {
             previouslyActiveTaskIds = currentTaskIds;
         })
         .catch(console.error);
+}
+
+function translateTaskMetric(metric, fallback) {
+    if (!metric || typeof metric !== 'object') return fallback;
+    const key = String(metric.label_key || '').trim();
+    if (key && window.I18n) {
+        const translated = window.I18n.t(key);
+        if (translated && translated !== key) return translated;
+    }
+    return metric.label || fallback;
+}
+
+function getTaskDisplaySummary(task) {
+    if (task && task.display_summary) {
+        return task.display_summary;
+    }
+    const errorCount = task && Array.isArray(task.errors) ? task.errors.length : 0;
+    if (task && task.type === 'catalog') {
+        return {
+            primary: { label: 'Scanned', value: task.catalog_scanned ?? task.items_processed ?? 0 },
+            secondary: [
+                { label: 'Categorized', value: task.catalog_ok ?? task.items_downloaded ?? 0 },
+                { label: 'Skipped', value: task.catalog_skipped ?? task.items_skipped ?? 0 },
+                { label: 'Errors', value: task.catalog_errors ?? errorCount },
+            ],
+        };
+    }
+    return {
+        primary: { label: 'Processed', value: task ? (task.items_processed || 0) : 0 },
+        secondary: [
+            { label: 'Completed', value: task ? (task.items_downloaded || 0) : 0 },
+            { label: 'Skipped', value: task ? (task.items_skipped || 0) : 0 },
+            { label: 'Errors', value: errorCount },
+        ],
+    };
+}
+
+function renderTaskItemsCell(task) {
+    const summary = getTaskDisplaySummary(task);
+    const primary = summary.primary || { label: 'Processed', value: 0 };
+    const secondary = Array.isArray(summary.secondary) ? summary.secondary : [];
+    const primaryLabel = translateTaskMetric(primary, 'Processed');
+    const secondaryText = secondary
+        .map((metric) => `${escapeHtml(translateTaskMetric(metric, 'Value'))}: ${Number(metric.value || 0)}`)
+        .join(' / ');
+    return `
+        ${escapeHtml(primaryLabel)}: ${Number(primary.value || 0)}
+        ${secondaryText ? `<br><small>${secondaryText}</small>` : ''}
+    `;
+}
+
+function renderTaskStatsList(task) {
+    const summary = getTaskDisplaySummary(task);
+    const primary = summary.primary || { label: 'Processed', value: 0 };
+    const secondary = Array.isArray(summary.secondary) ? summary.secondary : [];
+    return [
+        `<li><strong>${escapeHtml(translateTaskMetric(primary, 'Processed'))}</strong> ${Number(primary.value || 0)}</li>`,
+        ...secondary.map((metric) => `<li><strong>${escapeHtml(translateTaskMetric(metric, 'Value'))}</strong> ${Number(metric.value || 0)}</li>`),
+    ].join('');
 }
 
 function loadTaskHistory() {
@@ -2068,27 +2130,8 @@ function loadTaskHistory() {
                             <tr>
                                 <td>${escapeHtml(task.name)}</td>
                                 <td>${task.type}</td>
-                                <td><span class="status-badge status-${task.status}">${task.status}</span></td>
-                                <td>
-                                    ${task.type === 'catalog'
-                                        ? `
-                                            ${_tn('tasks.hist_scanned', task.catalog_scanned ?? task.items_processed ?? 0)}
-                                            <br><small>
-                                                ${_tn('tasks.hist_categorized', task.catalog_ok ?? task.items_downloaded ?? 0)} /
-                                                ${_tn('tasks.hist_skipped', task.catalog_skipped ?? task.items_skipped ?? 0)} /
-                                                ${_tn('tasks.hist_failed', task.catalog_errors ?? (task.errors ? task.errors.length : 0))}
-                                            </small>
-                                          `
-                                        : `
-                                            ${_tn('tasks.hist_processed', task.items_processed || 0)}
-                                            <br><small>
-                                                ${_tn('tasks.hist_new', task.items_downloaded || 0)} /
-                                                ${_tn('tasks.hist_skip', task.items_skipped || 0)} /
-                                                ${_tn('tasks.hist_err', task.errors ? task.errors.length : 0)}
-                                            </small>
-                                          `
-                                    }
-                                </td>
+                                <td><span class="status-badge status-${escapeHtml(task.status || 'unknown')}">${escapeHtml(task.status || 'unknown')}</span></td>
+                                <td>${renderTaskItemsCell(task)}</td>
                                 <td>${formatDate(task.started_at)}</td>
                                 <td>
                                     <button onclick='showLog(${JSON.stringify(task)})' class="btn-small">${_t('tasks.hist_view_log', 'View Log')}</button>
@@ -2104,21 +2147,8 @@ function loadTaskHistory() {
 }
 
 function showLog(task) {
-    const _t = k => window.I18n ? window.I18n.t(k) : k;
-    const isCatalog = task.type === 'catalog';
-    const mainStats = isCatalog
-        ? `
-            <li><strong>${_t('tasks.log_scanned')}</strong> ${task.catalog_scanned ?? task.items_processed ?? 0}</li>
-            <li><strong>${_t('tasks.log_ok')}</strong> ${task.catalog_ok ?? task.items_downloaded ?? 0}</li>
-            <li><strong>${_t('tasks.log_skipped')}</strong> ${task.catalog_skipped ?? task.items_skipped ?? 0}</li>
-            <li><strong>${_t('tasks.log_failed_lbl')}</strong> ${task.catalog_errors ?? (task.errors ? task.errors.length : 0)}</li>
-          `
-        : `
-            <li><strong>${_t('tasks.log_items_processed')}</strong> ${task.items_processed || 0}</li>
-            <li><strong>${_t('tasks.log_new_updated')}</strong> ${task.items_downloaded || 0}</li>
-            <li><strong>${_t('tasks.log_skipped')}</strong> ${task.items_skipped || 0}</li>
-            <li><strong>${_t('tasks.log_errors_lbl')}</strong> ${task.errors ? task.errors.length : 0}</li>
-          `;
+    const _t = (k, fb) => window.I18n ? window.I18n.t(k) : (fb || k);
+    const mainStats = renderTaskStatsList(task);
 
     const content = `
         <div style="padding: 10px;">

--- a/docs/规划文档-2026-03-11-task-kb-chat-smoke-checklist.md
+++ b/docs/规划文档-2026-03-11-task-kb-chat-smoke-checklist.md
@@ -1,0 +1,74 @@
+# Task / KB / Chat Smoke Checklist
+
+Date: 2026-03-11
+Branch: `fix/task-history-kb-chat-bugs-20260311`
+
+Scope:
+- `tasks` page and task history APIs
+- `rag` list/detail pages and KB status APIs
+- `chat` page, KB/doc explorer APIs, and document explain route payload
+
+Method:
+- Used project virtualenv: `.venv\Scripts\python.exe`
+- Used Flask `test_client()` against local app and current local data/config
+- For `POST /api/chat/query` document explain smoke, stubbed `LLMClient.generate_response` to avoid external model calls
+- This is a route/API smoke pass, not a visual browser click-through
+
+## 1. Tasks
+
+- `[pass]` `GET /tasks` returned `200`
+- `[pass]` `GET /api/tasks/history?limit=5` returned `200`
+- `[pass]` task history rows include `display_summary`
+- `[pass]` `GET /api/tasks/active` returned `200`
+
+Checks:
+- task history now exposes backend-owned summary structure
+- no active task at smoke time, so stop/progress UX was not re-verified interactively
+
+## 2. Knowledge Bases
+
+- `[pass]` `GET /rag` returned `200`
+- `[pass]` `GET /api/rag/knowledge-bases` returned `200` with `3` KBs
+- `[pass]` `GET /rag/KB_20260303_0001` returned `200`
+- `[pass]` `GET /api/rag/knowledge-bases/KB_20260303_0001` returned `200` with stats and embedding metadata
+- `[pass]` `GET /api/rag/knowledge-bases/KB_20260303_0001/composition/status` returned:
+  - `has_index = true`
+  - `needs_reindex = false`
+  - `file_count = 1`
+  - `pending_file_count = 0`
+- `[pass]` `GET /api/rag/knowledge-bases/KB_20260303_0001/files` returned `sample_status = indexed`
+- `[pass]` `GET /api/rag/knowledge-bases/KB_20260303_0001/tasks?limit=10` returned `200`
+- `[pass]` KB task history rows include `display_summary`
+
+Checks:
+- legacy index state is now visible through composition fallback
+- detail file row status and composition status aligned for sampled KB
+
+## 3. Chat
+
+- `[pass]` `GET /chat` returned `200`
+- `[pass]` `GET /api/chat/knowledge-bases` returned `200` with `3` KBs and current embedding metadata
+- `[pass]` `GET /api/chat/available-documents` returned `200` with `10` documents
+- `[pass]` `GET /api/files/<file_url>/markdown` returned `200` for sampled document and markdown content was present
+
+Document explain smoke:
+- `[pass]` `POST /api/chat/query` with `document_sources` returned `200`
+- `[pass]` response contained `2` citations for `a.pdf` and `b.pdf`
+- `[pass]` response contained `2` retrieved blocks
+- `[pass]` citations contained `quote`
+
+Live LLM smoke:
+- `[pass]` `POST /api/chat/query` with one real local markdown document returned `200`
+- `[pass]` live response contained `1` citation and `1` retrieved block
+- `[pass]` live citation contained `quote`
+
+Checks:
+- document list is reachable
+- markdown fetch path for explain-doc is reachable
+- multi-document explain payload now preserves per-file citations and quotes
+
+## Residual Risks
+
+- No real browser click-through was performed, so final DOM rendering was validated only indirectly through template/API wiring.
+- Only one small live external LLM call was executed in this smoke pass.
+- No active background task was created during smoke, so task completion notifications and stop interaction were not re-exercised live.

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -207,7 +207,56 @@ class TestChatRoutes(unittest.TestCase):
         
         # Should return 401 or 403
         self.assertIn(response.status_code, [401, 403])
-    
+
+    def test_get_available_documents_lists_markdown_files(self):
+        """Document explorer should list only files with markdown content."""
+        from ai_actuarial.storage import Storage
+
+        storage = Storage(self.db_path)
+        try:
+            file_url = "https://example.com/doc-1.pdf"
+            storage.insert_file(
+                url=file_url,
+                sha256="chat-doc-1",
+                title="Doc One",
+                source_site="example.com",
+                source_page_url="https://example.com/page",
+                original_filename="doc-1.pdf",
+                local_path="/tmp/doc-1.pdf",
+                bytes=1024,
+                content_type="application/pdf",
+            )
+            storage.update_file_markdown(
+                file_url,
+                "# Heading\n\nDocument body.",
+                "manual",
+            )
+            storage.upsert_catalog_item(
+                {
+                    "url": file_url,
+                    "sha256": "chat-doc-1",
+                    "category": "General",
+                    "summary": "Summary",
+                    "keywords": ["solvency", "capital"],
+                }
+            )
+        finally:
+            storage.close()
+
+        response = self.client.get(
+            "/api/chat/available-documents",
+            headers=self.auth_header,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["success"])
+        documents = payload["data"]["documents"]
+        self.assertEqual(len(documents), 1)
+        self.assertEqual(documents[0]["file_url"], file_url)
+        self.assertEqual(documents[0]["category"], "General")
+        self.assertIn("solvency", documents[0]["keywords"])
+
     @patch('ai_actuarial.chatbot.retrieval.RAGRetriever')
     @patch('ai_actuarial.chatbot.llm.LLMClient')
     def test_chat_query_success(self, mock_llm_class, mock_retriever_class):
@@ -265,6 +314,47 @@ class TestChatRoutes(unittest.TestCase):
         self.assertIn("Solvency II", result["response"])
         self.assertEqual(len(result["citations"]), 1)
         self.assertEqual(result["citations"][0]["filename"], "regulation.pdf")
+
+    @patch('ai_actuarial.chatbot.llm.LLMClient')
+    def test_chat_query_document_sources_return_per_file_citations(self, mock_llm_class):
+        """Document explain mode should keep one citation per selected document."""
+        mock_llm = Mock()
+        mock_llm.generate_response.return_value = "Comparison response."
+        mock_llm_class.return_value = mock_llm
+
+        response = self.client.post(
+            "/api/chat/query",
+            headers=self.auth_header,
+            json={
+                "message": "Compare these documents",
+                "mode": "comparison",
+                "document_content": "Combined content",
+                "document_filename": "Comparison",
+                "document_sources": [
+                    {
+                        "file_url": "https://example.com/doc-a.pdf",
+                        "filename": "doc-a.pdf",
+                        "content": "# Doc A\n\nAlpha text.",
+                    },
+                    {
+                        "file_url": "https://example.com/doc-b.pdf",
+                        "filename": "doc-b.pdf",
+                        "content": "# Doc B\n\nBeta text.",
+                    },
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["success"])
+        data = payload["data"]
+        self.assertEqual(len(data["citations"]), 2)
+        self.assertEqual(len(data["retrieved_blocks"]), 2)
+        filenames = {item["filename"] for item in data["citations"]}
+        self.assertEqual(filenames, {"doc-a.pdf", "doc-b.pdf"})
+        self.assertTrue(all(item.get("quote") for item in data["citations"]))
+        self.assertTrue(all(item.get("file_detail_url") for item in data["citations"]))
 
     @patch('ai_actuarial.chatbot.retrieval.RAGRetriever')
     @patch('openai.OpenAI')

--- a/tests/test_global_chunk_phasea.py
+++ b/tests/test_global_chunk_phasea.py
@@ -192,6 +192,60 @@ class TestGlobalChunkPhaseA(unittest.TestCase):
         self.assertEqual(status_data["data"]["file_count"], 1)
         self.assertGreaterEqual(status_data["data"]["chunk_set_count"], 1)
 
+    def test_composition_status_falls_back_to_legacy_index_records(self):
+        kb_id = "kb_legacy_index_status"
+        create_kb_resp = self.client.post(
+            "/api/rag/knowledge-bases",
+            headers=self.auth_header,
+            json={
+                "kb_id": kb_id,
+                "name": "Legacy Index KB",
+                "kb_mode": "manual",
+            },
+        )
+        if create_kb_resp.status_code == 503:
+            self.skipTest("RAG functionality not available")
+        self.assertEqual(create_kb_resp.status_code, 201)
+
+        add_file_resp = self.client.post(
+            f"/api/rag/knowledge-bases/{kb_id}/files",
+            headers=self.auth_header,
+            json={"file_urls": [self.file_url]},
+        )
+        self.assertEqual(add_file_resp.status_code, 200)
+
+        indexed_at = datetime.now(timezone.utc).isoformat()
+        self.storage._conn.execute(
+            """
+            UPDATE rag_kb_files
+            SET indexed_at = ?, chunk_count = ?
+            WHERE kb_id = ? AND file_url = ?
+            """,
+            (indexed_at, 4, kb_id, self.file_url),
+        )
+        self.storage._conn.execute(
+            """
+            UPDATE rag_knowledge_bases
+            SET chunk_count = ?, updated_at = ?
+            WHERE kb_id = ?
+            """,
+            (4, indexed_at, kb_id),
+        )
+        self.storage._conn.commit()
+
+        status_resp = self.client.get(
+            f"/api/rag/knowledge-bases/{kb_id}/composition/status",
+            headers=self.auth_header,
+        )
+        self.assertEqual(status_resp.status_code, 200)
+        payload = status_resp.get_json()["data"]
+        self.assertTrue(payload["has_index"])
+        self.assertFalse(payload["needs_reindex"])
+        self.assertEqual(payload["file_count"], 1)
+        self.assertEqual(payload["indexed_file_count"], 1)
+        self.assertEqual(payload["pending_file_count"], 0)
+        self.assertEqual(payload["latest_index"]["source"], "legacy")
+
     def test_chunk_profile_delete_endpoint_removes_profile(self):
         profile_resp = self.client.post(
             "/api/chunk/profiles",

--- a/tests/test_task_history_api.py
+++ b/tests/test_task_history_api.py
@@ -1,0 +1,133 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import types
+import unittest
+
+import yaml
+
+if "schedule" not in sys.modules:
+    sys.modules["schedule"] = types.ModuleType("schedule")
+
+import ai_actuarial.web.app as web_app_module
+from ai_actuarial.web.app import FLASK_AVAILABLE, create_app
+
+
+class TestTaskHistoryApi(unittest.TestCase):
+    def setUp(self):
+        if not FLASK_AVAILABLE:
+            self.skipTest("Flask is not installed")
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+        self.config_path = os.path.join(self.temp_dir, "sites.yaml")
+        self.categories_path = os.path.join(self.temp_dir, "categories.yaml")
+
+        config_data = {
+            "paths": {
+                "db": self.db_path,
+                "download_dir": os.path.join(self.temp_dir, "files"),
+                "updates_dir": os.path.join(self.temp_dir, "updates"),
+                "last_run_new": os.path.join(self.temp_dir, "last_run_new.json"),
+            },
+            "defaults": {
+                "user_agent": "test-agent/1.0",
+                "max_pages": 5,
+                "max_depth": 1,
+                "file_exts": [".pdf"],
+                "keywords": ["actuarial"],
+            },
+            "sites": [],
+        }
+        categories_data = {"categories": {"General": ["test"]}}
+
+        with open(self.config_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(config_data, f, sort_keys=False, allow_unicode=True)
+        with open(self.categories_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(categories_data, f, sort_keys=False, allow_unicode=True)
+
+        self.original_env = dict(os.environ)
+        os.environ["CONFIG_PATH"] = self.config_path
+        os.environ["CATEGORIES_CONFIG_PATH"] = self.categories_path
+        os.environ["FLASK_SECRET_KEY"] = "test-task-history-secret"
+        os.environ["REQUIRE_AUTH"] = "false"
+        os.environ["RAG_DATA_DIR"] = os.path.join(self.temp_dir, "rag_data")
+
+        self.original_history = list(web_app_module._task_history)
+        self.original_active = dict(web_app_module._active_tasks)
+        with web_app_module._task_lock:
+            web_app_module._task_history.clear()
+            web_app_module._active_tasks.clear()
+
+        self.app = create_app({"TESTING": True, "DEBUG": True})
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        with web_app_module._task_lock:
+            web_app_module._task_history.clear()
+            web_app_module._task_history.extend(self.original_history)
+            web_app_module._active_tasks.clear()
+            web_app_module._active_tasks.update(self.original_active)
+
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+        for _ in range(10):
+            try:
+                shutil.rmtree(self.temp_dir)
+                break
+            except PermissionError:
+                time.sleep(0.1)
+
+    def test_history_includes_display_summary_for_task_types(self):
+        with web_app_module._task_lock:
+            web_app_module._task_history.extend(
+                [
+                    {
+                        "id": "task_md_1",
+                        "name": "Markdown Batch",
+                        "type": "markdown_conversion",
+                        "status": "partial",
+                        "started_at": "2026-03-11T10:00:00",
+                        "completed_at": "2026-03-11T10:05:00",
+                        "items_processed": 3,
+                        "items_downloaded": 1,
+                        "items_skipped": 1,
+                        "errors": ["file-3 failed"],
+                    },
+                    {
+                        "id": "task_rag_1",
+                        "name": "KB Index",
+                        "type": "rag_indexing",
+                        "status": "completed",
+                        "started_at": "2026-03-11T09:00:00",
+                        "completed_at": "2026-03-11T09:04:00",
+                        "items_processed": 4,
+                        "items_downloaded": 4,
+                        "items_skipped": 0,
+                        "errors": [],
+                        "rag_total_chunks": 27,
+                        "rag_error_files": 0,
+                    },
+                ]
+            )
+
+        response = self.client.get("/api/tasks/history?limit=10")
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.data)
+        self.assertIn("tasks", payload)
+        self.assertEqual(len(payload["tasks"]), 2)
+
+        markdown_task = next(task for task in payload["tasks"] if task["type"] == "markdown_conversion")
+        self.assertEqual(markdown_task["error_count"], 1)
+        self.assertEqual(markdown_task["display_summary"]["primary"]["label"], "Converted")
+        self.assertEqual(markdown_task["display_summary"]["primary"]["value"], 1)
+        self.assertEqual(markdown_task["display_summary"]["secondary"][0]["label"], "Skipped")
+
+        rag_task = next(task for task in payload["tasks"] if task["type"] == "rag_indexing")
+        self.assertEqual(rag_task["display_summary"]["primary"]["label"], "Indexed Files")
+        self.assertEqual(rag_task["display_summary"]["primary"]["value"], 4)
+        self.assertEqual(rag_task["display_summary"]["secondary"][2]["value"], 27)


### PR DESCRIPTION
## Summary
- unify task history/status summaries so tasks, settings, and KB task history consume backend-owned display data
- fix KB composition/index status fallback so legacy indexed KBs show aligned index state in RAG detail views
- wire chat document explain/list/citation flows, including multi-document sources and quote rendering
- add task/KB/chat smoke checklist documentation and targeted regression coverage

## Validation
- page/API smoke for tasks, RAG list/detail, and chat documented in `docs/????-2026-03-11-task-kb-chat-smoke-checklist.md`
- real local `POST /api/chat/query` smoke with `.env` API key returned 200 with citation and quote
- `.venv\\Scripts\\python.exe -m py_compile ai_actuarial/web/app.py ai_actuarial/web/chat_routes.py ai_actuarial/storage.py`