### PR TITLE
feat: restore native global logs page

### DIFF
--- a/ai_actuarial/api/routers/ops_read.py
+++ b/ai_actuarial/api/routers/ops_read.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -26,12 +27,40 @@ from ..services.ops_read import (
 
 router = APIRouter()
 
+_GLOBAL_LOGS_RATE_LIMIT = 30
+_GLOBAL_LOGS_WINDOW_SECONDS = 60.0
+
 
 def _get_db_path(request: Request) -> str:
     db_path = str(getattr(request.app.state, "db_path", "") or "")
     if not db_path:
         raise HTTPException(status_code=500, detail="Database path is unavailable")
     return db_path
+
+
+def _global_logs_rate_key(request: Request, auth: AuthContext) -> str:
+    token = auth.token or {}
+    if token.get("_email_user_id") is not None:
+        return f"user:{token['_email_user_id']}"
+    if token.get("id") is not None:
+        return f"token:{token['id']}"
+    client_host = getattr(getattr(request, "client", None), "host", None) or "unknown"
+    return f"ip:{client_host}"
+
+
+def _enforce_global_logs_rate_limit(request: Request, auth: AuthContext) -> JSONResponse | None:
+    now = time.monotonic()
+    bucket_key = _global_logs_rate_key(request, auth)
+    buckets = getattr(request.app.state, "global_logs_rate_limit_buckets", None)
+    if not isinstance(buckets, dict):
+        buckets = {}
+        request.app.state.global_logs_rate_limit_buckets = buckets
+    recent = [stamp for stamp in buckets.get(bucket_key, []) if now - stamp < _GLOBAL_LOGS_WINDOW_SECONDS]
+    if len(recent) >= _GLOBAL_LOGS_RATE_LIMIT:
+        return JSONResponse(status_code=429, content={"error": "Rate limit exceeded"})
+    recent.append(now)
+    buckets[bucket_key] = recent
+    return None
 
 
 @router.get("/config/sites")
@@ -100,6 +129,9 @@ def api_logs_global(
     request: Request,
     _auth: AuthContext = Depends(require_permissions("logs.system.read")),
 ) -> dict[str, object]:
+    rate_limited = _enforce_global_logs_rate_limit(request, _auth)
+    if rate_limited is not None:
+        return rate_limited
     expected_token = os.getenv("LOGS_READ_AUTH_TOKEN")
     if expected_token:
         provided_token = request.headers.get("X-Auth-Token")

--- a/ai_actuarial/api/routers/ops_read.py
+++ b/ai_actuarial/api/routers/ops_read.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -11,6 +12,7 @@ from ..services.ops_read import (
     get_backend_settings,
     get_config_categories,
     get_config_sites,
+    get_global_logs,
     get_llm_providers,
     get_schedule_status,
     get_scheduled_tasks,
@@ -91,6 +93,22 @@ def api_task_log(
         return get_task_log(task_id, tail)
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"error": str(exc)})
+
+
+@router.get("/logs/global")
+def api_logs_global(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("logs.system.read")),
+) -> dict[str, object]:
+    expected_token = os.getenv("LOGS_READ_AUTH_TOKEN")
+    if expected_token:
+        provided_token = request.headers.get("X-Auth-Token")
+        if not provided_token or provided_token != expected_token:
+            return JSONResponse(status_code=403, content={"error": "Forbidden"})
+    result = get_global_logs()
+    if result.get("error") == "Forbidden":
+        return JSONResponse(status_code=403, content={"error": "Forbidden"})
+    return result
 
 
 @router.get("/config/backend-settings")

--- a/ai_actuarial/api/services/ops_read.py
+++ b/ai_actuarial/api/services/ops_read.py
@@ -76,9 +76,7 @@ def get_global_logs() -> dict[str, str]:
     if not log_file.exists():
         return {"logs": "No logs found."}
 
-    with open(log_file, "r", encoding="utf-8", errors="replace") as handle:
-        all_lines = handle.readlines()
-    lines = all_lines[-500:]
+    lines = tail_text_file(log_file, max_lines=500).splitlines(keepends=True)
     lines.reverse()
     return {"logs": "".join(lines)}
 

--- a/ai_actuarial/api/services/ops_read.py
+++ b/ai_actuarial/api/services/ops_read.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
 from typing import Any
 
 import ai_actuarial.llm_models as llm_models
@@ -64,6 +65,22 @@ def get_backend_settings() -> dict[str, Any]:
         if "categories_config_path" in runtime:
             runtime["categories_config_path_set"] = bool(runtime.pop("categories_config_path", None))
     return settings
+
+
+def get_global_logs() -> dict[str, str]:
+    enable_global_logs_api = str(os.getenv("ENABLE_GLOBAL_LOGS_API") or "").strip().lower()
+    if enable_global_logs_api not in {"1", "true", "yes", "on"}:
+        return {"error": "Forbidden"}
+
+    log_file = Path("data") / "app.log"
+    if not log_file.exists():
+        return {"logs": "No logs found."}
+
+    with open(log_file, "r", encoding="utf-8", errors="replace") as handle:
+        all_lines = handle.readlines()
+    lines = all_lines[-500:]
+    lines.reverse()
+    return {"logs": "".join(lines)}
 
 
 def get_search_engines() -> dict[str, list[dict[str, object]]]:

--- a/ai_actuarial/shared_runtime.py
+++ b/ai_actuarial/shared_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -76,8 +77,8 @@ def tail_text_file(path: Path, max_lines: int = 400) -> str:
     if max_lines <= 0 or not path.exists():
         return ""
     with path.open("r", encoding="utf-8", errors="replace") as handle:
-        lines = handle.readlines()
-    return "".join(lines[-max_lines:])
+        lines = deque(handle, maxlen=max_lines)
+    return "".join(lines)
 
 
 def serialize_backend_settings(config_data: dict[str, Any]) -> dict[str, Any]:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,7 @@ import FilePreview from "@/pages/FilePreview";
 import KBDetail from "@/pages/KBDetail";
 import Knowledge from "@/pages/Knowledge";
 import Login from "@/pages/Login";
-import NativeLogs from "@/pages/NativeLogs";
+import LogsPage from "@/pages/Logs";
 import Profile from "@/pages/Profile";
 import Register from "@/pages/Register";
 import SettingsPage from "@/pages/Settings";
@@ -55,7 +55,7 @@ function Router() {
             </Route>
             <Route path="/logs">
               <RequireAuth>
-                <NativeLogs />
+                <LogsPage />
               </RequireAuth>
             </Route>
             <Route path="/knowledge/:kbId">

--- a/tests/fixtures/flask_api_route_signatures.json
+++ b/tests/fixtures/flask_api_route_signatures.json
@@ -4,7 +4,6 @@
     "GET /api/collections/history",
     "GET /api/config/search-defaults",
     "GET /api/files/<path:file_url>/indexes",
-    "GET /api/logs/global",
     "GET /api/rag/knowledge-bases/<kb_id>/composition/status",
     "GET /api/rag/knowledge-bases/<kb_id>/tasks",
     "GET /api/user/quota",

--- a/tests/test_fastapi_entrypoint.py
+++ b/tests/test_fastapi_entrypoint.py
@@ -68,8 +68,8 @@ def test_fastapi_migration_inventory_exposes_native_and_legacy_routes_when_enabl
 def test_unported_legacy_api_fallback_is_blocked_by_default() -> None:
     client = TestClient(create_app())
 
-    response = client.get("/api/logs/global")
-    head_response = client.head("/api/logs/global")
+    response = client.get("/api/collections/history")
+    head_response = client.head("/api/collections/history")
 
     assert response.status_code == 410
     assert "Legacy Flask /api fallback is disabled" in response.json()["detail"]

--- a/tests/test_fastapi_ops_read_endpoints.py
+++ b/tests/test_fastapi_ops_read_endpoints.py
@@ -417,8 +417,6 @@ def test_fastapi_ai_config_registry_credentials_and_routing_read_endpoints(tmp_p
     assert bindings["embeddings"]["provider"] == "openai"
     assert bindings["embeddings"]["embedding_fingerprint"].startswith("openai:text-embedding-3-large:")
 
-
-
 def test_fastapi_global_logs_read_endpoint_is_native(tmp_path: Path, monkeypatch) -> None:
     _patch_available_models(monkeypatch)
     client, app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
@@ -431,19 +429,22 @@ def test_fastapi_global_logs_read_endpoint_is_native(tmp_path: Path, monkeypatch
         encoding="utf-8",
     )
 
-    admin_token = "admin-token"
     storage = Storage(str(app.state.db_path))
     try:
-        storage.upsert_auth_token_by_hash(
-            subject="admin-token",
-            group_name="admin",
-            token_hash=hashlib.sha256(admin_token.encode("utf-8")).hexdigest(),
-            is_active=True,
+        admin_user_id = storage.create_user(
+            "admin@example.com",
+            "admin-password-hash",
+            role="admin",
+            display_name="Admin",
         )
     finally:
         storage.close()
 
-    response = client.get("/api/logs/global", headers={"Authorization": f"Bearer {admin_token}"})
+    cookie_name = app.state.legacy_flask_app.config.get("SESSION_COOKIE_NAME", "session")
+    session_cookie = _make_session_cookie(app, {"email_user_id": admin_user_id})
+    client.cookies.set(cookie_name, session_cookie)
+
+    response = client.get("/api/logs/global")
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["logs"].splitlines()[0].endswith("ERROR second")

--- a/tests/test_fastapi_ops_read_endpoints.py
+++ b/tests/test_fastapi_ops_read_endpoints.py
@@ -416,3 +416,35 @@ def test_fastapi_ai_config_registry_credentials_and_routing_read_endpoints(tmp_p
     assert bindings["chat"]["config_section"] == "chatbot"
     assert bindings["embeddings"]["provider"] == "openai"
     assert bindings["embeddings"]["embedding_fingerprint"].startswith("openai:text-embedding-3-large:")
+
+
+
+def test_fastapi_global_logs_read_endpoint_is_native(tmp_path: Path, monkeypatch) -> None:
+    _patch_available_models(monkeypatch)
+    client, app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ENABLE_GLOBAL_LOGS_API", "1")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "app.log").write_text(
+        "2026-04-17 10:00:00 INFO first\n2026-04-17 10:01:00 ERROR second\n",
+        encoding="utf-8",
+    )
+
+    admin_token = "admin-token"
+    storage = Storage(str(app.state.db_path))
+    try:
+        storage.upsert_auth_token_by_hash(
+            subject="admin-token",
+            group_name="admin",
+            token_hash=hashlib.sha256(admin_token.encode("utf-8")).hexdigest(),
+            is_active=True,
+        )
+    finally:
+        storage.close()
+
+    response = client.get("/api/logs/global", headers={"Authorization": f"Bearer {admin_token}"})
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["logs"].splitlines()[0].endswith("ERROR second")
+    assert body["logs"].splitlines()[1].endswith("INFO first")

--- a/tests/test_react_fastapi_authority.py
+++ b/tests/test_react_fastapi_authority.py
@@ -20,7 +20,7 @@ PRODUCT_SOURCE_FILES = [
     ROOT / "pages" / "KBDetail.tsx",
     ROOT / "pages" / "Knowledge.tsx",
     ROOT / "pages" / "Login.tsx",
-    ROOT / "pages" / "NativeLogs.tsx",
+    ROOT / "pages" / "Logs.tsx",
     ROOT / "pages" / "NativeSettings.tsx",
     ROOT / "pages" / "Profile.tsx",
     ROOT / "pages" / "Register.tsx",


### PR DESCRIPTION
## Summary
- port `GET /api/logs/global` to native FastAPI
- restore `/logs` to the full `Logs.tsx` page instead of `NativeLogs`
- remove `GET /api/logs/global` from the frozen Flask-only API baseline
- add native endpoint and authority regression coverage for the restored logs page

## Test Plan
- `python -m pytest tests/test_fastapi_entrypoint.py::test_unported_legacy_api_fallback_is_blocked_by_default tests/test_fastapi_ops_read_endpoints.py::test_fastapi_global_logs_read_endpoint_is_native tests/test_flask_api_boundary.py tests/test_react_fastapi_authority.py -q`
- `npm run build`

## Scope
This PR only restores the full Logs page by making its last Flask-only API dependency native.
