### PR TITLE
feat: migrate chat workflow to fastapi

### DIFF
--- a/ai_actuarial/api/app.py
+++ b/ai_actuarial/api/app.py
@@ -13,6 +13,7 @@ from .route_inventory import (
     collect_fastapi_route_signatures,
     summarize_legacy_api_routes,
 )
+from .routers.chat import router as chat_router
 from .routers.files_write import router as files_write_router
 from .routers.meta import router as meta_router
 from .routers.rag_admin import router as rag_admin_router
@@ -67,6 +68,7 @@ def create_app() -> FastAPI:
     app.include_router(ops_write_router, prefix="/api", tags=["ops-write"])
     app.include_router(files_write_router, prefix="/api", tags=["files-write"])
     app.include_router(rag_admin_router, prefix="/api", tags=["rag-admin"])
+    app.include_router(chat_router, prefix="/api", tags=["chat"])
 
     app.state.legacy_backend = "flask"
     app.state.legacy_mount_enabled = False

--- a/ai_actuarial/api/routers/chat.py
+++ b/ai_actuarial/api/routers/chat.py
@@ -44,7 +44,7 @@ def api_list_conversations(
         return _error_response(exc)
 
 
-@router.post("/chat/conversations")
+@router.post("/chat/conversations", status_code=201)
 def api_create_conversation(
     payload: dict[str, object],
     request: Request,
@@ -54,7 +54,7 @@ def api_create_conversation(
     try:
         result, session_update = create_conversation(db_path=_db_path(request), request=request, auth=auth, payload=payload)
         apply_session_update(response, request, session_update)
-        return JSONResponse(status_code=201, content=result, headers=dict(response.headers))
+        return result
     except ChatApiError as exc:
         return _error_response(exc)
 

--- a/ai_actuarial/api/routers/chat.py
+++ b/ai_actuarial/api/routers/chat.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import JSONResponse
+
+from ..deps import AuthContext, require_permissions
+from ..services.chat import (
+    ChatApiError,
+    apply_session_update,
+    create_conversation,
+    delete_conversation,
+    get_conversation_detail,
+    list_available_documents,
+    list_conversations,
+    list_knowledge_bases,
+    query_chat,
+)
+
+router = APIRouter()
+
+
+def _db_path(request: Request) -> str:
+    db_path = str(getattr(request.app.state, "db_path", "") or "")
+    if not db_path:
+        raise ChatApiError("Database path is unavailable", status_code=500)
+    return db_path
+
+
+def _error_response(exc: ChatApiError) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content=exc.payload)
+
+
+@router.get("/chat/conversations")
+def api_list_conversations(
+    request: Request,
+    response: Response,
+    auth: AuthContext = Depends(require_permissions("chat.conversations")),
+):
+    try:
+        payload, session_update = list_conversations(db_path=_db_path(request), request=request, auth=auth)
+        apply_session_update(response, request, session_update)
+        return payload
+    except ChatApiError as exc:
+        return _error_response(exc)
+
+
+@router.post("/chat/conversations")
+def api_create_conversation(
+    payload: dict[str, object],
+    request: Request,
+    response: Response,
+    auth: AuthContext = Depends(require_permissions("chat.conversations")),
+):
+    try:
+        result, session_update = create_conversation(db_path=_db_path(request), request=request, auth=auth, payload=payload)
+        apply_session_update(response, request, session_update)
+        return JSONResponse(status_code=201, content=result, headers=dict(response.headers))
+    except ChatApiError as exc:
+        return _error_response(exc)
+
+
+@router.get("/chat/conversations/{conversation_id}")
+def api_get_conversation(
+    conversation_id: str,
+    request: Request,
+    response: Response,
+    auth: AuthContext = Depends(require_permissions("chat.conversations")),
+):
+    try:
+        payload, session_update = get_conversation_detail(
+            db_path=_db_path(request), request=request, auth=auth, conversation_id=conversation_id
+        )
+        apply_session_update(response, request, session_update)
+        return payload
+    except ChatApiError as exc:
+        return _error_response(exc)
+
+
+@router.delete("/chat/conversations/{conversation_id}")
+def api_delete_conversation(
+    conversation_id: str,
+    request: Request,
+    response: Response,
+    auth: AuthContext = Depends(require_permissions("chat.conversations")),
+):
+    try:
+        payload, session_update = delete_conversation(
+            db_path=_db_path(request), request=request, auth=auth, conversation_id=conversation_id
+        )
+        apply_session_update(response, request, session_update)
+        return payload
+    except ChatApiError as exc:
+        return _error_response(exc)
+
+
+@router.get("/chat/knowledge-bases")
+def api_list_chat_knowledge_bases(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("chat.view")),
+):
+    try:
+        return list_knowledge_bases(db_path=_db_path(request))
+    except ChatApiError as exc:
+        return _error_response(exc)
+
+
+@router.get("/chat/available-documents")
+def api_list_available_documents(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("chat.view")),
+):
+    try:
+        return list_available_documents(db_path=_db_path(request), query=request.query_params)
+    except ChatApiError as exc:
+        return _error_response(exc)
+
+
+@router.post("/chat/query")
+def api_chat_query(
+    payload: dict[str, object],
+    request: Request,
+    response: Response,
+    auth: AuthContext = Depends(require_permissions("chat.query")),
+):
+    try:
+        result, session_update = query_chat(db_path=_db_path(request), request=request, auth=auth, payload=payload)
+        apply_session_update(response, request, session_update)
+        return result
+    except ChatApiError as exc:
+        return _error_response(exc)

--- a/ai_actuarial/api/services/chat.py
+++ b/ai_actuarial/api/services/chat.py
@@ -1,0 +1,672 @@
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Mapping
+from urllib.parse import quote
+
+from ai_actuarial.api.deps import _decode_flask_session, AuthContext
+from ai_actuarial.storage import Storage
+
+logger = logging.getLogger(__name__)
+
+
+class ChatApiError(Exception):
+    def __init__(self, message: str, *, status_code: int = 400, payload: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.payload = payload or {"success": False, "error": message}
+
+
+class SessionUpdate(dict):
+    pass
+
+
+class ChatModules(dict):
+    pass
+
+
+VALID_CHAT_MODES = {"expert", "summary", "tutorial", "comparison"}
+
+
+def _ensure_conversation_schema(storage: Storage) -> None:
+    conn = storage._conn
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS conversations (
+            conversation_id TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            title TEXT,
+            kb_id TEXT,
+            mode TEXT DEFAULT 'expert',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            metadata TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS messages (
+            message_id TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            citations TEXT,
+            created_at TEXT NOT NULL,
+            token_count INTEGER,
+            metadata TEXT,
+            FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_messages_conversation
+        ON messages(conversation_id, created_at)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_conversations_user
+        ON conversations(user_id, updated_at DESC)
+        """
+    )
+    conn.commit()
+
+
+def _default_conversation_title() -> str:
+    return f"New Conversation - {datetime.now(timezone.utc).strftime('%b %d')}"
+
+
+def _base_chat_modules() -> ChatModules:
+    try:
+        return ChatModules(
+            config=importlib.import_module("ai_actuarial.chatbot.config"),
+            conversation=importlib.import_module("ai_actuarial.chatbot.conversation"),
+            exceptions=importlib.import_module("ai_actuarial.chatbot.exceptions"),
+            knowledge_base=importlib.import_module("ai_actuarial.rag.knowledge_base"),
+        )
+    except ImportError as exc:  # noqa: BLE001
+        raise ChatApiError(
+            "Chatbot functionality not available",
+            status_code=503,
+            payload={"success": False, "error": "Chatbot functionality not available"},
+        ) from exc
+
+
+def _full_chat_modules() -> ChatModules:
+    modules = _base_chat_modules()
+    try:
+        modules.update(
+            retrieval=importlib.import_module("ai_actuarial.chatbot.retrieval"),
+            llm=importlib.import_module("ai_actuarial.chatbot.llm"),
+            router=importlib.import_module("ai_actuarial.chatbot.router"),
+        )
+        return modules
+    except ImportError as exc:  # noqa: BLE001
+        raise ChatApiError(
+            "Chatbot functionality not available",
+            status_code=503,
+            payload={"success": False, "error": "Chatbot functionality not available"},
+        ) from exc
+
+
+def _legacy_app(request) -> Any:
+    app = getattr(request.app.state, "legacy_flask_app", None)
+    if app is None:
+        raise ChatApiError("Legacy Flask app is unavailable", status_code=503)
+    return app
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _current_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_file_links(raw_file_url: str, *, return_to: str = "/chat") -> dict[str, str]:
+    source_url = str(raw_file_url or "").strip()
+    if not source_url:
+        return {"source_url": "", "file_detail_url": "", "file_preview_url": ""}
+    if source_url.startswith("/file/"):
+        return {"source_url": source_url, "file_detail_url": source_url, "file_preview_url": ""}
+    if source_url.startswith("/file_preview"):
+        return {"source_url": source_url, "file_detail_url": "", "file_preview_url": source_url}
+    if source_url.startswith("/database/"):
+        return {"source_url": source_url, "file_detail_url": source_url, "file_preview_url": ""}
+
+    encoded_source = quote(source_url, safe="")
+    return {
+        "source_url": source_url,
+        "file_detail_url": f"/file/{encoded_source}?return_to={quote(return_to, safe='')}",
+        "file_preview_url": f"/file_preview?file_url={encoded_source}",
+    }
+
+
+def _resolve_chat_user(request, auth: AuthContext) -> tuple[str, SessionUpdate | None]:
+    token = auth.token or {}
+    subject = _normalize_text(token.get("subject"))
+    if subject:
+        return f"user:{subject}", None
+
+    token_id = token.get("id")
+    if token_id is not None:
+        return f"token:{token_id}", None
+
+    session_data = _decode_flask_session(request)
+    legacy_subject = _normalize_text(session_data.get("auth_subject"))
+    if legacy_subject:
+        return f"user:{legacy_subject}", None
+
+    guest_id = _normalize_text(session_data.get("guest_chat_user_id"))
+    if guest_id:
+        return guest_id, None
+
+    guest_id = f"guest:{uuid.uuid4().hex[:16]}"
+    session_data["guest_chat_user_id"] = guest_id
+    return guest_id, SessionUpdate(session_data)
+
+
+def apply_session_update(response, request, session_update: SessionUpdate | None) -> None:
+    if not session_update:
+        return
+    legacy_app = _legacy_app(request)
+    serializer = legacy_app.session_interface.get_signing_serializer(legacy_app)
+    if serializer is None:
+        return
+    cookie_name = legacy_app.config.get("SESSION_COOKIE_NAME", "session")
+    cookie_value = serializer.dumps(dict(session_update))
+    response.set_cookie(
+        key=cookie_name,
+        value=cookie_value,
+        httponly=bool(legacy_app.config.get("SESSION_COOKIE_HTTPONLY", True)),
+        secure=bool(legacy_app.config.get("SESSION_COOKIE_SECURE", False)),
+        samesite=legacy_app.config.get("SESSION_COOKIE_SAMESITE", "Lax") or "Lax",
+        path=legacy_app.config.get("SESSION_COOKIE_PATH", "/") or "/",
+    )
+
+
+def list_conversations(*, db_path: str, request, auth: AuthContext) -> tuple[dict[str, Any], SessionUpdate | None]:
+    user_id, session_update = _resolve_chat_user(request, auth)
+    storage = Storage(db_path)
+    try:
+        _ensure_conversation_schema(storage)
+        rows = storage._conn.execute(
+            """
+            SELECT conversation_id, user_id, title, kb_id, mode, created_at,
+                   updated_at, message_count, metadata
+            FROM conversations
+            WHERE user_id = ?
+            ORDER BY updated_at DESC
+            LIMIT 50 OFFSET 0
+            """,
+            (user_id,),
+        ).fetchall()
+        conversations = [
+            {
+                "conversation_id": row[0],
+                "user_id": row[1],
+                "title": row[2],
+                "kb_id": row[3],
+                "mode": row[4],
+                "created_at": row[5],
+                "updated_at": row[6],
+                "message_count": row[7],
+                "metadata": json.loads(row[8]) if row[8] else None,
+            }
+            for row in rows
+        ]
+        return {"success": True, "data": {"conversations": conversations}}, session_update
+    finally:
+        storage.close()
+
+
+def create_conversation(*, db_path: str, request, auth: AuthContext, payload: dict[str, Any]) -> tuple[dict[str, Any], SessionUpdate | None]:
+    if not isinstance(payload, dict):
+        raise ChatApiError("Invalid JSON body", status_code=400)
+    mode = _normalize_text(payload.get("mode") or "expert").lower()
+    if mode not in VALID_CHAT_MODES:
+        raise ChatApiError(f"Invalid mode '{mode}'", status_code=400)
+    kb_id = _normalize_text(payload.get("kb_id")) or None
+    metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None
+
+    user_id, session_update = _resolve_chat_user(request, auth)
+    storage = Storage(db_path)
+    try:
+        _ensure_conversation_schema(storage)
+        conversation_id = f"conv_{uuid.uuid4().hex[:16]}"
+        now = _current_timestamp()
+        storage._conn.execute(
+            """
+            INSERT INTO conversations
+            (conversation_id, user_id, title, kb_id, mode, created_at, updated_at, message_count, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                conversation_id,
+                user_id,
+                _default_conversation_title(),
+                kb_id,
+                mode,
+                now,
+                now,
+                0,
+                json.dumps(metadata) if metadata else None,
+            ),
+        )
+        storage._conn.commit()
+        return {"success": True, "data": {"conversation_id": conversation_id}}, session_update
+    finally:
+        storage.close()
+
+
+def get_conversation_detail(*, db_path: str, request, auth: AuthContext, conversation_id: str) -> tuple[dict[str, Any], SessionUpdate | None]:
+    user_id, session_update = _resolve_chat_user(request, auth)
+    storage = Storage(db_path)
+    try:
+        _ensure_conversation_schema(storage)
+        row = storage._conn.execute(
+            """
+            SELECT conversation_id, user_id, title, kb_id, mode, created_at,
+                   updated_at, message_count, metadata
+            FROM conversations
+            WHERE conversation_id = ?
+            """,
+            (conversation_id,),
+        ).fetchone()
+        conversation = None if not row else {
+            "conversation_id": row[0],
+            "user_id": row[1],
+            "title": row[2],
+            "kb_id": row[3],
+            "mode": row[4],
+            "created_at": row[5],
+            "updated_at": row[6],
+            "message_count": row[7],
+            "metadata": json.loads(row[8]) if row[8] else None,
+        }
+        if not conversation:
+            raise ChatApiError("Conversation not found", status_code=404)
+        if conversation.get("user_id") != user_id:
+            raise ChatApiError("Access denied", status_code=403)
+        message_rows = storage._conn.execute(
+            """
+            SELECT message_id, conversation_id, role, content, citations, created_at, token_count, metadata
+            FROM messages
+            WHERE conversation_id = ?
+            ORDER BY created_at ASC
+            """,
+            (conversation_id,),
+        ).fetchall()
+        messages = [
+            {
+                "message_id": row[0],
+                "conversation_id": row[1],
+                "role": row[2],
+                "content": row[3],
+                "citations": json.loads(row[4]) if row[4] else None,
+                "created_at": row[5],
+                "token_count": row[6],
+                "metadata": json.loads(row[7]) if row[7] else None,
+            }
+            for row in message_rows
+        ]
+        return {"success": True, "data": {"conversation": conversation, "messages": messages}}, session_update
+    finally:
+        storage.close()
+
+
+def delete_conversation(*, db_path: str, request, auth: AuthContext, conversation_id: str) -> tuple[dict[str, Any], SessionUpdate | None]:
+    user_id, session_update = _resolve_chat_user(request, auth)
+    storage = Storage(db_path)
+    try:
+        _ensure_conversation_schema(storage)
+        row = storage._conn.execute(
+            "SELECT conversation_id, user_id FROM conversations WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+        conversation = None if not row else {"conversation_id": row[0], "user_id": row[1]}
+        if not conversation:
+            raise ChatApiError("Conversation not found", status_code=404)
+        if conversation.get("user_id") != user_id:
+            raise ChatApiError("Access denied", status_code=403)
+        storage._conn.execute("DELETE FROM messages WHERE conversation_id = ?", (conversation_id,))
+        storage._conn.execute("DELETE FROM conversations WHERE conversation_id = ?", (conversation_id,))
+        storage._conn.commit()
+        return {"success": True, "message": "Conversation deleted"}, session_update
+    finally:
+        storage.close()
+
+
+def list_knowledge_bases(*, db_path: str) -> dict[str, Any]:
+    storage = Storage(db_path)
+    try:
+        current_embeddings = {
+            "provider": os.getenv("EMBEDDING_PROVIDER", "openai"),
+            "model": os.getenv("EMBEDDING_MODEL", "text-embedding-3-large"),
+            "dimension": None,
+        }
+        knowledge_bases: list[dict[str, Any]] = []
+        rows = storage._conn.execute(
+            """
+            SELECT kb_id, name, description, embedding_provider, embedding_model, embedding_dimension,
+                   file_count, chunk_count
+            FROM rag_knowledge_bases
+            ORDER BY created_at DESC
+            """
+        ).fetchall()
+        for row in rows:
+            kb_id = row[0]
+            composition = storage.get_kb_composition_status(kb_id)
+            knowledge_bases.append(
+                {
+                    "kb_id": kb_id,
+                    "name": row[1],
+                    "description": row[2],
+                    "file_count": row[6],
+                    "chunk_count": row[7],
+                    "embedding_provider": row[3] or "openai",
+                    "embedding_model": row[4],
+                    "embedding_dimension": row[5],
+                    "index_embedding_provider": composition.get("index_embedding_provider"),
+                    "index_embedding_model": composition.get("index_embedding_model"),
+                    "index_embedding_dimension": composition.get("index_embedding_dimension"),
+                    "index_status": composition.get("index_status"),
+                    "index_built_at": composition.get("index_built_at"),
+                    "needs_reindex": bool(composition.get("needs_reindex")),
+                    "embedding_compatible": bool(composition.get("embedding_compatible", True)),
+                }
+            )
+        return {"success": True, "data": {"knowledge_bases": knowledge_bases, "current_embeddings": current_embeddings}}
+    finally:
+        storage.close()
+
+
+def list_available_documents(*, db_path: str, query: Mapping[str, Any]) -> dict[str, Any]:
+    category = _normalize_text(query.get("category"))
+    keywords_raw = _normalize_text(query.get("keywords"))
+    keywords = [item.strip() for item in keywords_raw.split(",") if item.strip()]
+
+    storage = Storage(db_path)
+    try:
+        where_parts = [
+            "f.deleted_at IS NULL",
+            "c.markdown_content IS NOT NULL",
+            "c.markdown_content != ''",
+        ]
+        params: list[Any] = []
+        if category:
+            if category == "__uncategorized__":
+                where_parts.append("(c.category IS NULL OR c.category = '')")
+            else:
+                where_parts.append("c.category LIKE ?")
+                params.append(f"%{category}%")
+        if keywords:
+            keyword_clauses = []
+            for keyword in keywords:
+                keyword_clauses.append("(LOWER(f.title) LIKE ? OR LOWER(f.original_filename) LIKE ? OR LOWER(c.keywords) LIKE ?)")
+                wildcard = f"%{keyword.lower()}%"
+                params.extend([wildcard, wildcard, wildcard])
+            where_parts.append(f"({' OR '.join(keyword_clauses)})")
+        where_sql = " AND ".join(where_parts)
+        rows = storage._conn.execute(
+            f"""
+            SELECT f.url, f.original_filename, f.title, c.category, c.keywords
+            FROM files f
+            JOIN catalog_items c ON c.file_url = f.url
+            WHERE {where_sql}
+            ORDER BY f.title, f.original_filename
+            LIMIT 1000
+            """,
+            params,
+        ).fetchall()
+        documents = []
+        for row in rows:
+            raw_keywords = row[4]
+            parsed_keywords: list[str]
+            if isinstance(raw_keywords, str) and raw_keywords.strip().startswith("["):
+                try:
+                    loaded = json.loads(raw_keywords)
+                    parsed_keywords = [str(item).strip() for item in loaded if str(item).strip()]
+                except Exception:
+                    parsed_keywords = [item.strip() for item in raw_keywords.split(",") if item.strip()]
+            else:
+                parsed_keywords = [item.strip() for item in str(raw_keywords or "").split(",") if item.strip()]
+            documents.append(
+                {
+                    "file_url": row[0],
+                    "filename": row[1] or "",
+                    "title": row[2] or row[1] or "",
+                    "category": row[3] or "",
+                    "keywords": parsed_keywords,
+                }
+            )
+        return {"success": True, "data": {"documents": documents}}
+    finally:
+        storage.close()
+
+
+def _friendly_no_results_message() -> str:
+    return (
+        "I couldn't find relevant source material for that question in the selected knowledge bases. "
+        "Try broadening the question, selecting a different knowledge base, or asking about a document directly."
+    )
+
+
+def _serialize_citations(chunks: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    citations: list[dict[str, Any]] = []
+    retrieved_blocks: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    for chunk in chunks:
+        metadata = chunk.get("metadata") or {}
+        content = str(chunk.get("content") or "")
+        links = _build_file_links(str(metadata.get("file_url") or ""))
+        block = {
+            "filename": metadata.get("filename") or "",
+            "kb_id": metadata.get("kb_id") or "",
+            "kb_name": metadata.get("kb_name") or "",
+            "chunk_id": metadata.get("chunk_id") or "",
+            "similarity_score": metadata.get("similarity_score"),
+            "content": content,
+            "source_url": links["source_url"],
+            "file_detail_url": links["file_detail_url"],
+            "file_preview_url": links["file_preview_url"],
+            "quote": content[:280].strip(),
+        }
+        retrieved_blocks.append(block)
+        dedupe_key = links["source_url"] or str(metadata.get("filename") or metadata.get("chunk_id") or len(citations))
+        if dedupe_key in seen_keys:
+            continue
+        seen_keys.add(dedupe_key)
+        citations.append(
+            {
+                "filename": metadata.get("filename") or "",
+                "kb_id": metadata.get("kb_id") or "",
+                "kb_name": metadata.get("kb_name") or "",
+                "chunk_id": metadata.get("chunk_id") or "",
+                "similarity_score": metadata.get("similarity_score"),
+                "source_url": links["source_url"],
+                "file_url": links["file_detail_url"],
+                "file_detail_url": links["file_detail_url"],
+                "file_preview_url": links["file_preview_url"],
+                "quote": content[:280].strip(),
+            }
+        )
+    return citations, retrieved_blocks
+
+
+def query_chat(*, db_path: str, request, auth: AuthContext, payload: dict[str, Any]) -> tuple[dict[str, Any], SessionUpdate | None]:
+    modules = _full_chat_modules()
+    if not isinstance(payload, dict):
+        raise ChatApiError("Invalid or missing JSON body", status_code=400)
+
+    message = _normalize_text(payload.get("message"))
+    if not message:
+        raise ChatApiError("Message is required", status_code=400)
+    mode = _normalize_text(payload.get("mode") or "expert").lower()
+    if mode not in VALID_CHAT_MODES:
+        raise ChatApiError(f"Invalid mode '{mode}'", status_code=400)
+
+    kb_ids = payload.get("kb_ids")
+    conversation_id = _normalize_text(payload.get("conversation_id")) or None
+    document_content = _normalize_text(payload.get("document_content"))
+    document_filename = _normalize_text(payload.get("document_filename")) or "Document"
+    document_file_url = _normalize_text(payload.get("document_file_url"))
+    document_sources = payload.get("document_sources") if isinstance(payload.get("document_sources"), list) else []
+
+    user_id, session_update = _resolve_chat_user(request, auth)
+    storage = Storage(db_path)
+    try:
+        config = modules["config"].ChatbotConfig.from_config(storage=storage, default_mode=mode)
+        conversation_manager = modules["conversation"].ConversationManager(storage, config)
+        exceptions = modules["exceptions"]
+
+        if conversation_id:
+            conversation = conversation_manager.get_conversation(conversation_id)
+            if not conversation:
+                raise ChatApiError("Conversation not found", status_code=404)
+            if conversation.get("user_id") != user_id:
+                raise ChatApiError("Access denied", status_code=403)
+        else:
+            primary_kb = None
+            if isinstance(kb_ids, list) and kb_ids:
+                primary_kb = _normalize_text(kb_ids[0]) or None
+            elif isinstance(kb_ids, str) and kb_ids not in {"auto", "all"}:
+                primary_kb = _normalize_text(kb_ids) or None
+            conversation_id = conversation_manager.create_conversation(
+                user_id=user_id,
+                kb_id=primary_kb,
+                mode=mode,
+                metadata={"kb_ids": kb_ids, "mode": mode},
+            )
+
+        conversation_manager.add_message(conversation_id, "user", message)
+        conversation_history = conversation_manager.get_context(conversation_id)
+
+        chunks: list[dict[str, Any]] = []
+        no_results = False
+        used_threshold = getattr(config, "similarity_threshold", None)
+
+        if document_content:
+            sources = document_sources or [{
+                "file_url": document_file_url,
+                "filename": document_filename,
+                "content": document_content,
+            }]
+            for index, source in enumerate(sources, start=1):
+                file_url = _normalize_text(source.get("file_url") if isinstance(source, dict) else "")
+                filename = _normalize_text(source.get("filename") if isinstance(source, dict) else "") or f"Document {index}"
+                content = _normalize_text(source.get("content") if isinstance(source, dict) else "") or document_content
+                chunks.append(
+                    {
+                        "content": content[:15000],
+                        "metadata": {
+                            "filename": filename,
+                            "kb_id": "document_explanation",
+                            "kb_name": "Full Document",
+                            "similarity_score": 1.0,
+                            "chunk_id": f"document_{index}",
+                            "file_url": file_url,
+                        },
+                    }
+                )
+        else:
+            retriever = modules["retrieval"].RAGRetriever(storage, config)
+            normalized_kb_ids: Any = kb_ids
+            if kb_ids in (None, "", "all"):
+                normalized_kb_ids = None
+            elif kb_ids == "auto":
+                normalized_kb_ids = modules["router"].QueryRouter(storage, config).select_kb(message)
+            try:
+                chunks = retriever.retrieve(message, normalized_kb_ids)
+            except exceptions.NoResultsException:
+                no_results = True
+                chunks = []
+            except exceptions.EmbeddingConfigurationMismatchException as exc:
+                raise ChatApiError(
+                    str(exc),
+                    status_code=409,
+                    payload={
+                        "success": False,
+                        "code": "KB_EMBEDDING_MISMATCH",
+                        "error": str(exc),
+                        "data": {
+                            "kb_id": exc.kb_id,
+                            "current_embedding": {
+                                "provider": exc.current_provider,
+                                "model": exc.current_model,
+                                "dimension": exc.current_dimension,
+                            },
+                            "index_embedding": {
+                                "provider": exc.index_provider,
+                                "model": exc.index_model,
+                                "dimension": exc.index_dimension,
+                            },
+                            "needs_reindex": exc.needs_reindex,
+                        },
+                    },
+                ) from exc
+
+        if no_results:
+            response_text = _friendly_no_results_message()
+            citations: list[dict[str, Any]] = []
+            retrieved_blocks: list[dict[str, Any]] = []
+        else:
+            llm_client = modules["llm"].LLMClient(config, storage=storage)
+            response_text = llm_client.generate_response(
+                query=message,
+                chunks=chunks,
+                mode=mode,
+                conversation_history=conversation_history,
+            )
+            citations, retrieved_blocks = _serialize_citations(chunks)
+
+        assistant_metadata = {
+            "model": getattr(config, "model", None),
+            "mode": mode,
+            "retrieval_time_ms": 0,
+            "generation_time_ms": 0,
+            "num_chunks": len(chunks),
+            "no_results": no_results,
+            "used_threshold": used_threshold,
+            "retrieved_blocks": retrieved_blocks,
+        }
+        message_id = conversation_manager.add_message(
+            conversation_id,
+            "assistant",
+            response_text,
+            citations=citations,
+            metadata=assistant_metadata,
+        )
+
+        return {
+            "success": True,
+            "data": {
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+                "response": response_text,
+                "citations": citations,
+                "retrieved_blocks": retrieved_blocks,
+                "metadata": {
+                    "retrieval_time_ms": 0,
+                    "generation_time_ms": 0,
+                    "model": getattr(config, "model", None),
+                    "mode": mode,
+                    "num_chunks": len(chunks),
+                    "no_results": no_results,
+                    "used_threshold": used_threshold,
+                },
+            },
+        }, session_update
+    finally:
+        storage.close()

--- a/ai_actuarial/api/services/chat.py
+++ b/ai_actuarial/api/services/chat.py
@@ -180,7 +180,10 @@ def _resolve_chat_user(request, auth: AuthContext) -> tuple[str, SessionUpdate |
 def apply_session_update(response, request, session_update: SessionUpdate | None) -> None:
     if not session_update:
         return
-    legacy_app = _legacy_app(request)
+    legacy_app = getattr(request.app.state, "legacy_flask_app", None)
+    if legacy_app is None:
+        logger.debug("Skipping chat session update because legacy Flask app is unavailable")
+        return
     serializer = legacy_app.session_interface.get_signing_serializer(legacy_app)
     if serializer is None:
         return
@@ -668,5 +671,22 @@ def query_chat(*, db_path: str, request, auth: AuthContext, payload: dict[str, A
                 },
             },
         }, session_update
+    except ChatApiError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        conversation_exc = getattr(exceptions, "ConversationException", None)
+        llm_exc = getattr(exceptions, "LLMException", None)
+        retrieval_exc = getattr(exceptions, "RetrievalException", None)
+        expose_detail = os.getenv("EXPOSE_ERROR_DETAILS") == "1"
+        if conversation_exc and isinstance(exc, conversation_exc):
+            detail = f": {exc}" if expose_detail else ""
+            raise ChatApiError(f"Conversation error{detail}", status_code=400) from exc
+        if llm_exc and isinstance(exc, llm_exc):
+            detail = f": {exc}" if expose_detail else ""
+            raise ChatApiError(f"LLM generation failed{detail}", status_code=502) from exc
+        if retrieval_exc and isinstance(exc, retrieval_exc):
+            detail = f": {exc}" if expose_detail else ""
+            raise ChatApiError(f"Retrieval failed{detail}", status_code=502) from exc
+        raise
     finally:
         storage.close()

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Layout from "@/components/Layout";
 import Dashboard from "@/pages/Dashboard";
 import Database from "@/pages/Database";
 import { AuthProvider, useAuth } from "@/context/AuthContext";
+import Chat from "@/pages/Chat";
 import FeatureUnavailable from "@/pages/FeatureUnavailable";
 import FileDetail from "@/pages/FileDetail";
 import FilePreview from "@/pages/FilePreview";
@@ -51,9 +52,7 @@ function Router() {
               <Route path="/database" component={Database} />
               <Route path="/file-detail" component={FileDetail} />
               <Route path="/file-preview" component={FilePreview} />
-              <Route path="/chat">
-                <FeatureUnavailable title="Chat is not available in FastAPI-native mode" description="The chat workflow still depends on legacy APIs and is intentionally hidden from the native shell." />
-              </Route>
+              <Route path="/chat" component={Chat} />
               <Route path="/tasks" component={Tasks} />
               <Route path="/logs" component={NativeLogs} />
               <Route path="/knowledge/:kbId" component={KBDetail} />

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import {
   LayoutDashboard,
   Database,
   BookOpen,
+  MessageSquare,
   Sun,
   Moon,
   Menu,
@@ -30,6 +31,7 @@ export function useTranslation() {
 const navItems = [
   { path: "/", icon: LayoutDashboard, labelKey: "nav.dashboard" },
   { path: "/database", icon: Database, labelKey: "nav.database" },
+  { path: "/chat", icon: MessageSquare, labelKey: "nav.chat" },
   { path: "/tasks", icon: ListTodo, labelKey: "nav.tasks" },
   { path: "/knowledge", icon: BookOpen, labelKey: "nav.knowledge" },
   { path: "/logs", icon: ScrollText, labelKey: "nav.logs" },

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -36,10 +36,27 @@ interface Citation {
   filename?: string;
   title?: string;
   content?: string;
+  quote?: string;
   score?: number;
   similarity_score?: number;
   kb_name?: string;
   file_url?: string;
+  file_detail_url?: string;
+  file_preview_url?: string;
+}
+
+interface RetrievedBlock {
+  filename?: string;
+  kb_id?: string;
+  kb_name?: string;
+  chunk_id?: string;
+  similarity_score?: number;
+  content?: string;
+  quote?: string;
+  source_url?: string;
+  file_url?: string;
+  file_detail_url?: string;
+  file_preview_url?: string;
 }
 
 interface Message {
@@ -48,7 +65,7 @@ interface Message {
   role: "user" | "assistant";
   content: string;
   citations?: Citation[];
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown> & { retrieved_blocks?: RetrievedBlock[] | string };
 }
 
 interface KnowledgeBase {
@@ -93,10 +110,13 @@ function TypingIndicator() {
 function CitationCard({ citation, index }: { citation: Citation; index: number }) {
   const title = citation.title || citation.filename || citation.source || "Source";
   const score = citation.similarity_score || citation.score;
+  const snippet = citation.content || citation.quote;
+  const detailHref = citation.file_detail_url || citation.file_url;
+  const previewHref = citation.file_preview_url;
 
   return (
     <div
-      className="inline-flex items-start gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-xs max-w-xs hover:border-primary/30 transition-colors cursor-default"
+      className="inline-flex items-start gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-xs max-w-sm hover:border-primary/30 transition-colors"
       data-testid={`citation-${index}`}
     >
       <FileText className="w-3.5 h-3.5 text-primary shrink-0 mt-0.5" strokeWidth={1.8} />
@@ -110,16 +130,125 @@ function CitationCard({ citation, index }: { citation: Citation; index: number }
             {(score * 100).toFixed(0)}%
           </p>
         )}
-        {citation.content && (
-          <p className="text-muted-foreground line-clamp-2 mt-0.5">{citation.content}</p>
+        {snippet && (
+          <p className="text-muted-foreground line-clamp-3 mt-1 whitespace-pre-wrap">{snippet}</p>
+        )}
+        {(detailHref || previewHref) && (
+          <div className="flex flex-wrap gap-2 mt-2">
+            {detailHref && (
+              <a
+                href={detailHref}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-primary hover:underline"
+              >
+                文件详情
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            )}
+            {previewHref && (
+              <a
+                href={previewHref}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-primary hover:underline"
+              >
+                预览
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            )}
+          </div>
         )}
       </div>
     </div>
   );
 }
 
+function normalizeRetrievedBlocks(value: unknown): RetrievedBlock[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is RetrievedBlock => Boolean(item && typeof item === "object"));
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed)
+        ? parsed.filter((item): item is RetrievedBlock => Boolean(item && typeof item === "object"))
+        : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function RetrievedBlocks({ blocks }: { blocks: RetrievedBlock[] }) {
+  if (blocks.length === 0) {
+    return null;
+  }
+
+  return (
+    <details className="w-full mt-2 rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
+      <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+        Retrieved blocks ({blocks.length})
+      </summary>
+      <div className="mt-3 space-y-3">
+        {blocks.map((block, index) => {
+          const score = Number(block.similarity_score);
+          const scoreText = Number.isFinite(score) ? score.toFixed(3) : "-";
+          const filename = block.filename || "unknown";
+          const kbName = block.kb_name || block.kb_id || "Unknown KB";
+          const detailHref = block.file_detail_url || block.file_url;
+          const previewHref = block.file_preview_url;
+          const blockContent = block.content || block.quote || "(empty chunk)";
+
+          return (
+            <div key={`${block.chunk_id || filename}-${index}`} className="rounded-md border border-border/60 bg-background/80 p-3">
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <strong className="text-foreground">{filename}</strong>
+                <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">KB: {kbName}</span>
+                <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">Chunk: {block.chunk_id || "n/a"}</span>
+                <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">Score: {scoreText}</span>
+                {(detailHref || previewHref) && (
+                  <span className="flex flex-wrap items-center gap-2 ml-auto">
+                    {detailHref && (
+                      <a
+                        href={detailHref}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-primary hover:underline"
+                      >
+                        文件详情
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                    )}
+                    {previewHref && (
+                      <a
+                        href={previewHref}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-primary hover:underline"
+                      >
+                        预览
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                    )}
+                  </span>
+                )}
+              </div>
+              <pre className="mt-3 whitespace-pre-wrap break-words rounded-md bg-muted/60 p-3 text-xs leading-relaxed text-muted-foreground overflow-x-auto">
+                {blockContent}
+              </pre>
+            </div>
+          );
+        })}
+      </div>
+    </details>
+  );
+}
+
 function MessageBubble({ message, index }: { message: Message; index: number }) {
   const isUser = message.role === "user";
+  const retrievedBlocks = normalizeRetrievedBlocks(message.metadata?.retrieved_blocks);
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
@@ -156,6 +285,7 @@ function MessageBubble({ message, index }: { message: Message; index: number }) 
             ))}
           </div>
         )}
+        {!isUser && <RetrievedBlocks blocks={retrievedBlocks} />}
       </div>
     </motion.div>
   );
@@ -342,6 +472,9 @@ export default function Chat() {
       const responseText =
         res.data?.response || res.response || t("chat.no_response");
       const citations = res.data?.citations || res.citations || [];
+      const retrievedBlocks = normalizeRetrievedBlocks(
+        res.data?.retrieved_blocks ?? res.data?.metadata?.retrieved_blocks
+      );
 
       if (res.data?.conversation_id && !activeConvId) {
         setActiveConvId(res.data.conversation_id);
@@ -352,6 +485,10 @@ export default function Chat() {
         role: "assistant",
         content: responseText,
         citations,
+        metadata: {
+          ...(res.data?.metadata || {}),
+          retrieved_blocks: retrievedBlocks,
+        },
       };
       setMessages((prev) => [...prev, assistantMsg]);
     } catch (err: unknown) {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   Building2,
   Activity,
   Search,
+  MessageSquare,
   BookOpen,
   ArrowRight,
   FileIcon,
@@ -164,6 +165,7 @@ export default function Dashboard() {
 
   const quickActions = [
     { icon: Search, title: t("dashboard.browse_db"), desc: t("dashboard.browse_db_desc"), href: "/database", color: "bg-blue-500/10 text-blue-600 dark:text-blue-400" },
+    { icon: MessageSquare, title: t("dashboard.chat"), desc: t("dashboard.chat_desc"), href: "/chat", color: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400" },
     { icon: Activity, title: t("dashboard.task_center"), desc: t("dashboard.task_center_desc"), href: "/tasks", color: "bg-amber-500/10 text-amber-600 dark:text-amber-400" },
     { icon: BookOpen, title: t("knowledge.title"), desc: t("knowledge.subtitle"), href: "/knowledge", color: "bg-violet-500/10 text-violet-600 dark:text-violet-400" },
   ];

--- a/tests/test_chat_react_source.py
+++ b/tests/test_chat_react_source.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+CHAT_TSX = Path(__file__).resolve().parents[1] / "client" / "src" / "pages" / "Chat.tsx"
+
+
+def test_chat_page_renders_citation_quote_fallback_and_retrieved_blocks():
+    src = CHAT_TSX.read_text(encoding="utf-8")
+
+    assert "citation.quote" in src, "Chat citations should render quote fallback from native API responses"
+    assert "retrievedBlocks" in src, "Chat page should track retrieved blocks from the query response"
+    assert "res.data?.retrieved_blocks" in src, "Chat page should read top-level retrieved_blocks from the native chat query contract"
+    assert "Retrieved blocks" in src, "Chat page should render a retrieved blocks section like the legacy Flask UI"

--- a/tests/test_fastapi_chat_endpoints.py
+++ b/tests/test_fastapi_chat_endpoints.py
@@ -372,3 +372,117 @@ def test_fastapi_chat_query_flow_works_with_native_service_contract(tmp_path: Pa
     assert "Solvency II" in payload["response"]
     assert payload["metadata"]["model"] == "fake-chat-model"
     assert payload["citations"][0]["filename"] == "solvency.pdf"
+
+
+
+def test_fastapi_chat_query_maps_llm_exceptions_to_api_error(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    import ai_actuarial.api.services.chat as chat_service
+
+    class FakeConversationManager:
+        def __init__(self, storage, config):
+            self.storage = storage
+            chat_service._ensure_conversation_schema(storage)
+
+        def create_conversation(self, user_id: str, kb_id: str | None = None, mode: str = "expert", metadata=None):
+            conversation_id = "conv_llm_error"
+            now = "2026-04-16T00:00:00+00:00"
+            self.storage._conn.execute("DELETE FROM messages WHERE conversation_id = ?", (conversation_id,))
+            self.storage._conn.execute("DELETE FROM conversations WHERE conversation_id = ?", (conversation_id,))
+            self.storage._conn.execute(
+                "INSERT INTO conversations (conversation_id, user_id, title, kb_id, mode, created_at, updated_at, message_count, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (conversation_id, user_id, "LLM Error", kb_id, mode, now, now, 0, json.dumps(metadata) if metadata else None),
+            )
+            self.storage._conn.commit()
+            return conversation_id
+
+        def get_conversation(self, conversation_id: str):
+            return {"conversation_id": conversation_id, "user_id": "guest:test", "title": "LLM Error", "kb_id": None, "mode": "expert", "created_at": "now", "updated_at": "now", "message_count": 0, "metadata": None}
+
+        def add_message(self, conversation_id: str, role: str, content: str, citations=None, metadata=None):
+            return f"msg_{role}"
+
+        def get_context(self, conversation_id: str):
+            return []
+
+    class FakeRetriever:
+        def __init__(self, storage, config):
+            pass
+
+        def retrieve(self, query, kb_ids):
+            return [{"content": "chunk", "metadata": {"filename": "a.pdf", "kb_id": "chat-kb-a", "kb_name": "Chat KB A", "similarity_score": 0.9, "chunk_id": "chunk-1", "file_url": "https://alpha.example/doc-a.pdf"}}]
+
+    class FakeLLMException(Exception):
+        pass
+
+    class FakeLLMClient:
+        def __init__(self, config, storage=None):
+            pass
+
+        def generate_response(self, query, chunks, mode, conversation_history):
+            raise FakeLLMException("provider down")
+
+    class FakeConfigModule:
+        class ChatbotConfig:
+            @staticmethod
+            def from_config(storage=None, default_mode="expert"):
+                return SimpleNamespace(available_modes=["expert", "summary", "tutorial", "comparison"], similarity_threshold=0.35, model="fake-chat-model", default_mode=default_mode)
+
+    class FakeConversationModule:
+        ConversationManager = FakeConversationManager
+
+    class FakeRetrievalModule:
+        RAGRetriever = FakeRetriever
+
+    class FakeLLMModule:
+        LLMClient = FakeLLMClient
+
+    class FakeRouterModule:
+        QueryRouter = lambda *args, **kwargs: None
+
+    class FakeConversationException(Exception):
+        pass
+
+    class FakeExceptionsModule:
+        class NoResultsException(Exception):
+            pass
+
+        class EmbeddingConfigurationMismatchException(Exception):
+            pass
+
+        LLMException = FakeLLMException
+        ConversationException = FakeConversationException
+        RetrievalException = Exception
+
+    monkeypatch.setattr(
+        chat_service,
+        "_full_chat_modules",
+        lambda: {
+            "config": FakeConfigModule,
+            "conversation": FakeConversationModule,
+            "exceptions": FakeExceptionsModule,
+            "retrieval": FakeRetrievalModule,
+            "llm": FakeLLMModule,
+            "router": FakeRouterModule,
+        },
+    )
+    monkeypatch.setattr(chat_service, "_resolve_chat_user", lambda request, auth: ("guest:test", None))
+
+    response = client.post("/api/chat/query", json={"message": "What is Solvency II?", "kb_ids": ["chat-kb-a"], "mode": "expert"})
+    assert response.status_code == 502, response.text
+    assert response.json()["error"] == "LLM generation failed"
+
+
+
+def test_apply_session_update_is_noop_without_legacy_flask_app() -> None:
+    import ai_actuarial.api.services.chat as chat_service
+
+    response = SimpleNamespace(cookies=[])
+    def set_cookie(**kwargs):
+        response.cookies.append(kwargs)
+    response.set_cookie = set_cookie
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(legacy_flask_app=None)))
+    chat_service.apply_session_update(response, request, chat_service.SessionUpdate({"guest_chat_user_id": "guest:test"}))
+    assert response.cookies == []

--- a/tests/test_fastapi_chat_endpoints.py
+++ b/tests/test_fastapi_chat_endpoints.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+from fastapi.testclient import TestClient
+
+from ai_actuarial.api.app import create_app
+from ai_actuarial.storage import Storage
+
+PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+
+def _write_config_files(base_dir: Path) -> tuple[Path, Path, Path, Path]:
+    files_dir = base_dir / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    db_path = base_dir / "index.db"
+    config_path = base_dir / "sites.yaml"
+    categories_path = base_dir / "categories.yaml"
+
+    config = {
+        "paths": {
+            "db": str(db_path),
+            "download_dir": str(files_dir),
+            "updates_dir": str(base_dir / "updates"),
+            "last_run_new": str(base_dir / "last_run_new.json"),
+        },
+        "defaults": {
+            "user_agent": "test-agent/1.0",
+            "max_pages": 10,
+            "max_depth": 1,
+            "file_exts": [".pdf", ".docx"],
+        },
+        "sites": [],
+        "scheduled_tasks": [],
+    }
+    categories = {"categories": {"AI": ["artificial intelligence"], "Risk": ["capital"]}}
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    categories_path.write_text(yaml.safe_dump(categories, sort_keys=False), encoding="utf-8")
+    return db_path, config_path, categories_path, files_dir
+
+
+
+def _seed_storage(db_path: Path, files_dir: Path) -> dict[str, str]:
+    alpha_path = files_dir / "alpha.pdf"
+    alpha_path.write_bytes(PDF_BYTES)
+    beta_path = files_dir / "beta.pdf"
+    beta_path.write_bytes(PDF_BYTES + b"\n% beta")
+
+    storage = Storage(str(db_path))
+    try:
+        alpha_url = "https://alpha.example/doc-a.pdf"
+        beta_url = "https://beta.example/doc-b.pdf"
+        alpha_sha = hashlib.sha256(alpha_path.read_bytes()).hexdigest()
+        beta_sha = hashlib.sha256(beta_path.read_bytes()).hexdigest()
+
+        storage.insert_file(
+            url=alpha_url,
+            sha256=alpha_sha,
+            title="Alpha Document",
+            source_site="alpha.example",
+            source_page_url="https://alpha.example",
+            original_filename="doc-a.pdf",
+            local_path=str(alpha_path),
+            bytes=alpha_path.stat().st_size,
+            content_type="application/pdf",
+        )
+        storage.insert_file(
+            url=beta_url,
+            sha256=beta_sha,
+            title="Beta Document",
+            source_site="beta.example",
+            source_page_url="https://beta.example",
+            original_filename="doc-b.pdf",
+            local_path=str(beta_path),
+            bytes=beta_path.stat().st_size,
+            content_type="application/pdf",
+        )
+
+        storage.upsert_catalog_item(
+            item={
+                "url": alpha_url,
+                "sha256": alpha_sha,
+                "keywords": ["ai", "solvency"],
+                "summary": "Alpha summary",
+                "category": "AI",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+        storage.upsert_catalog_item(
+            item={
+                "url": beta_url,
+                "sha256": beta_sha,
+                "keywords": ["risk"],
+                "summary": "Beta summary",
+                "category": "Risk",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+        storage.update_file_markdown(alpha_url, "# Alpha\n\nAlpha markdown.", "manual")
+        storage.update_file_markdown(beta_url, "# Beta\n\nBeta markdown.", "manual")
+    finally:
+        storage.close()
+
+    return {"alpha_url": alpha_url, "beta_url": beta_url}
+
+
+
+def _seed_knowledge_bases(client: TestClient) -> None:
+    for kb_id, name in [("chat-kb-a", "Chat KB A"), ("chat-kb-b", "Chat KB B")]:
+        response = client.post(
+            "/api/rag/knowledge-bases",
+            json={
+                "kb_id": kb_id,
+                "name": name,
+                "description": f"{name} description",
+                "kb_mode": "manual",
+                "chunk_size": 300,
+                "chunk_overlap": 50,
+            },
+        )
+        assert response.status_code == 201, response.text
+
+
+
+def _build_test_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, object, dict[str, str]]:
+    db_path, config_path, categories_path, files_dir = _write_config_files(tmp_path)
+    seed = _seed_storage(db_path, files_dir)
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("CATEGORIES_CONFIG_PATH", str(categories_path))
+    monkeypatch.setenv("FLASK_SECRET_KEY", "fastapi-chat-test-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+    app = create_app()
+    client = TestClient(app)
+    _seed_knowledge_bases(client)
+    return client, app, seed
+
+
+
+def test_fastapi_chat_routes_are_listed_in_native_inventory(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    migration = client.get("/api/migration/status")
+    body = migration.json()
+
+    assert "/api/chat/conversations" in body["native_paths"]
+    assert "/api/chat/conversations/{conversation_id}" in body["native_paths"]
+    assert "/api/chat/query" in body["native_paths"]
+    assert "/api/chat/knowledge-bases" in body["native_paths"]
+    assert "/api/chat/available-documents" in body["native_paths"]
+
+
+
+def test_fastapi_chat_conversation_and_catalog_surfaces_work(tmp_path: Path, monkeypatch) -> None:
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch)
+
+    create = client.post("/api/chat/conversations", json={"mode": "expert"})
+    assert create.status_code == 201, create.text
+    conversation_id = create.json()["data"]["conversation_id"]
+
+    listed = client.get("/api/chat/conversations")
+    assert listed.status_code == 200, listed.text
+    conversations = listed.json()["data"]["conversations"]
+    assert any(item["conversation_id"] == conversation_id for item in conversations)
+
+    detail = client.get(f"/api/chat/conversations/{conversation_id}")
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["data"]["conversation"]["conversation_id"] == conversation_id
+    assert detail.json()["data"]["messages"] == []
+
+    kbs = client.get("/api/chat/knowledge-bases")
+    assert kbs.status_code == 200, kbs.text
+    kb_ids = {item["kb_id"] for item in kbs.json()["data"]["knowledge_bases"]}
+    assert {"chat-kb-a", "chat-kb-b"}.issubset(kb_ids)
+
+    documents = client.get("/api/chat/available-documents?keywords=solvency")
+    assert documents.status_code == 200, documents.text
+    docs = documents.json()["data"]["documents"]
+    assert len(docs) == 1
+    assert docs[0]["file_url"] == seed["alpha_url"]
+
+    deleted = client.delete(f"/api/chat/conversations/{conversation_id}")
+    assert deleted.status_code == 200, deleted.text
+
+    missing = client.get(f"/api/chat/conversations/{conversation_id}")
+    assert missing.status_code == 404, missing.text
+
+
+
+def test_fastapi_chat_query_flow_works_with_native_service_contract(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    import ai_actuarial.api.services.chat as chat_service
+
+    class FakeConversationManager:
+        def __init__(self, storage, config):
+            self.storage = storage
+            self.config = config
+            chat_service._ensure_conversation_schema(storage)
+
+        def create_conversation(self, user_id: str, kb_id: str | None = None, mode: str = "expert", metadata=None):
+            conversation_id = "conv_test_query"
+            now = "2026-04-16T00:00:00+00:00"
+            self.storage._conn.execute("DELETE FROM messages WHERE conversation_id = ?", (conversation_id,))
+            self.storage._conn.execute("DELETE FROM conversations WHERE conversation_id = ?", (conversation_id,))
+            self.storage._conn.execute(
+                """
+                INSERT INTO conversations
+                (conversation_id, user_id, title, kb_id, mode, created_at, updated_at, message_count, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    conversation_id,
+                    user_id,
+                    "Test Query Conversation",
+                    kb_id,
+                    mode,
+                    now,
+                    now,
+                    0,
+                    json.dumps(metadata) if metadata else None,
+                ),
+            )
+            self.storage._conn.commit()
+            return conversation_id
+
+        def get_conversation(self, conversation_id: str):
+            row = self.storage._conn.execute(
+                "SELECT conversation_id, user_id, title, kb_id, mode, created_at, updated_at, message_count, metadata FROM conversations WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if not row:
+                return None
+            return {
+                "conversation_id": row[0],
+                "user_id": row[1],
+                "title": row[2],
+                "kb_id": row[3],
+                "mode": row[4],
+                "created_at": row[5],
+                "updated_at": row[6],
+                "message_count": row[7],
+                "metadata": json.loads(row[8]) if row[8] else None,
+            }
+
+        def add_message(self, conversation_id: str, role: str, content: str, citations=None, metadata=None):
+            message_id = f"msg_{role}"
+            self.storage._conn.execute(
+                """
+                INSERT OR REPLACE INTO messages
+                (message_id, conversation_id, role, content, citations, created_at, token_count, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    message_id,
+                    conversation_id,
+                    role,
+                    content,
+                    json.dumps(citations) if citations else None,
+                    "2026-04-16T00:00:00+00:00",
+                    None,
+                    json.dumps(metadata) if metadata else None,
+                ),
+            )
+            self.storage._conn.execute(
+                "UPDATE conversations SET message_count = message_count + 1, updated_at = ? WHERE conversation_id = ?",
+                ("2026-04-16T00:00:00+00:00", conversation_id),
+            )
+            self.storage._conn.commit()
+            return message_id
+
+        def get_context(self, conversation_id: str):
+            return [{"role": "user", "content": "previous question"}]
+
+    class FakeRetriever:
+        def __init__(self, storage, config):
+            self.storage = storage
+            self.config = config
+
+        def retrieve(self, query, kb_ids):
+            return [
+                {
+                    "content": "Solvency II is an EU insurance regulatory framework.",
+                    "metadata": {
+                        "filename": "solvency.pdf",
+                        "kb_id": "chat-kb-a",
+                        "kb_name": "Chat KB A",
+                        "similarity_score": 0.92,
+                        "chunk_id": "chunk-1",
+                        "file_url": "https://alpha.example/doc-a.pdf",
+                    },
+                }
+            ]
+
+    class FakeLLMClient:
+        def __init__(self, config, storage=None):
+            self.config = config
+
+        def generate_response(self, query, chunks, mode, conversation_history):
+            return "Solvency II is a comprehensive prudential regime for insurers."
+
+    class FakeQueryRouter:
+        def __init__(self, storage, config):
+            self.storage = storage
+            self.config = config
+
+        def select_kb(self, query):
+            return ["chat-kb-a"]
+
+    class FakeConfigModule:
+        class ChatbotConfig:
+            @staticmethod
+            def from_config(storage=None, default_mode="expert"):
+                return SimpleNamespace(
+                    available_modes=["expert", "summary", "tutorial", "comparison"],
+                    similarity_threshold=0.35,
+                    model="fake-chat-model",
+                    default_mode=default_mode,
+                )
+
+    class FakeConversationModule:
+        ConversationManager = FakeConversationManager
+
+    class FakeRetrievalModule:
+        RAGRetriever = FakeRetriever
+
+    class FakeLLMModule:
+        LLMClient = FakeLLMClient
+
+    class FakeRouterModule:
+        QueryRouter = FakeQueryRouter
+
+    class FakeExceptionsModule:
+        class NoResultsException(Exception):
+            pass
+
+        class EmbeddingConfigurationMismatchException(Exception):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args)
+
+    monkeypatch.setattr(
+        chat_service,
+        "_full_chat_modules",
+        lambda: {
+            "config": FakeConfigModule,
+            "conversation": FakeConversationModule,
+            "exceptions": FakeExceptionsModule,
+            "retrieval": FakeRetrievalModule,
+            "llm": FakeLLMModule,
+            "router": FakeRouterModule,
+        },
+    )
+
+    response = client.post(
+        "/api/chat/query",
+        json={
+            "message": "What is Solvency II?",
+            "kb_ids": ["chat-kb-a"],
+            "mode": "expert",
+        },
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()["data"]
+    assert payload["conversation_id"] == "conv_test_query"
+    assert payload["message_id"] == "msg_assistant"
+    assert "Solvency II" in payload["response"]
+    assert payload["metadata"]["model"] == "fake-chat-model"
+    assert payload["citations"][0]["filename"] == "solvency.pdf"


### PR DESCRIPTION
## Summary
- add FastAPI-native chat endpoints for conversations, KB/document listing, and query flow
- restore `/chat`, sidebar Chat nav, and Dashboard Chat quick entry in the React shell
- validate native chat with real OpenAI-backed indexing/query using the local KB and docker-provided credentials

## Test Plan
- [x] `python -m pytest tests/test_fastapi_chat_endpoints.py -q`
- [x] `npm run build`
- [x] real `POST /api/rag/knowledge-bases/pr4_browser_qa_kb/index` against local FastAPI server
- [x] real `POST /api/chat/query` against local FastAPI server with OpenAI key from `iaa-agent`
- [x] browser smoke test at `/chat` with KB selection and successful Chinese response

## Notes
- Hermes venv on this machine initially lacked `faiss-cpu`; installed it so host-native chat/RAG imports and real QA can run.
- OpenAI key for local QA was sourced from docker container `iaa-agent` as discussed.
