### PR TITLE
fix: derive chat KB usability from FastAPI runtime

### DIFF
--- a/ai_actuarial/api/services/chat.py
+++ b/ai_actuarial/api/services/chat.py
@@ -11,8 +11,9 @@ from typing import Any, Mapping
 from urllib.parse import quote
 
 from itsdangerous import URLSafeSerializer
-
 from ai_actuarial.api.deps import _decode_flask_session, AuthContext
+from ai_actuarial.ai_runtime import infer_embedding_dimension, resolve_ai_function_runtime
+from ai_actuarial.rag.exceptions import EmbeddingException
 from ai_actuarial.storage import Storage
 from ai_actuarial.shared_auth import AI_CHAT_QUOTA
 
@@ -368,13 +369,44 @@ def delete_conversation(*, db_path: str, request, auth: AuthContext, conversatio
         storage.close()
 
 
+def _embedding_metadata_matches(
+    current: Mapping[str, Any],
+    *,
+    provider: Any,
+    model: Any,
+    dimension: Any,
+) -> bool:
+    current_provider = str(current.get("provider") or "").strip().lower()
+    current_model = str(current.get("model") or "").strip()
+    current_dimension = current.get("dimension")
+
+    index_provider = str(provider or "").strip().lower()
+    index_model = str(model or "").strip()
+    index_dimension = dimension
+
+    if index_provider and current_provider and index_provider != current_provider:
+        return False
+    if index_model and current_model and index_model != current_model:
+        return False
+    if index_dimension not in (None, "") and current_dimension not in (None, ""):
+        try:
+            if int(index_dimension) != int(current_dimension):
+                return False
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+
 def list_knowledge_bases(*, db_path: str) -> dict[str, Any]:
     storage = Storage(db_path)
     try:
+        embeddings_runtime = resolve_ai_function_runtime("embeddings", storage=storage)
         current_embeddings = {
-            "provider": os.getenv("EMBEDDING_PROVIDER", "openai"),
-            "model": os.getenv("EMBEDDING_MODEL", "text-embedding-3-large"),
-            "dimension": None,
+            "provider": embeddings_runtime.provider,
+            "model": embeddings_runtime.model,
+            "dimension": infer_embedding_dimension(embeddings_runtime.model),
+            "credential_source": embeddings_runtime.credential_source,
         }
         knowledge_bases: list[dict[str, Any]] = []
         rows = storage._conn.execute(
@@ -388,6 +420,33 @@ def list_knowledge_bases(*, db_path: str) -> dict[str, Any]:
         for row in rows:
             kb_id = row[0]
             composition = storage.get_kb_composition_status(kb_id)
+            latest_index = composition.get("latest_index") or {}
+            has_index = bool(composition.get("has_index"))
+            kb_provider = row[3] or "openai"
+            kb_model = row[4]
+            kb_dimension = row[5]
+            effective_index_provider = latest_index.get("embedding_provider") or kb_provider
+            effective_index_model = latest_index.get("embedding_model") or kb_model
+            effective_index_dimension = latest_index.get("embedding_dimension")
+            if effective_index_dimension in (None, ""):
+                effective_index_dimension = kb_dimension
+            embedding_compatible = _embedding_metadata_matches(
+                current_embeddings,
+                provider=effective_index_provider,
+                model=effective_index_model,
+                dimension=effective_index_dimension,
+            )
+            needs_reindex = bool(composition.get("needs_reindex")) or (has_index and not embedding_compatible)
+            index_status = str(latest_index.get("status") or "").strip().lower()
+            if not has_index or index_status in {"pending", "queued", "running", "building", "indexing"}:
+                availability = "building"
+                usable = False
+            elif needs_reindex:
+                availability = "needs_reindex"
+                usable = False
+            else:
+                availability = "ready"
+                usable = True
             knowledge_bases.append(
                 {
                     "kb_id": kb_id,
@@ -395,16 +454,18 @@ def list_knowledge_bases(*, db_path: str) -> dict[str, Any]:
                     "description": row[2],
                     "file_count": row[6],
                     "chunk_count": row[7],
-                    "embedding_provider": row[3] or "openai",
-                    "embedding_model": row[4],
-                    "embedding_dimension": row[5],
-                    "index_embedding_provider": composition.get("index_embedding_provider"),
-                    "index_embedding_model": composition.get("index_embedding_model"),
-                    "index_embedding_dimension": composition.get("index_embedding_dimension"),
-                    "index_status": composition.get("index_status"),
-                    "index_built_at": composition.get("index_built_at"),
-                    "needs_reindex": bool(composition.get("needs_reindex")),
-                    "embedding_compatible": bool(composition.get("embedding_compatible", True)),
+                    "embedding_provider": kb_provider,
+                    "embedding_model": kb_model,
+                    "embedding_dimension": kb_dimension,
+                    "index_embedding_provider": effective_index_provider,
+                    "index_embedding_model": effective_index_model,
+                    "index_embedding_dimension": effective_index_dimension,
+                    "index_status": latest_index.get("status") or ("ready" if effective_index_model else None),
+                    "index_built_at": latest_index.get("built_at"),
+                    "needs_reindex": needs_reindex,
+                    "embedding_compatible": embedding_compatible,
+                    "availability": availability,
+                    "usable": usable,
                 }
             )
         return {"success": True, "data": {"knowledge_bases": knowledge_bases, "current_embeddings": current_embeddings}}

--- a/ai_actuarial/api/services/chat.py
+++ b/ai_actuarial/api/services/chat.py
@@ -13,7 +13,6 @@ from urllib.parse import quote
 from itsdangerous import URLSafeSerializer
 from ai_actuarial.api.deps import _decode_flask_session, AuthContext
 from ai_actuarial.ai_runtime import infer_embedding_dimension, resolve_ai_function_runtime
-from ai_actuarial.rag.exceptions import EmbeddingException
 from ai_actuarial.storage import Storage
 from ai_actuarial.shared_auth import AI_CHAT_QUOTA
 
@@ -460,7 +459,7 @@ def list_knowledge_bases(*, db_path: str) -> dict[str, Any]:
                     "index_embedding_provider": effective_index_provider,
                     "index_embedding_model": effective_index_model,
                     "index_embedding_dimension": effective_index_dimension,
-                    "index_status": latest_index.get("status") or ("ready" if effective_index_model else None),
+                    "index_status": latest_index.get("status") or ("ready" if has_index and effective_index_model else None),
                     "index_built_at": latest_index.get("built_at"),
                     "needs_reindex": needs_reindex,
                     "embedding_compatible": embedding_compatible,

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -75,7 +75,7 @@ interface KnowledgeBase {
   file_count?: number;
   chunk_count?: number;
   usable?: boolean;
-  availability?: "ready" | "needs_reindex" | "building" | string;
+  availability?: "ready" | "needs_reindex" | "building" | (string & {});
 }
 
 interface AvailableDocument {

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -74,6 +74,8 @@ interface KnowledgeBase {
   description?: string;
   file_count?: number;
   chunk_count?: number;
+  usable?: boolean;
+  availability?: "ready" | "needs_reindex" | "building" | string;
 }
 
 interface AvailableDocument {
@@ -348,11 +350,15 @@ export default function Chat() {
   async function loadKnowledgeBases() {
     try {
       const res = await apiGet<{ success?: boolean; data?: { knowledge_bases?: KnowledgeBase[] }; knowledge_bases?: KnowledgeBase[] }>("/api/chat/knowledge-bases");
-      setKnowledgeBases(res.data?.knowledge_bases || res.knowledge_bases || []);
+      const nextKnowledgeBases = res.data?.knowledge_bases || res.knowledge_bases || [];
+      setKnowledgeBases(nextKnowledgeBases);
+      setSelectedKbs((prev) => prev.filter((kbId) => nextKnowledgeBases.some((kb) => kb.kb_id === kbId && kb.usable !== false)));
     } catch {
       setKnowledgeBases([]);
+      setSelectedKbs([]);
     }
   }
+
 
   async function loadDocuments() {
     setLoadingDocs(true);
@@ -441,12 +447,13 @@ export default function Chat() {
     const text = input.trim();
     if (!text || sending) return;
 
+    setShowKbDropdown(false);
+    setShowModeDropdown(false);
+    setSending(true);
     setErrorMsg(null);
     const userMsg: Message = { role: "user", content: text };
     setMessages((prev) => [...prev, userMsg]);
     setInput("");
-    setSending(true);
-
     if (inputRef.current) {
       inputRef.current.style.height = "auto";
     }
@@ -512,9 +519,14 @@ export default function Chat() {
   }
 
   function toggleKb(id: string) {
+    const target = knowledgeBases.find((kb) => kb.kb_id === id);
+    if (target?.usable === false) {
+      return;
+    }
     setSelectedKbs((prev) =>
       prev.includes(id) ? prev.filter((k) => k !== id) : [...prev, id]
     );
+    setShowKbDropdown(false);
   }
 
   return (
@@ -743,14 +755,22 @@ export default function Chat() {
                 </p>
                 <div className="grid grid-cols-2 gap-2 text-left">
                   <button
-                    onClick={() => setInput(t("chat.suggestion_1"))}
+                    onClick={() => {
+                      setInput(t("chat.suggestion_1"));
+                      setShowKbDropdown(false);
+                      setShowModeDropdown(false);
+                    }}
                     className="p-3 rounded-lg border border-border bg-card hover:border-primary/30 hover:bg-muted/50 transition-all text-xs text-muted-foreground"
                     data-testid="suggestion-1"
                   >
                     {t("chat.suggestion_1")}
                   </button>
                   <button
-                    onClick={() => setInput(t("chat.suggestion_2"))}
+                    onClick={() => {
+                      setInput(t("chat.suggestion_2"));
+                      setShowKbDropdown(false);
+                      setShowModeDropdown(false);
+                    }}
                     className="p-3 rounded-lg border border-border bg-card hover:border-primary/30 hover:bg-muted/50 transition-all text-xs text-muted-foreground"
                     data-testid="suggestion-2"
                   >
@@ -847,25 +867,37 @@ export default function Chat() {
                         {t("chat.no_kbs")}
                       </div>
                     ) : (
-                      knowledgeBases.map((kb) => (
+                      knowledgeBases.map((kb) => {
+                        const isSelected = selectedKbs.includes(kb.kb_id);
+                        const isUsable = kb.usable !== false;
+                        const availabilityLabel = kb.availability === "needs_reindex"
+                          ? "需重建"
+                          : kb.availability === "building"
+                            ? "构建中"
+                            : kb.availability === "ready"
+                              ? "可用"
+                              : kb.availability || "";
+                        return (
                         <button
                           key={kb.kb_id}
                           onClick={() => toggleKb(kb.kb_id)}
+                          disabled={!isUsable}
                           className={cn(
-                            "w-full text-left px-3 py-2 text-xs hover:bg-muted transition-colors flex items-center gap-2",
-                            selectedKbs.includes(kb.kb_id) && "text-primary font-medium"
+                            "w-full text-left px-3 py-2 text-xs transition-colors flex items-center gap-2",
+                            isUsable ? "hover:bg-muted" : "opacity-60 cursor-not-allowed bg-muted/20",
+                            isSelected && "text-primary font-medium"
                           )}
                           data-testid={`kb-option-${kb.kb_id}`}
                         >
                           <div
                             className={cn(
                               "w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0",
-                              selectedKbs.includes(kb.kb_id)
+                              isSelected
                                 ? "bg-primary border-primary"
                                 : "border-border"
                             )}
                           >
-                            {selectedKbs.includes(kb.kb_id) && (
+                            {isSelected && (
                               <svg className="w-2.5 h-2.5 text-primary-foreground" viewBox="0 0 12 12">
                                 <path d="M10 3L4.5 8.5 2 6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                               </svg>
@@ -873,15 +905,28 @@ export default function Chat() {
                           </div>
                           <div className="min-w-0 flex-1">
                             <span className="truncate block">{kb.name}</span>
-                            {kb.description && (
-                              <span className="text-[10px] text-muted-foreground truncate block">{kb.description}</span>
-                            )}
+                            <div className="flex items-center gap-2 min-w-0">
+                              {kb.description && (
+                                <span className="text-[10px] text-muted-foreground truncate block">{kb.description}</span>
+                              )}
+                              {availabilityLabel && (
+                                <span className={cn(
+                                  "shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-medium",
+                                  kb.availability === "ready" && "bg-emerald-500/10 text-emerald-600",
+                                  kb.availability === "needs_reindex" && "bg-amber-500/10 text-amber-700",
+                                  kb.availability === "building" && "bg-slate-500/10 text-slate-600"
+                                )}>
+                                  {availabilityLabel}
+                                </span>
+                              )}
+                            </div>
                           </div>
                           {kb.chunk_count != null && (
                             <span className="text-[10px] text-muted-foreground shrink-0">{kb.chunk_count} chunks</span>
                           )}
                         </button>
-                      ))
+                        );
+                      })
                     )}
                   </div>
                 </>
@@ -894,6 +939,7 @@ export default function Chat() {
               ref={inputRef}
               value={input}
               onChange={(e) => setInput(e.target.value)}
+              onFocus={() => setShowKbDropdown(false)}
               onKeyDown={handleKeyDown}
               placeholder={t("chat.input_placeholder")}
               rows={1}
@@ -907,6 +953,8 @@ export default function Chat() {
               data-testid="input-chat-message"
             />
             <button
+              type="button"
+              aria-label="Send message"
               onClick={sendMessage}
               disabled={!input.trim() || sending}
               className={cn(

--- a/config/yaml_config.py
+++ b/config/yaml_config.py
@@ -85,7 +85,11 @@ def _get_sites_config_path() -> Path:
 
 
 @lru_cache(maxsize=8)
-def _load_yaml_config_cached(config_path_str: str, cache_version: int) -> Dict[str, Any]:
+def _load_yaml_config_cached(
+    config_path_str: str,
+    cache_version: int,
+    file_signature: tuple[int | None, int | None],
+) -> Dict[str, Any]:
     """
     Load sites.yaml configuration with caching.
     
@@ -95,6 +99,9 @@ def _load_yaml_config_cached(config_path_str: str, cache_version: int) -> Dict[s
             independently.
         cache_version: Version number for cache invalidation. Increment this value
             to force a reload from disk without clearing the entire cache.
+        file_signature: Current file metadata `(mtime_ns, size)` so in-process edits
+            to the same path invalidate the cache without requiring explicit callers
+            to know about `invalidate_config_cache()`.
         
     Returns:
         Dict containing the full configuration
@@ -123,7 +130,12 @@ def load_yaml_config() -> Dict[str, Any]:
     """
     global _cache_version
     config_path = _get_sites_config_path()
-    return _load_yaml_config_cached(str(config_path), _cache_version)
+    try:
+        stat = config_path.stat()
+        file_signature = (stat.st_mtime_ns, stat.st_size)
+    except FileNotFoundError:
+        file_signature = (None, None)
+    return _load_yaml_config_cached(str(config_path), _cache_version, file_signature)
 
 
 def invalidate_config_cache():

--- a/tests/test_fastapi_chat_endpoints.py
+++ b/tests/test_fastapi_chat_endpoints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -176,8 +177,15 @@ def test_fastapi_chat_conversation_and_catalog_surfaces_work(tmp_path: Path, mon
 
     kbs = client.get("/api/chat/knowledge-bases")
     assert kbs.status_code == 200, kbs.text
-    kb_ids = {item["kb_id"] for item in kbs.json()["data"]["knowledge_bases"]}
+    kb_payload = kbs.json()["data"]
+    kb_ids = {item["kb_id"] for item in kb_payload["knowledge_bases"]}
     assert {"chat-kb-a", "chat-kb-b"}.issubset(kb_ids)
+    first_kb = next(item for item in kb_payload["knowledge_bases"] if item["kb_id"] == "chat-kb-a")
+    assert "embedding_compatible" in first_kb
+    assert "needs_reindex" in first_kb
+    assert "index_status" in first_kb
+    assert first_kb["availability"] == "building"
+    assert first_kb["usable"] is False
 
     documents = client.get("/api/chat/available-documents?keywords=solvency")
     assert documents.status_code == 200, documents.text
@@ -190,6 +198,66 @@ def test_fastapi_chat_conversation_and_catalog_surfaces_work(tmp_path: Path, mon
 
     missing = client.get(f"/api/chat/conversations/{conversation_id}")
     assert missing.status_code == 404, missing.text
+
+
+
+def test_fastapi_chat_knowledge_bases_reads_current_embeddings_from_ai_config(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    config_path = Path(os.environ["CONFIG_PATH"])
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["ai_config"] = {
+        "embeddings": {
+            "provider": "mistral",
+            "model": "mistral-embed",
+        }
+    }
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    response = client.get("/api/chat/knowledge-bases")
+    assert response.status_code == 200, response.text
+    current = response.json()["data"]["current_embeddings"]
+    assert current["provider"] == "mistral"
+    assert current["model"] == "mistral-embed"
+
+
+def test_fastapi_chat_knowledge_bases_marks_embedding_mismatch_for_reindex(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    storage = Storage(str(tmp_path / "index.db"))
+    try:
+        storage.create_kb_index_version(
+            kb_id="chat-kb-a",
+            embedding_provider="openai",
+            embedding_model="text-embedding-3-large",
+            embedding_dimension=3072,
+            index_type="Flat",
+            status="ready",
+            chunk_count=1,
+        )
+    finally:
+        storage.close()
+
+    config_path = Path(os.environ["CONFIG_PATH"])
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["ai_config"] = {
+        "embeddings": {
+            "provider": "mistral",
+            "model": "mistral-embed",
+        }
+    }
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    response = client.get("/api/chat/knowledge-bases")
+    assert response.status_code == 200, response.text
+    payload = response.json()["data"]
+    kb = next(item for item in payload["knowledge_bases"] if item["kb_id"] == "chat-kb-a")
+    assert kb["embedding_compatible"] is False
+    assert kb["needs_reindex"] is True
+    assert kb["index_embedding_provider"] == "openai"
+    assert kb["index_embedding_model"] == "text-embedding-3-large"
+    assert kb["availability"] == "needs_reindex"
+    assert kb["usable"] is False
 
 
 
@@ -472,6 +540,106 @@ def test_fastapi_chat_query_maps_llm_exceptions_to_api_error(tmp_path: Path, mon
     response = client.post("/api/chat/query", json={"message": "What is Solvency II?", "kb_ids": ["chat-kb-a"], "mode": "expert"})
     assert response.status_code == 502, response.text
     assert response.json()["error"] == "LLM generation failed"
+
+
+
+def test_fastapi_chat_query_maps_embedding_mismatch_to_409_payload(tmp_path: Path, monkeypatch) -> None:
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+
+    import ai_actuarial.api.services.chat as chat_service
+
+    class FakeConversationManager:
+        def __init__(self, storage, config):
+            self.storage = storage
+            chat_service._ensure_conversation_schema(storage)
+
+        def create_conversation(self, user_id: str, kb_id: str | None = None, mode: str = "expert", metadata=None):
+            return "conv_embedding_mismatch"
+
+        def get_conversation(self, conversation_id: str):
+            return None
+
+        def add_message(self, conversation_id: str, role: str, content: str, citations=None, metadata=None):
+            return f"msg_{role}"
+
+        def get_context(self, conversation_id: str):
+            return []
+
+    class FakeMismatchError(Exception):
+        def __init__(self):
+            super().__init__("KB embedding configuration mismatch")
+            self.kb_id = "chat-kb-a"
+            self.current_provider = "mistral"
+            self.current_model = "mistral-embed"
+            self.current_dimension = None
+            self.index_provider = "openai"
+            self.index_model = "text-embedding-3-large"
+            self.index_dimension = 3072
+            self.needs_reindex = True
+
+    class FakeRetriever:
+        def __init__(self, storage, config):
+            pass
+
+        def retrieve(self, query, kb_ids):
+            raise FakeMismatchError()
+
+    class FakeLLMClient:
+        def __init__(self, config, storage=None):
+            pass
+
+        def generate_response(self, query, chunks, mode, conversation_history):
+            return "should not be called"
+
+    class FakeConfigModule:
+        class ChatbotConfig:
+            @staticmethod
+            def from_config(storage=None, default_mode="expert"):
+                return SimpleNamespace(available_modes=["expert", "summary", "tutorial", "comparison"], similarity_threshold=0.35, model="fake-chat-model", default_mode=default_mode)
+
+    class FakeConversationModule:
+        ConversationManager = FakeConversationManager
+
+    class FakeRetrievalModule:
+        RAGRetriever = FakeRetriever
+
+    class FakeLLMModule:
+        LLMClient = FakeLLMClient
+
+    class FakeRouterModule:
+        QueryRouter = lambda *args, **kwargs: None
+
+    class FakeExceptionsModule:
+        class NoResultsException(Exception):
+            pass
+
+        EmbeddingConfigurationMismatchException = FakeMismatchError
+        LLMException = RuntimeError
+        ConversationException = RuntimeError
+        RetrievalException = RuntimeError
+
+    monkeypatch.setattr(
+        chat_service,
+        "_full_chat_modules",
+        lambda: {
+            "config": FakeConfigModule,
+            "conversation": FakeConversationModule,
+            "exceptions": FakeExceptionsModule,
+            "retrieval": FakeRetrievalModule,
+            "llm": FakeLLMModule,
+            "router": FakeRouterModule,
+        },
+    )
+    monkeypatch.setattr(chat_service, "_resolve_chat_user", lambda request, auth: ("guest:test", None))
+
+    response = client.post("/api/chat/query", json={"message": "What is Solvency II?", "kb_ids": ["chat-kb-a"], "mode": "expert"})
+    assert response.status_code == 409, response.text
+    payload = response.json()
+    assert payload["code"] == "KB_EMBEDDING_MISMATCH"
+    assert payload["data"]["kb_id"] == "chat-kb-a"
+    assert payload["data"]["current_embedding"]["provider"] == "mistral"
+    assert payload["data"]["index_embedding"]["provider"] == "openai"
+    assert payload["data"]["needs_reindex"] is True
 
 
 

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -182,6 +182,8 @@ def test_fastapi_rag_admin_chunk_profiles_and_kb_crud_work(tmp_path: Path, monke
     assert create_kb.status_code == 201, create_kb.text
     kb = create_kb.json()["knowledge_base"]
     assert kb["kb_id"] == "kb-pr4-test"
+    assert kb["embedding_model"] == "text-embedding-3-large"
+    assert kb["embedding_provider"] == "openai"
 
     list_kbs = client.get("/api/rag/knowledge-bases")
     assert list_kbs.status_code == 200, list_kbs.text


### PR DESCRIPTION
## Summary
- derive `/api/chat/knowledge-bases` availability and usability from the active FastAPI embeddings runtime
- invalidate YAML config cache automatically when the same config file path changes on disk
- update the chat UI to respect backend `usable` / `availability` state and close KB / mode overlays more predictably
- keep never-indexed KBs out of the `ready` state

## Test Plan
- [x] `python -m pytest tests/test_fastapi_chat_endpoints.py tests/test_fastapi_rag_admin_endpoints.py -q`
- [x] `npm run build`
- [x] real browser verification of Chat KB selection and send flow

## Notes
- this PR only covers the Chat / RAG usability convergence
- the Knowledge panel toggle bugfix will go in a follow-up PR
