### PR TITLE
feat: migrate knowledge management to fastapi

### DIFF
--- a/ai_actuarial/api/app.py
+++ b/ai_actuarial/api/app.py
@@ -15,6 +15,7 @@ from .route_inventory import (
 )
 from .routers.files_write import router as files_write_router
 from .routers.meta import router as meta_router
+from .routers.rag_admin import router as rag_admin_router
 from .routers.migration import router as migration_router
 from .routers.ops_read import router as ops_read_router
 from .routers.ops_write import router as ops_write_router
@@ -65,6 +66,7 @@ def create_app() -> FastAPI:
     app.include_router(ops_read_router, prefix="/api", tags=["ops-read"])
     app.include_router(ops_write_router, prefix="/api", tags=["ops-write"])
     app.include_router(files_write_router, prefix="/api", tags=["files-write"])
+    app.include_router(rag_admin_router, prefix="/api", tags=["rag-admin"])
 
     app.state.legacy_backend = "flask"
     app.state.legacy_mount_enabled = False

--- a/ai_actuarial/api/routers/rag_admin.py
+++ b/ai_actuarial/api/routers/rag_admin.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 from ..deps import AuthContext, require_permissions
 from ..services.rag_admin import (
     RagAdminError,
+    add_knowledge_base_files,
     bind_chunk_sets,
     cleanup_chunk_sets,
     create_chunk_profile,
@@ -22,6 +23,7 @@ from ..services.rag_admin import (
     list_knowledge_base_files,
     list_knowledge_bases,
     list_selectable_files,
+    remove_knowledge_base_file,
     set_knowledge_base_categories,
     update_knowledge_base,
 )
@@ -173,6 +175,32 @@ def api_list_knowledge_base_files(
 ):
     try:
         return list_knowledge_base_files(db_path=_db_path(request), kb_id=kb_id, query=request.query_params)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.post("/rag/knowledge-bases/{kb_id}/files")
+def api_add_knowledge_base_files(
+    kb_id: str,
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return add_knowledge_base_files(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.delete("/rag/knowledge-bases/{kb_id}/files/{file_url:path}")
+def api_remove_knowledge_base_file(
+    kb_id: str,
+    file_url: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return remove_knowledge_base_file(db_path=_db_path(request), kb_id=kb_id, file_url=file_url, headers=dict(request.headers))
     except RagAdminError as exc:
         return _error_response(exc)
 

--- a/ai_actuarial/api/routers/rag_admin.py
+++ b/ai_actuarial/api/routers/rag_admin.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from ..deps import AuthContext, require_permissions
+from ..services.rag_admin import (
+    RagAdminError,
+    bind_chunk_sets,
+    cleanup_chunk_sets,
+    create_chunk_profile,
+    create_index_task,
+    create_knowledge_base,
+    delete_chunk_profile,
+    delete_knowledge_base,
+    get_knowledge_base,
+    get_knowledge_base_categories,
+    get_knowledge_base_stats,
+    get_pending_files,
+    get_unmapped_categories,
+    list_chunk_profiles,
+    list_knowledge_base_files,
+    list_knowledge_bases,
+    list_selectable_files,
+    set_knowledge_base_categories,
+    update_knowledge_base,
+)
+
+router = APIRouter()
+
+
+def _db_path(request: Request) -> str:
+    db_path = str(getattr(request.app.state, "db_path", "") or "")
+    if not db_path:
+        raise HTTPException(status_code=500, detail="Database path is unavailable")
+    return db_path
+
+
+def _bridge_state(request: Request):
+    return request.app.state
+
+
+def _error_response(exc: RagAdminError) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content={"error": exc.message})
+
+
+@router.get("/chunk/profiles")
+def api_chunk_profiles(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return list_chunk_profiles(db_path=_db_path(request))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.post("/chunk/profiles")
+def api_create_chunk_profile(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        result = create_chunk_profile(db_path=_db_path(request), payload=payload, headers=dict(request.headers))
+        return JSONResponse(status_code=201, content=result)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.delete("/chunk/profiles/{profile_id}")
+def api_delete_chunk_profile(
+    profile_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return delete_chunk_profile(db_path=_db_path(request), profile_id=profile_id, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.post("/chunk-sets/cleanup")
+def api_chunk_sets_cleanup(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return cleanup_chunk_sets(db_path=_db_path(request), payload=payload, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/knowledge-bases")
+def api_list_knowledge_bases(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return list_knowledge_bases(db_path=_db_path(request), query=request.query_params)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.post("/rag/knowledge-bases")
+def api_create_knowledge_base(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        result = create_knowledge_base(db_path=_db_path(request), payload=payload, headers=dict(request.headers))
+        return JSONResponse(status_code=201, content=result)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/knowledge-bases/{kb_id}")
+def api_get_knowledge_base(
+    kb_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return get_knowledge_base(db_path=_db_path(request), kb_id=kb_id)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.put("/rag/knowledge-bases/{kb_id}")
+def api_update_knowledge_base(
+    kb_id: str,
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return update_knowledge_base(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.delete("/rag/knowledge-bases/{kb_id}")
+def api_delete_knowledge_base(
+    kb_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return delete_knowledge_base(db_path=_db_path(request), kb_id=kb_id, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/knowledge-bases/{kb_id}/stats")
+def api_get_knowledge_base_stats(
+    kb_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return get_knowledge_base_stats(db_path=_db_path(request), kb_id=kb_id)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/knowledge-bases/{kb_id}/files")
+def api_list_knowledge_base_files(
+    kb_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return list_knowledge_base_files(db_path=_db_path(request), kb_id=kb_id, query=request.query_params)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/categories/unmapped")
+def api_unmapped_categories(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return get_unmapped_categories(db_path=_db_path(request))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/files/selectable")
+def api_selectable_files(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return list_selectable_files(db_path=_db_path(request), query=request.query_params)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/knowledge-bases/{kb_id}/categories")
+def api_get_kb_categories(
+    kb_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return get_knowledge_base_categories(db_path=_db_path(request), kb_id=kb_id)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.post("/rag/knowledge-bases/{kb_id}/categories")
+def api_set_kb_categories(
+    kb_id: str,
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return set_knowledge_base_categories(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/knowledge-bases/{kb_id}/files/pending")
+def api_pending_files(
+    kb_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return get_pending_files(db_path=_db_path(request), kb_id=kb_id)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.post("/rag/knowledge-bases/{kb_id}/bindings")
+def api_bind_chunk_sets(
+    kb_id: str,
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return bind_chunk_sets(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.post("/rag/knowledge-bases/{kb_id}/index")
+def api_create_index_task(
+    kb_id: str,
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("tasks.run")),
+):
+    try:
+        result, status_code = create_index_task(
+            db_path=_db_path(request),
+            kb_id=kb_id,
+            payload=payload,
+            headers=dict(request.headers),
+            bridge_state=_bridge_state(request),
+        )
+        return JSONResponse(status_code=status_code, content=result)
+    except RagAdminError as exc:
+        return _error_response(exc)

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -1,0 +1,670 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Mapping
+
+from ai_actuarial.storage import Storage
+from ai_actuarial.web.app import _parse_int_clamped
+
+
+class RagAdminError(Exception):
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+
+def _manager_and_storage(db_path: str):
+    try:
+        from ai_actuarial.rag.knowledge_base import KnowledgeBase, KnowledgeBaseManager
+    except ImportError as exc:  # noqa: BLE001
+        raise RagAdminError("RAG functionality not available", status_code=503) from exc
+
+    storage = Storage(db_path)
+    manager = KnowledgeBaseManager(storage)
+    return KnowledgeBase, manager, storage
+
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip()
+
+
+
+def _list(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RagAdminError(f"{field} must be a list")
+    out: list[str] = []
+    for item in value:
+        normalized = _norm(item)
+        if normalized and normalized not in out:
+            out.append(normalized)
+    return out
+
+
+
+def _kb_id(value: Any) -> str:
+    kb_id = _norm(value)
+    if not kb_id:
+        raise RagAdminError("kb_id is required")
+    if not (2 <= len(kb_id) <= 64):
+        raise RagAdminError("kb_id must be between 2 and 64 characters long")
+    return kb_id
+
+
+
+def _serialize_kb(kb: Any) -> dict[str, Any]:
+    return {
+        "kb_id": kb.kb_id,
+        "name": kb.name,
+        "description": kb.description,
+        "kb_mode": kb.kb_mode,
+        "embedding_provider": getattr(kb, "embedding_provider", "openai"),
+        "embedding_model": kb.embedding_model,
+        "embedding_dimension": getattr(kb, "embedding_dimension", None),
+        "chunk_size": kb.chunk_size,
+        "chunk_overlap": kb.chunk_overlap,
+        "index_type": kb.index_type,
+        "file_count": kb.file_count,
+        "chunk_count": kb.chunk_count,
+        "created_at": kb.created_at,
+        "updated_at": kb.updated_at,
+    }
+
+
+
+def _require_config_write_token(headers: Mapping[str, str]) -> None:
+    expected_token = os.getenv("CONFIG_WRITE_AUTH_TOKEN")
+    if not expected_token:
+        return
+    provided_token = headers.get("X-Auth-Token") or headers.get("x-auth-token")
+    if not provided_token or provided_token != expected_token:
+        raise RagAdminError("Forbidden", status_code=403)
+
+
+
+def list_chunk_profiles(*, db_path: str) -> dict[str, Any]:
+    storage = Storage(db_path)
+    try:
+        return {"profiles": storage.list_chunk_profiles()}
+    finally:
+        storage.close()
+
+
+
+def create_chunk_profile(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    name = _norm(payload.get("name"))
+    if not name:
+        raise RagAdminError("name is required")
+    chunk_size = _parse_int_clamped(payload.get("chunk_size") or 800, default=800, min_value=1, max_value=10000)
+    chunk_overlap = _parse_int_clamped(payload.get("chunk_overlap") or 100, default=100, min_value=0, max_value=10000)
+    splitter = _norm(payload.get("splitter") or "semantic")
+    tokenizer = _norm(payload.get("tokenizer") or "cl100k_base")
+    version = _norm(payload.get("version") or "v1")
+    metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
+
+    storage = Storage(db_path)
+    try:
+        profile = storage.create_chunk_profile(
+            name=name,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            splitter=splitter,
+            tokenizer=tokenizer,
+            version=version,
+            metadata=metadata,
+            upsert=True,
+        )
+        return {"profile": profile}
+    finally:
+        storage.close()
+
+
+
+def delete_chunk_profile(*, db_path: str, profile_id: str, headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    normalized_profile_id = _norm(profile_id)
+    if not normalized_profile_id:
+        raise RagAdminError("profile_id is required")
+    storage = Storage(db_path)
+    try:
+        deleted = storage.delete_chunk_profile(normalized_profile_id)
+        if not deleted:
+            raise RagAdminError("chunk profile not found", status_code=404)
+        return deleted
+    finally:
+        storage.close()
+
+
+
+def list_knowledge_bases(*, db_path: str, query: Mapping[str, Any]) -> dict[str, Any]:
+    KnowledgeBase, _manager, storage = _manager_and_storage(db_path)
+    try:
+        kb_mode = _norm(query.get("kb_mode"))
+        search = _norm(query.get("search")).lower()
+        cursor = storage._conn.execute(
+            """
+            SELECT kb_id, name, description, kb_mode, embedding_provider, embedding_model, embedding_dimension, chunk_size, chunk_overlap,
+                   index_type, created_at, updated_at, file_count, chunk_count
+            FROM rag_knowledge_bases
+            ORDER BY created_at DESC
+            """
+        )
+        kbs = []
+        for row in cursor.fetchall():
+            kb = KnowledgeBase(
+                kb_id=row[0], name=row[1], description=row[2],
+                kb_mode=row[3] or "category",
+                embedding_provider=row[4] or "openai",
+                embedding_model=row[5], embedding_dimension=row[6],
+                chunk_size=row[7], chunk_overlap=row[8],
+                index_type=row[9], created_at=row[10], updated_at=row[11],
+                file_count=row[12], chunk_count=row[13],
+            )
+            if kb_mode and kb.kb_mode != kb_mode:
+                continue
+            if search and not (
+                search in (kb.name or "").lower()
+                or search in (kb.description or "").lower()
+                or search in (kb.kb_id or "").lower()
+            ):
+                continue
+            kbs.append(_serialize_kb(kb))
+        return {"knowledge_bases": kbs}
+    finally:
+        storage.close()
+
+
+
+def create_knowledge_base(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    kb_id = _kb_id(payload.get("kb_id"))
+    name = _norm(payload.get("name"))
+    if not name:
+        raise RagAdminError("name is required")
+    kb_mode = _norm(payload.get("kb_mode") or "manual").lower()
+    if kb_mode not in {"manual", "category"}:
+        raise RagAdminError("kb_mode must be 'category' or 'manual'")
+    chunk_size = _parse_int_clamped(payload.get("chunk_size") or 800, default=800, min_value=1, max_value=10000)
+    chunk_overlap = _parse_int_clamped(payload.get("chunk_overlap") or 100, default=100, min_value=0, max_value=10000)
+    categories = _list(payload.get("categories"), "categories")
+    file_urls = _list(payload.get("file_urls"), "file_urls")
+    if kb_mode == "category" and not categories:
+        raise RagAdminError("categories required for category mode")
+
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if manager.get_kb(kb_id):
+            raise RagAdminError(f"Knowledge base '{kb_id}' already exists", status_code=409)
+        runtime_embedding = manager.get_current_embedding_metadata()
+        manager.create_kb(
+            kb_id=kb_id,
+            name=name,
+            description=_norm(payload.get("description")),
+            kb_mode=kb_mode,
+            embedding_model=runtime_embedding["model"],
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+        )
+        if kb_mode == "category":
+            manager.link_kb_to_categories(kb_id, categories)
+        elif file_urls:
+            manager.add_files_to_kb(kb_id, file_urls)
+        kb = manager.get_kb(kb_id)
+        return {"knowledge_base": _serialize_kb(kb)}
+    finally:
+        storage.close()
+
+
+
+def get_knowledge_base(*, db_path: str, kb_id: str) -> dict[str, Any]:
+    kid = _kb_id(kb_id)
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        kb = manager.get_kb(kid)
+        if not kb:
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        payload = _serialize_kb(kb)
+        payload["stats"] = manager.get_kb_stats(kid)
+        payload["categories"] = manager.get_kb_categories(kid)
+        return {"knowledge_base": payload}
+    finally:
+        storage.close()
+
+
+
+def update_knowledge_base(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    kid = _kb_id(kb_id)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    name = _norm(payload["name"]) if "name" in payload else None
+    description = _norm(payload["description"]) if "description" in payload else None
+    if name is None and description is None:
+        raise RagAdminError("No valid update fields provided (name, description)")
+
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        manager.update_kb(kid, name=name, description=description)
+        return {"knowledge_base": _serialize_kb(manager.get_kb(kid))}
+    finally:
+        storage.close()
+
+
+
+def delete_knowledge_base(*, db_path: str, kb_id: str, headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    kid = _kb_id(kb_id)
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        manager.delete_kb(kid)
+        return {"success": True, "message": f"Knowledge base '{kid}' deleted successfully"}
+    finally:
+        storage.close()
+
+
+
+def get_knowledge_base_stats(*, db_path: str, kb_id: str) -> dict[str, Any]:
+    kid = _kb_id(kb_id)
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        return manager.get_kb_stats(kid)
+    finally:
+        storage.close()
+
+
+
+def list_knowledge_base_files(*, db_path: str, kb_id: str, query: Mapping[str, Any]) -> dict[str, Any]:
+    kid = _kb_id(kb_id)
+    status_filter = _norm(query.get("status")).lower()
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        bindings = storage.list_kb_chunk_bindings(kid)
+        latest_binding_by_file: dict[str, dict[str, Any]] = {}
+        version_count_cache: dict[tuple[str, str], int] = {}
+        profile_names: set[str] = set()
+        for binding in bindings:
+            file_url = str(binding.get("file_url") or "")
+            if not file_url or file_url in latest_binding_by_file:
+                continue
+            latest_binding_by_file[file_url] = binding
+            profile_name = str(binding.get("profile_name") or binding.get("profile_id") or "").strip()
+            if profile_name:
+                profile_names.add(profile_name)
+
+        rows = []
+        for item in manager.get_kb_files(kid):
+            file_url = item.get("file_url")
+            binding = latest_binding_by_file.get(str(file_url or ""), {})
+            profile_id = str(binding.get("profile_id") or "").strip()
+            cache_key = (str(file_url or ""), profile_id)
+            if cache_key not in version_count_cache:
+                if profile_id:
+                    row = storage._conn.execute(
+                        "SELECT COUNT(*) FROM file_chunk_sets WHERE file_url = ? AND profile_id = ?",
+                        (cache_key[0], profile_id),
+                    ).fetchone()
+                else:
+                    row = storage._conn.execute(
+                        "SELECT COUNT(*) FROM file_chunk_sets WHERE file_url = ?",
+                        (cache_key[0],),
+                    ).fetchone()
+                version_count_cache[cache_key] = int((row[0] if row else 0) or 0)
+            indexed = item.get("indexed_at") is not None
+            stale = bool(item.get("needs_reindex"))
+            status = "indexed" if indexed and not stale else ("stale" if indexed else "pending")
+            rows.append(
+                {
+                    "file_url": file_url,
+                    "title": item.get("title") or "",
+                    "category": item.get("category") or "",
+                    "source_site": item.get("source_site") or "",
+                    "added_at": item.get("added_at"),
+                    "indexed_at": item.get("indexed_at"),
+                    "markdown_updated_at": item.get("markdown_updated_at"),
+                    "chunk_count": binding.get("chunk_count") or item.get("chunk_count") or 0,
+                    "chunk_set_id": binding.get("chunk_set_id") or "",
+                    "chunk_version_count": version_count_cache.get(cache_key, 0),
+                    "chunk_set_updated_at": binding.get("chunk_set_updated_at") or binding.get("bound_at"),
+                    "bound_at": binding.get("bound_at"),
+                    "chunk_profile": binding.get("profile_name") or binding.get("profile_id") or "",
+                    "indexed": indexed,
+                    "needs_reindex": stale,
+                    "status": status,
+                }
+            )
+        if status_filter:
+            rows = [row for row in rows if row.get("status") == status_filter]
+        profile_summary = "-"
+        if len(profile_names) == 1:
+            profile_summary = next(iter(profile_names))
+        elif len(profile_names) > 1:
+            profile_summary = f"Mixed ({len(profile_names)})"
+        return {
+            "kb_id": kid,
+            "total_files": len(rows),
+            "files": rows,
+            "profile_summary": profile_summary,
+        }
+    finally:
+        storage.close()
+
+
+
+def get_unmapped_categories(*, db_path: str) -> dict[str, Any]:
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        rows = manager.get_unmapped_categories()
+        return {
+            "unmapped_categories": [
+                {"name": row.get("category"), "file_count": row.get("file_count") or 0}
+                for row in rows
+            ],
+            "total_count": len(rows),
+        }
+    finally:
+        storage.close()
+
+
+
+def list_selectable_files(*, db_path: str, query: Mapping[str, Any]) -> dict[str, Any]:
+    q = _norm(query.get("query")).lower()
+    category = _norm(query.get("category"))
+    kb_id_raw = _norm(query.get("kb_id"))
+    kb_id = _kb_id(kb_id_raw) if kb_id_raw else ""
+    limit = _parse_int_clamped(query.get("limit") or 100, default=100, min_value=1, max_value=500)
+    offset = _parse_int_clamped(query.get("offset") or 0, default=0, min_value=0, max_value=1_000_000)
+
+    storage = Storage(db_path)
+    try:
+        conn = storage._conn
+        where_parts = [
+            "f.deleted_at IS NULL",
+            "c.markdown_content IS NOT NULL",
+            "c.markdown_content != ''",
+        ]
+        params: list[Any] = []
+        if q:
+            where_parts.append("(LOWER(f.title) LIKE ? OR LOWER(f.original_filename) LIKE ? OR LOWER(f.url) LIKE ?)")
+            wildcard = f"%{q}%"
+            params.extend([wildcard, wildcard, wildcard])
+        if category:
+            where_parts.append("(c.category = ? OR c.category LIKE ? OR c.category LIKE ? OR c.category LIKE ?)")
+            params.extend([category, f"{category};%", f"%; {category}", f"%; {category};%"])
+        if kb_id:
+            row = conn.execute("SELECT 1 FROM rag_knowledge_bases WHERE kb_id = ?", [kb_id]).fetchone()
+            if not row:
+                raise RagAdminError(f"Knowledge base '{kb_id}' not found", status_code=404)
+            where_parts.append("NOT EXISTS (SELECT 1 FROM rag_kb_files kf WHERE kf.kb_id = ? AND kf.file_url = f.url)")
+            params.append(kb_id)
+        where_sql = " AND ".join(where_parts)
+
+        total = int(
+            conn.execute(
+                f"SELECT COUNT(*) FROM files f JOIN catalog_items c ON c.file_url = f.url WHERE {where_sql}",
+                params,
+            ).fetchone()[0]
+            or 0
+        )
+        rows = conn.execute(
+            f"""
+            SELECT f.url, f.title, f.original_filename, f.source_site, f.bytes, f.last_seen, c.category, c.markdown_updated_at
+            FROM files f
+            JOIN catalog_items c ON c.file_url = f.url
+            WHERE {where_sql}
+            ORDER BY f.last_seen DESC, f.id DESC
+            LIMIT ? OFFSET ?
+            """,
+            params + [limit, offset],
+        ).fetchall()
+        files = [
+            {
+                "url": row[0],
+                "title": row[1] or "",
+                "original_filename": row[2] or "",
+                "source_site": row[3] or "",
+                "bytes": row[4] or 0,
+                "last_seen": row[5],
+                "category": row[6] or "",
+                "markdown_updated_at": row[7],
+            }
+            for row in rows
+        ]
+        return {"files": files, "total": total, "limit": limit, "offset": offset, "kb_id": kb_id or None}
+    finally:
+        storage.close()
+
+
+
+def get_knowledge_base_categories(*, db_path: str, kb_id: str) -> dict[str, Any]:
+    kid = _kb_id(kb_id)
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        categories = manager.get_kb_categories(kid)
+        return {"kb_id": kid, "categories": categories, "count": len(categories)}
+    finally:
+        storage.close()
+
+
+
+def set_knowledge_base_categories(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    kid = _kb_id(kb_id)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    categories = _list(payload.get("categories"), "categories")
+    if not categories:
+        raise RagAdminError("categories must be a non-empty list")
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        before_n = int(manager.get_kb_stats(kid).get("total_files", 0))
+        manager.link_kb_to_categories(kid, categories)
+        after_n = int(manager.get_kb_stats(kid).get("total_files", 0))
+        return {"kb_id": kid, "linked_count": len(categories), "files_added": max(0, after_n - before_n)}
+    finally:
+        storage.close()
+
+
+
+def get_pending_files(*, db_path: str, kb_id: str) -> dict[str, Any]:
+    kid = _kb_id(kb_id)
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        pending = set(manager.get_files_needing_index(kid))
+        rows = []
+        for item in manager.get_kb_files(kid):
+            if item.get("file_url") not in pending:
+                continue
+            rows.append(
+                {
+                    "file_url": item.get("file_url"),
+                    "title": item.get("title") or "",
+                    "category": item.get("category") or "",
+                    "added_at": item.get("added_at"),
+                    "indexed_at": item.get("indexed_at"),
+                    "markdown_updated_at": item.get("markdown_updated_at"),
+                }
+            )
+        return {"kb_id": kid, "pending_count": len(rows), "pending_files": rows}
+    finally:
+        storage.close()
+
+
+
+def bind_chunk_sets(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    kid = _kb_id(kb_id)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    bound_by = _norm(payload.get("bound_by") or "api")
+    default_binding_mode = _norm(payload.get("binding_mode") or "follow_latest").lower()
+    if isinstance(payload.get("bindings"), list):
+        items = payload.get("bindings") or []
+    else:
+        items = [{
+            "file_url": payload.get("file_url"),
+            "chunk_set_id": payload.get("chunk_set_id"),
+            "binding_mode": payload.get("binding_mode") or "follow_latest",
+        }]
+    parsed: list[tuple[str, str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        file_url = _norm(item.get("file_url"))
+        chunk_set_id = _norm(item.get("chunk_set_id"))
+        binding_mode = _norm(item.get("binding_mode") or default_binding_mode or "pin").lower()
+        if file_url and chunk_set_id and binding_mode:
+            parsed.append((file_url, chunk_set_id, binding_mode))
+    if not parsed:
+        raise RagAdminError("bindings must include file_url and chunk_set_id")
+
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        kb = manager.get_kb(kid)
+        if not kb:
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        created_n = 0
+        out: list[dict[str, Any]] = []
+        for file_url, chunk_set_id, binding_mode in parsed:
+            try:
+                res = storage.bind_chunk_set_to_kb(
+                    kb_id=kid,
+                    file_url=file_url,
+                    chunk_set_id=chunk_set_id,
+                    bound_by=bound_by,
+                    binding_mode=binding_mode,
+                )
+            except ValueError as exc:
+                message = str(exc)
+                status_code = 404 if "not found" in message.lower() else 400
+                raise RagAdminError(message, status_code=status_code) from exc
+            if res.get("created"):
+                created_n += 1
+            out.append(res)
+        return {
+            "kb_id": kid,
+            "processed": len(out),
+            "created": created_n,
+            "existing": len(out) - created_n,
+            "bindings": out,
+        }
+    finally:
+        storage.close()
+
+
+
+def create_index_task(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str], bridge_state: Any) -> tuple[dict[str, Any], int]:
+    _require_config_write_token(headers)
+    kid = _kb_id(kb_id)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    force_reindex = bool(payload.get("force_reindex", False) or payload.get("reindex_all", False))
+    incremental = bool(payload.get("incremental", True))
+    requested = _list(payload.get("file_urls"), "file_urls")
+
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        kb = manager.get_kb(kid)
+        if not kb:
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        user_requested = bool(requested)
+        files_to_index = requested
+        if not files_to_index:
+            if force_reindex or not incremental:
+                files_to_index = [row.get("file_url") for row in manager.get_kb_files(kid)]
+                files_to_index = [url for url in files_to_index if url]
+            else:
+                files_to_index = manager.get_files_needing_index(kid)
+        if not files_to_index:
+            raise RagAdminError("No files to index")
+
+        skipped_no_markdown = 0
+        if not user_requested:
+            markdown_urls = set()
+            batch_size = 900
+            for i in range(0, len(files_to_index), batch_size):
+                batch = files_to_index[i:i + batch_size]
+                placeholders = ",".join(["?" for _ in batch])
+                rows = storage._conn.execute(
+                    f"""
+                    SELECT DISTINCT file_url FROM catalog_items
+                    WHERE file_url IN ({placeholders})
+                      AND markdown_content IS NOT NULL
+                      AND markdown_content != ''
+                    """,
+                    batch,
+                ).fetchall()
+                markdown_urls.update(row[0] for row in rows if row and row[0])
+            original_count = len(files_to_index)
+            files_to_index = [url for url in files_to_index if url in markdown_urls]
+            skipped_no_markdown = max(0, original_count - len(files_to_index))
+            if not files_to_index:
+                raise RagAdminError("No markdown files to index (all candidates missing markdown)")
+
+        start_background_task = getattr(bridge_state, "legacy_start_background_task", None)
+        if start_background_task is not None:
+            task_id = start_background_task(
+                "rag_indexing",
+                {
+                    "type": "rag_indexing",
+                    "kb_id": kid,
+                    "file_urls": files_to_index,
+                    "force_reindex": force_reindex,
+                    "incremental": incremental,
+                    "name": f"RAG Indexing: {kb.name}",
+                },
+                task_name=f"RAG Indexing: {kb.name}",
+                extra_fields={"kb_id": kid, "kb_name": kb.name, "rag_file_count": len(files_to_index)},
+            )
+        else:
+            task_id = f"rag_index_{kid}_{int(time.time())}"
+
+        return {
+            "job_id": task_id,
+            "kb_id": kid,
+            "file_count": len(files_to_index),
+            "skipped_no_markdown": skipped_no_markdown,
+            "force_reindex": force_reindex,
+            "incremental": incremental,
+        }, 202
+    finally:
+        storage.close()
+
+
+
+def cleanup_chunk_sets(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    older_than_days = _parse_int_clamped(payload.get("older_than_days") or 30, default=30, min_value=1, max_value=3650)
+    limit = _parse_int_clamped(payload.get("limit") or 5000, default=5000, min_value=1, max_value=20000)
+    dry_run = bool(payload.get("dry_run", False))
+
+    storage = Storage(db_path)
+    try:
+        return storage.cleanup_orphan_chunk_sets(older_than_days=older_than_days, limit=limit, dry_run=dry_run)
+    finally:
+        storage.close()

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -368,6 +368,51 @@ def list_knowledge_base_files(*, db_path: str, kb_id: str, query: Mapping[str, A
 
 
 
+def add_knowledge_base_files(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    kid = _kb_id(kb_id)
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    file_urls = _list(payload.get("file_urls"), "file_urls")
+    if not file_urls:
+        raise RagAdminError("file_urls must be a non-empty list")
+
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        result = manager.add_files_to_kb(kid, file_urls)
+        return {
+            "kb_id": kid,
+            "added_count": int(result.get("added_count") or 0),
+            "skipped_count": int(result.get("skipped_count") or 0),
+            "total_files": int(result.get("total_files") or 0),
+        }
+    finally:
+        storage.close()
+
+
+
+def remove_knowledge_base_file(*, db_path: str, kb_id: str, file_url: str, headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    kid = _kb_id(kb_id)
+    normalized_file_url = _norm(file_url)
+    if not normalized_file_url:
+        raise RagAdminError("file_url is required")
+
+    _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
+    try:
+        if not manager.get_kb(kid):
+            raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
+        removed = manager.remove_files_from_kb(kid, [normalized_file_url])
+        if removed <= 0:
+            raise RagAdminError("File not found in knowledge base", status_code=404)
+        return {"kb_id": kid, "removed_count": int(removed), "file_url": normalized_file_url}
+    finally:
+        storage.close()
+
+
+
 def get_unmapped_categories(*, db_path: str) -> dict[str, Any]:
     _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
     try:

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import time
 from typing import Any, Mapping
 
 from ai_actuarial.storage import Storage
@@ -103,8 +102,8 @@ def create_chunk_profile(*, db_path: str, payload: dict[str, Any], headers: Mapp
     name = _norm(payload.get("name"))
     if not name:
         raise RagAdminError("name is required")
-    chunk_size = _parse_int_clamped(payload.get("chunk_size") or 800, default=800, min_value=1, max_value=10000)
-    chunk_overlap = _parse_int_clamped(payload.get("chunk_overlap") or 100, default=100, min_value=0, max_value=10000)
+    chunk_size = _parse_int_clamped(payload.get("chunk_size"), default=800, min_value=1, max_value=10000)
+    chunk_overlap = _parse_int_clamped(payload.get("chunk_overlap"), default=100, min_value=0, max_value=10000)
     splitter = _norm(payload.get("splitter") or "semantic")
     tokenizer = _norm(payload.get("tokenizer") or "cl100k_base")
     version = _norm(payload.get("version") or "v1")
@@ -194,8 +193,8 @@ def create_knowledge_base(*, db_path: str, payload: dict[str, Any], headers: Map
     kb_mode = _norm(payload.get("kb_mode") or "manual").lower()
     if kb_mode not in {"manual", "category"}:
         raise RagAdminError("kb_mode must be 'category' or 'manual'")
-    chunk_size = _parse_int_clamped(payload.get("chunk_size") or 800, default=800, min_value=1, max_value=10000)
-    chunk_overlap = _parse_int_clamped(payload.get("chunk_overlap") or 100, default=100, min_value=0, max_value=10000)
+    chunk_size = _parse_int_clamped(payload.get("chunk_size"), default=800, min_value=1, max_value=10000)
+    chunk_overlap = _parse_int_clamped(payload.get("chunk_overlap"), default=100, min_value=0, max_value=10000)
     categories = _list(payload.get("categories"), "categories")
     file_urls = _list(payload.get("file_urls"), "file_urls")
     if kb_mode == "category" and not categories:
@@ -697,22 +696,22 @@ def create_index_task(*, db_path: str, kb_id: str, payload: dict[str, Any], head
                 raise RagAdminError("No markdown files to index (all candidates missing markdown)")
 
         start_background_task = getattr(bridge_state, "legacy_start_background_task", None)
-        if start_background_task is not None:
-            task_id = start_background_task(
-                "rag_indexing",
-                {
-                    "type": "rag_indexing",
-                    "kb_id": kid,
-                    "file_urls": files_to_index,
-                    "force_reindex": force_reindex,
-                    "incremental": incremental,
-                    "name": f"RAG Indexing: {kb.name}",
-                },
-                task_name=f"RAG Indexing: {kb.name}",
-                extra_fields={"kb_id": kid, "kb_name": kb.name, "rag_file_count": len(files_to_index)},
-            )
-        else:
-            task_id = f"rag_index_{kid}_{int(time.time())}"
+        if start_background_task is None:
+            raise RagAdminError("Task bridge is unavailable", status_code=503)
+
+        task_id = start_background_task(
+            "rag_indexing",
+            {
+                "type": "rag_indexing",
+                "kb_id": kid,
+                "file_urls": files_to_index,
+                "force_reindex": force_reindex,
+                "incremental": incremental,
+                "name": f"RAG Indexing: {kb.name}",
+            },
+            task_name=f"RAG Indexing: {kb.name}",
+            extra_fields={"kb_id": kid, "kb_name": kb.name, "rag_file_count": len(files_to_index)},
+        )
 
         return {
             "job_id": task_id,

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -519,14 +519,41 @@ def set_knowledge_base_categories(*, db_path: str, kb_id: str, payload: dict[str
     categories = _list(payload.get("categories"), "categories")
     if not categories:
         raise RagAdminError("categories must be a non-empty list")
+    action = _norm(payload.get("action") or "add").lower()
+    if action not in {"add", "remove", "replace"}:
+        raise RagAdminError("action must be one of: add, remove, replace")
     _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
     try:
         if not manager.get_kb(kid):
             raise RagAdminError(f"Knowledge base '{kid}' not found", status_code=404)
         before_n = int(manager.get_kb_stats(kid).get("total_files", 0))
+        manager._ensure_category_mapping_table()
+        conn = storage._conn
+        timestamp = _KnowledgeBase._get_timestamp()
+
+        if action == "add":
+            manager.link_kb_to_categories(kid, categories)
+            after_n = int(manager.get_kb_stats(kid).get("total_files", 0))
+            return {"kb_id": kid, "action": action, "linked_count": len(categories), "files_added": max(0, after_n - before_n)}
+
+        if action == "remove":
+            placeholders = ",".join(["?" for _ in categories])
+            deleted = conn.execute(
+                f"DELETE FROM rag_kb_category_mappings WHERE kb_id = ? AND category IN ({placeholders})",
+                [kid, *categories],
+            ).rowcount
+            conn.execute(
+                "UPDATE rag_knowledge_bases SET updated_at = ? WHERE kb_id = ?",
+                (timestamp, kid),
+            )
+            conn.commit()
+            return {"kb_id": kid, "action": action, "removed_count": int(deleted), "categories": manager.get_kb_categories(kid)}
+
+        conn.execute("DELETE FROM rag_kb_category_mappings WHERE kb_id = ?", (kid,))
+        conn.commit()
         manager.link_kb_to_categories(kid, categories)
         after_n = int(manager.get_kb_stats(kid).get("total_files", 0))
-        return {"kb_id": kid, "linked_count": len(categories), "files_added": max(0, after_n - before_n)}
+        return {"kb_id": kid, "action": action, "linked_count": len(categories), "files_added": max(0, after_n - before_n), "categories": manager.get_kb_categories(kid)}
     finally:
         storage.close()
 

--- a/ai_actuarial/rag/knowledge_base.py
+++ b/ai_actuarial/rag/knowledge_base.py
@@ -352,8 +352,8 @@ class KnowledgeBaseManager:
             embedding_provider=current_embedding["provider"],
             embedding_model=current_embedding["model"],
             embedding_dimension=current_embedding["dimension"],
-            chunk_size=chunk_size or self.config.max_chunk_tokens,
-            chunk_overlap=chunk_overlap or 100,
+            chunk_size=chunk_size if chunk_size is not None else self.config.max_chunk_tokens,
+            chunk_overlap=chunk_overlap if chunk_overlap is not None else 100,
             index_type=index_type or self.config.index_type
         )
         

--- a/ai_actuarial/web/app.py
+++ b/ai_actuarial/web/app.py
@@ -186,6 +186,7 @@ _PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED: frozenset[str] = frozenset(
         "tasks.run",
         "tasks.stop",
         "config.read",
+        "config.write",
         "schedule.write",
         "catalog.write",
         "markdown.write",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,8 @@ import { AuthProvider, useAuth } from "@/context/AuthContext";
 import FeatureUnavailable from "@/pages/FeatureUnavailable";
 import FileDetail from "@/pages/FileDetail";
 import FilePreview from "@/pages/FilePreview";
+import KBDetail from "@/pages/KBDetail";
+import Knowledge from "@/pages/Knowledge";
 import NativeLogs from "@/pages/NativeLogs";
 import NativeSettings from "@/pages/NativeSettings";
 import Tasks from "@/pages/Tasks";
@@ -54,12 +56,8 @@ function Router() {
               </Route>
               <Route path="/tasks" component={Tasks} />
               <Route path="/logs" component={NativeLogs} />
-              <Route path="/knowledge/:kbId">
-                <FeatureUnavailable title="Knowledge Bases are not available in FastAPI-native mode" description="Knowledge base management still depends on legacy APIs and is intentionally hidden from the native shell." />
-              </Route>
-              <Route path="/knowledge">
-                <FeatureUnavailable title="Knowledge Bases are not available in FastAPI-native mode" description="Knowledge base management still depends on legacy APIs and is intentionally hidden from the native shell." />
-              </Route>
+              <Route path="/knowledge/:kbId" component={KBDetail} />
+              <Route path="/knowledge" component={Knowledge} />
               <Route path="/settings" component={NativeSettings} />
               <Route path="/users">
                 <FeatureUnavailable title="User management is not available in FastAPI-native mode" description="User management still depends on legacy APIs and is intentionally hidden from the native shell." />

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -31,6 +31,7 @@ const navItems = [
   { path: "/", icon: LayoutDashboard, labelKey: "nav.dashboard" },
   { path: "/database", icon: Database, labelKey: "nav.database" },
   { path: "/tasks", icon: ListTodo, labelKey: "nav.tasks" },
+  { path: "/knowledge", icon: BookOpen, labelKey: "nav.knowledge" },
   { path: "/logs", icon: ScrollText, labelKey: "nav.logs" },
   { path: "/settings", icon: Settings, labelKey: "nav.settings" },
 ];

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   Building2,
   Activity,
   Search,
+  BookOpen,
   ArrowRight,
   FileIcon,
   Inbox,
@@ -164,6 +165,7 @@ export default function Dashboard() {
   const quickActions = [
     { icon: Search, title: t("dashboard.browse_db"), desc: t("dashboard.browse_db_desc"), href: "/database", color: "bg-blue-500/10 text-blue-600 dark:text-blue-400" },
     { icon: Activity, title: t("dashboard.task_center"), desc: t("dashboard.task_center_desc"), href: "/tasks", color: "bg-amber-500/10 text-amber-600 dark:text-amber-400" },
+    { icon: BookOpen, title: t("knowledge.title"), desc: t("knowledge.subtitle"), href: "/knowledge", color: "bg-violet-500/10 text-violet-600 dark:text-violet-400" },
   ];
 
   return (

--- a/client/src/pages/KBDetail.tsx
+++ b/client/src/pages/KBDetail.tsx
@@ -47,6 +47,10 @@ interface KBStats {
   chunk_count?: number;
   pending_count?: number;
   indexed_count?: number;
+  total_files?: number;
+  total_chunks?: number;
+  pending_files?: number;
+  indexed_files?: number;
 }
 
 interface KBFile {
@@ -57,10 +61,16 @@ interface KBFile {
   binding_mode?: string;
   chunk_count?: number;
   profile_name?: string;
+  chunk_profile?: string;
   status?: string;
 }
 
 interface KBCategory {
+  name: string;
+  file_count?: number;
+}
+
+interface UnmappedCategory {
   name: string;
   file_count?: number;
 }
@@ -116,15 +126,21 @@ export default function KBDetail() {
   const [bindableFiles, setBindableFiles] = useState<SelectableFile[]>([]);
   const [bindLoading, setBindLoading] = useState(false);
   const [selectedBindFiles, setSelectedBindFiles] = useState<string[]>([]);
-  const [bindingMode, setBindingMode] = useState<"pin" | "follow_latest">("follow_latest");
   const [bindSubmitting, setBindSubmitting] = useState(false);
 
   const loadMeta = useCallback(async () => {
     if (!kbId) return;
     try {
-      const res = await apiGet<KBMeta | { data: KBMeta }>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}`);
-      const m = (res as { data: KBMeta }).data || (res as KBMeta);
+      const res = await apiGet<{ knowledge_base?: (KBMeta & { stats?: KBStats; categories?: string[] }) }>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}`);
+      const m = res.knowledge_base;
+      if (!m) {
+        setMeta(null);
+        return;
+      }
       setMeta(m);
+      if (m.stats) {
+        setStats(m.stats);
+      }
       setEditName(m.name || "");
       setEditDesc(m.description || "");
     } catch {
@@ -135,8 +151,8 @@ export default function KBDetail() {
   const loadStats = useCallback(async () => {
     if (!kbId) return;
     try {
-      const res = await apiGet<KBStats | { data: KBStats }>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/stats`);
-      setStats((res as { data: KBStats }).data || (res as KBStats));
+      const res = await apiGet<KBStats>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/stats`);
+      setStats(res);
     } catch {
       setStats(null);
     }
@@ -155,14 +171,17 @@ export default function KBDetail() {
   const loadCategories = useCallback(async () => {
     if (!kbId) return;
     try {
-      const res = await apiGet<{ categories?: KBCategory[]; data?: { categories?: KBCategory[] } }>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/categories`);
-      setCategories(res.data?.categories || res.categories || []);
+      const res = await apiGet<{ categories?: Array<string | KBCategory> }>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/categories`);
+      const normalized = (res.categories || []).map((item) =>
+        typeof item === "string" ? { name: item } : { name: item.name, file_count: item.file_count }
+      );
+      setCategories(normalized);
     } catch {
       setCategories([]);
     }
     try {
-      const res2 = await apiGet<{ categories?: string[]; data?: { categories?: string[] } }>("/api/rag/categories/unmapped");
-      setUnmappedCategories(res2.data?.categories || res2.categories || []);
+      const res2 = await apiGet<{ unmapped_categories?: UnmappedCategory[] }>("/api/rag/categories/unmapped");
+      setUnmappedCategories((res2.unmapped_categories || []).map((item) => item.name).filter(Boolean));
     } catch {
       setUnmappedCategories([]);
     }
@@ -219,18 +238,6 @@ export default function KBDetail() {
     }
   };
 
-  const handleRemoveCategory = async (cat: string) => {
-    try {
-      await apiPost(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/categories`, {
-        categories: [cat],
-        action: "remove",
-      });
-      await loadCategories();
-    } catch (err) {
-      console.error("Failed to remove category:", err);
-    }
-  };
-
   const handleBuildIndex = async (force: boolean) => {
     setIndexing(true);
     try {
@@ -248,11 +255,19 @@ export default function KBDetail() {
     setBindLoading(true);
     try {
       const params = new URLSearchParams();
-      if (query) params.set("q", query);
+      if (query) params.set("query", query);
+      params.set("kb_id", kbId);
       params.set("limit", "50");
       const url = `/api/rag/files/selectable?${params.toString()}`;
-      const res = await apiGet<{ files?: SelectableFile[]; data?: { files?: SelectableFile[] } }>(url);
-      setBindableFiles(res.data?.files || res.files || []);
+      const res = await apiGet<{ files?: Array<SelectableFile & { url?: string }> }>(url);
+      setBindableFiles(
+        (res.files || []).map((file) => ({
+          file_url: file.file_url || file.url || "",
+          title: file.title,
+          category: file.category,
+          source_site: file.source_site,
+        })).filter((file) => file.file_url)
+      );
     } catch {
       setBindableFiles([]);
     } finally {
@@ -264,7 +279,6 @@ export default function KBDetail() {
     setShowBindDialog(true);
     setBindSearch("");
     setSelectedBindFiles([]);
-    setBindingMode("follow_latest");
     handleSearchBindable();
   };
 
@@ -278,15 +292,14 @@ export default function KBDetail() {
     if (selectedBindFiles.length === 0) return;
     setBindSubmitting(true);
     try {
-      await apiPost(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/bindings`, {
+      await apiPost(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/files`, {
         file_urls: selectedBindFiles,
-        binding_mode: bindingMode,
       });
       setShowBindDialog(false);
       setSelectedBindFiles([]);
       await Promise.all([loadFiles(), loadStats()]);
     } catch (err) {
-      console.error("Failed to bind files:", err);
+      console.error("Failed to add files to KB:", err);
     } finally {
       setBindSubmitting(false);
     }
@@ -295,8 +308,8 @@ export default function KBDetail() {
   const loadPendingFiles = async () => {
     setLoadingPending(true);
     try {
-      const res = await apiGet<{ files?: KBFile[]; data?: { files?: KBFile[] } }>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/files/pending`);
-      setPendingFiles(res.data?.files || res.files || []);
+      const res = await apiGet<{ pending_files?: KBFile[] }>(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/files/pending`);
+      setPendingFiles(res.pending_files || []);
       setShowPendingFiles(true);
     } catch (err) {
       console.error("Failed to load pending files:", err);
@@ -343,7 +356,7 @@ export default function KBDetail() {
     );
   });
 
-  const pendingCount = stats?.pending_count ?? 0;
+  const pendingCount = stats?.pending_count ?? stats?.pending_files ?? 0;
 
   return (
     <div className="space-y-6">
@@ -435,9 +448,9 @@ export default function KBDetail() {
         className="grid grid-cols-2 sm:grid-cols-4 gap-3"
       >
         {[
-          { label: t("kb.stat_files"), value: stats?.file_count ?? meta.file_count ?? 0, icon: FileText, color: "text-blue-500" },
-          { label: t("kb.stat_chunks"), value: stats?.chunk_count ?? meta.chunk_count ?? 0, icon: Layers, color: "text-violet-500" },
-          { label: t("kb.stat_indexed"), value: stats?.indexed_count ?? 0, icon: CheckCircle2, color: "text-emerald-500" },
+          { label: t("kb.stat_files"), value: stats?.file_count ?? stats?.total_files ?? meta.file_count ?? 0, icon: FileText, color: "text-blue-500" },
+          { label: t("kb.stat_chunks"), value: stats?.chunk_count ?? stats?.total_chunks ?? meta.chunk_count ?? 0, icon: Layers, color: "text-violet-500" },
+          { label: t("kb.stat_indexed"), value: stats?.indexed_count ?? stats?.indexed_files ?? 0, icon: CheckCircle2, color: "text-emerald-500" },
           { label: t("kb.stat_pending"), value: pendingCount, icon: Clock, color: pendingCount > 0 ? "text-amber-500" : "text-muted-foreground" },
         ].map((s, i) => (
           <div key={i} className="rounded-xl border border-border bg-card p-4" data-testid={`stat-card-${i}`}>
@@ -621,13 +634,6 @@ export default function KBDetail() {
                   {cat.file_count != null && (
                     <span className="text-[10px] text-primary/60">({cat.file_count})</span>
                   )}
-                  <button
-                    onClick={() => handleRemoveCategory(cat.name)}
-                    className="ml-0.5 opacity-0 group-hover:opacity-100 hover:text-red-500 transition-all"
-                    data-testid={`button-remove-category-${cat.name}`}
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
                 </span>
               ))
             )}
@@ -698,8 +704,8 @@ export default function KBDetail() {
                           {file.category}
                         </span>
                       )}
-                      {file.profile_name && (
-                        <span className="font-mono">{file.profile_name}</span>
+                      {(file.profile_name || file.chunk_profile) && (
+                        <span className="font-mono">{file.profile_name || file.chunk_profile}</span>
                       )}
                       {file.chunk_count != null && (
                         <span>{file.chunk_count} chunks</span>
@@ -776,34 +782,6 @@ export default function KBDetail() {
                 >
                   {bindLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />}
                 </button>
-              </div>
-
-              <div className="flex items-center gap-4 mt-3">
-                <span className="text-xs text-muted-foreground">{t("kb.binding_mode")}:</span>
-                <label className="flex items-center gap-1.5 text-xs cursor-pointer">
-                  <input
-                    type="radio"
-                    name="bindingMode"
-                    value="follow_latest"
-                    checked={bindingMode === "follow_latest"}
-                    onChange={() => setBindingMode("follow_latest")}
-                    className="accent-primary"
-                    data-testid="radio-bind-follow-latest"
-                  />
-                  {t("kb.follow_latest")}
-                </label>
-                <label className="flex items-center gap-1.5 text-xs cursor-pointer">
-                  <input
-                    type="radio"
-                    name="bindingMode"
-                    value="pin"
-                    checked={bindingMode === "pin"}
-                    onChange={() => setBindingMode("pin")}
-                    className="accent-primary"
-                    data-testid="radio-bind-pin"
-                  />
-                  {t("kb.pinned")}
-                </label>
               </div>
             </div>
 

--- a/client/src/pages/KBDetail.tsx
+++ b/client/src/pages/KBDetail.tsx
@@ -238,6 +238,18 @@ export default function KBDetail() {
     }
   };
 
+  const handleRemoveCategory = async (cat: string) => {
+    try {
+      await apiPost(`/api/rag/knowledge-bases/${encodeURIComponent(kbId)}/categories`, {
+        categories: [cat],
+        action: "remove",
+      });
+      await loadCategories();
+    } catch (err) {
+      console.error("Failed to remove category:", err);
+    }
+  };
+
   const handleBuildIndex = async (force: boolean) => {
     setIndexing(true);
     try {
@@ -634,6 +646,13 @@ export default function KBDetail() {
                   {cat.file_count != null && (
                     <span className="text-[10px] text-primary/60">({cat.file_count})</span>
                   )}
+                  <button
+                    onClick={() => handleRemoveCategory(cat.name)}
+                    className="ml-0.5 opacity-0 group-hover:opacity-100 hover:text-red-500 transition-all"
+                    data-testid={`button-remove-category-${cat.name}`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
                 </span>
               ))
             )}

--- a/client/src/pages/Knowledge.tsx
+++ b/client/src/pages/Knowledge.tsx
@@ -138,12 +138,15 @@ export default function Knowledge() {
         const kbList: KnowledgeBase[] = kbPayload?.knowledge_bases || kbPayload?.data?.knowledge_bases || [];
         setKbs(kbList);
 
-        const profRaw = profileResp?.data;
-        const pList: ChunkProfile[] = Array.isArray(profRaw)
-          ? profRaw
-          : Array.isArray((profRaw as Record<string, unknown>)?.profiles)
-            ? (profRaw as Record<string, unknown>).profiles as ChunkProfile[]
-            : [];
+        const profilePayload = profileResp as { profiles?: ChunkProfile[]; data?: ChunkProfile[] | { profiles?: ChunkProfile[] } } | null;
+        const legacyProfiles = profilePayload?.data;
+        const pList: ChunkProfile[] = Array.isArray(profilePayload?.profiles)
+          ? profilePayload.profiles
+          : Array.isArray(legacyProfiles)
+            ? legacyProfiles
+            : Array.isArray((legacyProfiles as Record<string, unknown> | undefined)?.profiles)
+              ? ((legacyProfiles as Record<string, unknown>).profiles as ChunkProfile[])
+              : [];
         setProfiles(pList);
 
         if (aiResp) {

--- a/client/src/pages/Knowledge.tsx
+++ b/client/src/pages/Knowledge.tsx
@@ -134,8 +134,8 @@ export default function Knowledge() {
       apiGet<Record<string, unknown>>("/api/config/ai-models").catch(() => null),
     ])
       .then(([kbResp, profileResp, aiResp]) => {
-        const kbRaw = kbResp?.data;
-        const kbList: KnowledgeBase[] = Array.isArray(kbRaw) ? kbRaw : [];
+        const kbPayload = kbResp as { knowledge_bases?: KnowledgeBase[]; data?: { knowledge_bases?: KnowledgeBase[] } } | null;
+        const kbList: KnowledgeBase[] = kbPayload?.knowledge_bases || kbPayload?.data?.knowledge_bases || [];
         setKbs(kbList);
 
         const profRaw = profileResp?.data;

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from ai_actuarial.api.app import create_app
+from ai_actuarial.storage import Storage
+
+PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+
+def _write_config_files(base_dir: Path) -> tuple[Path, Path, Path, Path]:
+    files_dir = base_dir / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    db_path = base_dir / "index.db"
+    config_path = base_dir / "sites.yaml"
+    categories_path = base_dir / "categories.yaml"
+
+    config = {
+        "paths": {
+            "db": str(db_path),
+            "download_dir": str(files_dir),
+            "updates_dir": str(base_dir / "updates"),
+            "last_run_new": str(base_dir / "last_run_new.json"),
+        },
+        "defaults": {
+            "user_agent": "test-agent/1.0",
+            "max_pages": 10,
+            "max_depth": 1,
+            "file_exts": [".pdf", ".docx"],
+        },
+        "sites": [],
+        "scheduled_tasks": [],
+    }
+    categories = {"categories": {"AI": ["artificial intelligence"], "Risk": ["capital"]}}
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    categories_path.write_text(yaml.safe_dump(categories, sort_keys=False), encoding="utf-8")
+    return db_path, config_path, categories_path, files_dir
+
+
+
+def _seed_storage(db_path: Path, files_dir: Path) -> dict[str, str]:
+    alpha_path = files_dir / "alpha.pdf"
+    alpha_path.write_bytes(PDF_BYTES)
+    beta_path = files_dir / "beta.pdf"
+    beta_path.write_bytes(PDF_BYTES + b"\n% beta")
+
+    storage = Storage(str(db_path))
+    try:
+        alpha_url = "https://alpha.example/doc-a.pdf"
+        beta_url = "https://beta.example/doc-b.pdf"
+        alpha_sha = hashlib.sha256(alpha_path.read_bytes()).hexdigest()
+        beta_sha = hashlib.sha256(beta_path.read_bytes()).hexdigest()
+
+        storage.insert_file(
+            url=alpha_url,
+            sha256=alpha_sha,
+            title="Alpha Document",
+            source_site="alpha.example",
+            source_page_url="https://alpha.example",
+            original_filename="doc-a.pdf",
+            local_path=str(alpha_path),
+            bytes=alpha_path.stat().st_size,
+            content_type="application/pdf",
+        )
+        storage.insert_file(
+            url=beta_url,
+            sha256=beta_sha,
+            title="Beta Document",
+            source_site="beta.example",
+            source_page_url="https://beta.example",
+            original_filename="doc-b.pdf",
+            local_path=str(beta_path),
+            bytes=beta_path.stat().st_size,
+            content_type="application/pdf",
+        )
+
+        storage.upsert_catalog_item(
+            item={
+                "url": alpha_url,
+                "sha256": alpha_sha,
+                "keywords": ["ai"],
+                "summary": "Alpha summary",
+                "category": "AI",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+        storage.upsert_catalog_item(
+            item={
+                "url": beta_url,
+                "sha256": beta_sha,
+                "keywords": ["risk"],
+                "summary": "Beta summary",
+                "category": "Risk",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+        storage.update_file_markdown(alpha_url, "# Alpha\n\nAlpha markdown.", "manual")
+        storage.update_file_markdown(beta_url, "# Beta\n\nBeta markdown.", "manual")
+    finally:
+        storage.close()
+
+    return {"alpha_url": alpha_url, "beta_url": beta_url}
+
+
+
+def _build_test_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, object, dict[str, str]]:
+    db_path, config_path, categories_path, files_dir = _write_config_files(tmp_path)
+    seed = _seed_storage(db_path, files_dir)
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("CATEGORIES_CONFIG_PATH", str(categories_path))
+    monkeypatch.setenv("FLASK_SECRET_KEY", "fastapi-rag-admin-test-secret")
+    monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+    app = create_app()
+    client = TestClient(app)
+    return client, app, seed
+
+
+
+def test_fastapi_rag_admin_routes_are_listed_in_native_inventory(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    migration = client.get("/api/migration/status")
+    body = migration.json()
+
+    assert "/api/chunk/profiles" in body["native_paths"]
+    assert "/api/chunk/profiles/{profile_id}" in body["native_paths"]
+    assert "/api/rag/knowledge-bases" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}/stats" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}/files" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}/categories" in body["native_paths"]
+    assert "/api/rag/categories/unmapped" in body["native_paths"]
+    assert "/api/rag/files/selectable" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}/files/pending" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}/bindings" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}/index" in body["native_paths"]
+    assert "/api/chunk-sets/cleanup" in body["native_paths"]
+
+
+
+def test_fastapi_rag_admin_chunk_profiles_and_kb_crud_work(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    create_profile = client.post(
+        "/api/chunk/profiles",
+        json={
+            "name": "default-profile",
+            "chunk_size": 300,
+            "chunk_overlap": 50,
+            "splitter": "semantic",
+            "tokenizer": "cl100k_base",
+            "version": "v1",
+        },
+    )
+    assert create_profile.status_code == 201, create_profile.text
+    profile = create_profile.json()["profile"]
+    profile_id = profile["profile_id"]
+
+    list_profiles = client.get("/api/chunk/profiles")
+    assert list_profiles.status_code == 200, list_profiles.text
+    assert any(item["profile_id"] == profile_id for item in list_profiles.json()["profiles"])
+
+    create_kb = client.post(
+        "/api/rag/knowledge-bases",
+        json={
+            "kb_id": "kb-pr4-test",
+            "name": "PR4 Test KB",
+            "description": "Knowledge base for FastAPI PR4",
+            "kb_mode": "manual",
+            "chunk_size": 300,
+            "chunk_overlap": 50,
+            "embedding_model": "text-embedding-3-small",
+        },
+    )
+    assert create_kb.status_code == 201, create_kb.text
+    kb = create_kb.json()["knowledge_base"]
+    assert kb["kb_id"] == "kb-pr4-test"
+
+    list_kbs = client.get("/api/rag/knowledge-bases")
+    assert list_kbs.status_code == 200, list_kbs.text
+    assert any(item["kb_id"] == "kb-pr4-test" for item in list_kbs.json()["knowledge_bases"])
+
+    get_kb = client.get("/api/rag/knowledge-bases/kb-pr4-test")
+    assert get_kb.status_code == 200, get_kb.text
+    assert get_kb.json()["knowledge_base"]["name"] == "PR4 Test KB"
+
+    update_kb = client.put(
+        "/api/rag/knowledge-bases/kb-pr4-test",
+        json={"name": "PR4 Test KB Updated", "description": "Updated description"},
+    )
+    assert update_kb.status_code == 200, update_kb.text
+    assert update_kb.json()["knowledge_base"]["name"] == "PR4 Test KB Updated"
+
+    delete_profile = client.delete(f"/api/chunk/profiles/{profile_id}")
+    assert delete_profile.status_code == 200, delete_profile.text
+
+    delete_kb = client.delete("/api/rag/knowledge-bases/kb-pr4-test")
+    assert delete_kb.status_code == 200, delete_kb.text
+
+
+
+def test_fastapi_rag_admin_kb_detail_surfaces_work(tmp_path: Path, monkeypatch) -> None:
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch)
+    alpha_url = seed["alpha_url"]
+
+    create_kb = client.post(
+        "/api/rag/knowledge-bases",
+        json={
+            "kb_id": "kb-detail-test",
+            "name": "Detail Test KB",
+            "kb_mode": "manual",
+            "chunk_size": 300,
+            "chunk_overlap": 50,
+            "embedding_model": "text-embedding-3-small",
+        },
+    )
+    assert create_kb.status_code == 201, create_kb.text
+
+    stats = client.get("/api/rag/knowledge-bases/kb-detail-test/stats")
+    assert stats.status_code == 200, stats.text
+
+    files = client.get("/api/rag/knowledge-bases/kb-detail-test/files")
+    assert files.status_code == 200, files.text
+
+    categories = client.get("/api/rag/knowledge-bases/kb-detail-test/categories")
+    assert categories.status_code == 200, categories.text
+
+    unmapped = client.get("/api/rag/categories/unmapped")
+    assert unmapped.status_code == 200, unmapped.text
+
+    selectable = client.get("/api/rag/files/selectable")
+    assert selectable.status_code == 200, selectable.text
+    assert any(item["url"] == alpha_url for item in selectable.json()["files"])
+
+    pending = client.get("/api/rag/knowledge-bases/kb-detail-test/files/pending")
+    assert pending.status_code == 200, pending.text
+
+    bind = client.post(
+        "/api/rag/knowledge-bases/kb-detail-test/bindings",
+        json={
+            "bindings": [
+                {"file_url": alpha_url, "chunk_set_id": "cs_missing", "binding_mode": "follow_latest"}
+            ]
+        },
+    )
+    assert bind.status_code in {200, 400, 404}, bind.text
+
+    set_categories = client.post(
+        "/api/rag/knowledge-bases/kb-detail-test/categories",
+        json={"categories": ["AI"]},
+    )
+    assert set_categories.status_code == 200, set_categories.text
+
+    index = client.post(
+        "/api/rag/knowledge-bases/kb-detail-test/index",
+        json={"file_urls": [alpha_url]},
+    )
+    assert index.status_code in {200, 202}, index.text
+
+    cleanup = client.post("/api/chunk-sets/cleanup", json={"dry_run": True})
+    assert cleanup.status_code == 200, cleanup.text

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -303,6 +303,15 @@ def test_fastapi_rag_admin_kb_detail_surfaces_work(tmp_path: Path, monkeypatch) 
     assert categories_after_remove.status_code == 200, categories_after_remove.text
     assert "AI" not in categories_after_remove.json()["categories"]
 
+    replace_categories = client.post(
+        "/api/rag/knowledge-bases/kb-detail-test/categories",
+        json={"categories": ["Risk"], "action": "replace"},
+    )
+    assert replace_categories.status_code == 200, replace_categories.text
+    categories_after_replace = client.get("/api/rag/knowledge-bases/kb-detail-test/categories")
+    assert categories_after_replace.status_code == 200, categories_after_replace.text
+    assert categories_after_replace.json()["categories"] == ["Risk"]
+
     index = client.post(
         "/api/rag/knowledge-bases/kb-detail-test/index",
         json={"file_urls": [alpha_url]},

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -134,6 +134,7 @@ def test_fastapi_rag_admin_routes_are_listed_in_native_inventory(tmp_path: Path,
     assert "/api/rag/knowledge-bases/{kb_id}" in body["native_paths"]
     assert "/api/rag/knowledge-bases/{kb_id}/stats" in body["native_paths"]
     assert "/api/rag/knowledge-bases/{kb_id}/files" in body["native_paths"]
+    assert "/api/rag/knowledge-bases/{kb_id}/files/{file_url:path}" in body["native_paths"]
     assert "/api/rag/knowledge-bases/{kb_id}/categories" in body["native_paths"]
     assert "/api/rag/categories/unmapped" in body["native_paths"]
     assert "/api/rag/files/selectable" in body["native_paths"]
@@ -202,6 +203,42 @@ def test_fastapi_rag_admin_chunk_profiles_and_kb_crud_work(tmp_path: Path, monke
 
     delete_kb = client.delete("/api/rag/knowledge-bases/kb-pr4-test")
     assert delete_kb.status_code == 200, delete_kb.text
+
+
+
+def test_fastapi_rag_admin_kb_file_membership_routes_work(tmp_path: Path, monkeypatch) -> None:
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch)
+    alpha_url = seed["alpha_url"]
+
+    create_kb = client.post(
+        "/api/rag/knowledge-bases",
+        json={
+            "kb_id": "kb-files-test",
+            "name": "KB Files Test",
+            "kb_mode": "manual",
+            "chunk_size": 300,
+            "chunk_overlap": 50,
+        },
+    )
+    assert create_kb.status_code == 201, create_kb.text
+
+    add_files = client.post(
+        "/api/rag/knowledge-bases/kb-files-test/files",
+        json={"file_urls": [alpha_url]},
+    )
+    assert add_files.status_code == 200, add_files.text
+    assert add_files.json()["added_count"] == 1
+
+    files_after_add = client.get("/api/rag/knowledge-bases/kb-files-test/files")
+    assert files_after_add.status_code == 200, files_after_add.text
+    assert any(item["file_url"] == alpha_url for item in files_after_add.json()["files"])
+
+    remove_file = client.delete(f"/api/rag/knowledge-bases/kb-files-test/files/{alpha_url}")
+    assert remove_file.status_code == 200, remove_file.text
+
+    files_after_remove = client.get("/api/rag/knowledge-bases/kb-files-test/files")
+    assert files_after_remove.status_code == 200, files_after_remove.text
+    assert not any(item["file_url"] == alpha_url for item in files_after_remove.json()["files"])
 
 
 

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -320,3 +320,46 @@ def test_fastapi_rag_admin_kb_detail_surfaces_work(tmp_path: Path, monkeypatch) 
 
     cleanup = client.post("/api/chunk-sets/cleanup", json={"dry_run": True})
     assert cleanup.status_code == 200, cleanup.text
+
+
+def test_fastapi_rag_admin_preserves_zero_chunk_overlap_and_requires_task_bridge(tmp_path: Path, monkeypatch) -> None:
+    client, app, seed = _build_test_client(tmp_path, monkeypatch)
+    alpha_url = seed["alpha_url"]
+
+    create_profile = client.post(
+        "/api/chunk/profiles",
+        json={
+            "name": "zero-overlap-profile",
+            "chunk_size": 256,
+            "chunk_overlap": 0,
+        },
+    )
+    assert create_profile.status_code == 201, create_profile.text
+    assert create_profile.json()["profile"]["chunk_overlap"] == 0
+
+    create_kb = client.post(
+        "/api/rag/knowledge-bases",
+        json={
+            "kb_id": "kb-zero-overlap",
+            "name": "KB Zero Overlap",
+            "kb_mode": "manual",
+            "chunk_size": 256,
+            "chunk_overlap": 0,
+            "file_urls": [alpha_url],
+        },
+    )
+    assert create_kb.status_code == 201, create_kb.text
+    assert create_kb.json()["knowledge_base"]["chunk_overlap"] == 0
+
+    original_bridge = getattr(app.state, "legacy_start_background_task", None)
+    app.state.legacy_start_background_task = None
+    try:
+        index = client.post(
+            "/api/rag/knowledge-bases/kb-zero-overlap/index",
+            json={"force_reindex": True},
+        )
+    finally:
+        app.state.legacy_start_background_task = original_bridge
+
+    assert index.status_code == 503, index.text
+    assert index.json()["error"] == "Task bridge is unavailable"

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -294,6 +294,15 @@ def test_fastapi_rag_admin_kb_detail_surfaces_work(tmp_path: Path, monkeypatch) 
     )
     assert set_categories.status_code == 200, set_categories.text
 
+    remove_categories = client.post(
+        "/api/rag/knowledge-bases/kb-detail-test/categories",
+        json={"categories": ["AI"], "action": "remove"},
+    )
+    assert remove_categories.status_code == 200, remove_categories.text
+    categories_after_remove = client.get("/api/rag/knowledge-bases/kb-detail-test/categories")
+    assert categories_after_remove.status_code == 200, categories_after_remove.text
+    assert "AI" not in categories_after_remove.json()["categories"]
+
     index = client.post(
         "/api/rag/knowledge-bases/kb-detail-test/index",
         json={"file_urls": [alpha_url]},


### PR DESCRIPTION
## Summary
- add native FastAPI RAG admin endpoints and KB file/category mutation flows
- restore `/knowledge` and `/knowledge/:kbId` in the React shell with FastAPI-native wiring
- finish KB category add/remove/replace semantics and tighten PR4 endpoint coverage

## Test Plan
- source /home/ec2-user/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_fastapi_rag_admin_endpoints.py -q
- npm run build
- browser validation on `/knowledge` and `/knowledge/:kbId` against local FastAPI
