### PR TITLE
fix: require fixed token encryption key from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,10 +50,14 @@ SILICONFLOW_API_KEY=
 # Flask secret key for session management (generate with: python -c "import secrets; print(secrets.token_hex(32))")
 SECRET_KEY=your-secret-key-here
 
-# Token encryption key for API token management (generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
-# This key is used to encrypt API tokens stored in the database
-# IMPORTANT: Keep this key secure and backed up. If lost, all stored API tokens will be unrecoverable.
-TOKEN_ENCRYPTION_KEY=
+# Token encryption key for provider/API credential management
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# This key is required to decrypt provider credentials stored in the database.
+# The service now fails fast if TOKEN_ENCRYPTION_KEY is missing.
+# Do NOT rely on auto-generated or file-based fallback keys.
+# Keep this key stable across restarts/deployments and back it up securely.
+# If it changes or is lost, all previously stored provider credentials become unreadable.
+TOKEN_ENCRYPTION_KEY=***
 
 # ===================================
 # CONFIGURATION MOVED TO sites.yaml

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ AI Actuarial Info Search is a system for discovering, downloading, and catalogin
 - Python 3.10+
 - Node.js 18+（含 npm，仅 React 界面需要）
 - （可选）AI 服务的 API Key，配置在 `config/sites.yaml` 或 `.env`
+- 如果要使用数据库里保存的 provider credentials，必须在进程环境或项目 `.env` 中设置固定的 `TOKEN_ENCRYPTION_KEY`
 
 ### 只启动 Flask 界面（最简单，端口 8000）
 
@@ -276,15 +277,38 @@ flowchart LR
 ### Environment Variables
 - Web search keys: `BRAVE_API_KEY`, `SERPAPI_API_KEY`
 - Markdown conversion API keys: `MISTRAL_API_KEY`, `SILICONFLOW_API_KEY`, `SILICONFLOW_BASE_URL`
+- Provider credential encryption key: `TOKEN_ENCRYPTION_KEY`（必须稳定；用于解密数据库中保存的 provider credentials）
 - File deletion: set `ENABLE_FILE_DELETION=true` before starting the web service
 - Authentication: `REQUIRE_AUTH=true` (default: false for guest read-only mode)
+
+### Provider Credential Encryption Key
+
+- `TOKEN_ENCRYPTION_KEY` 用于加解密数据库中的 provider credentials。
+- 可以来自：
+  - **进程环境变量**
+  - **项目根目录 `.env`**
+- 当前实现**不会再自动生成 key**，也**不会再使用 key-file fallback**。
+- 如果缺少这个变量，服务会在启动或首次使用加密服务时直接报错。
+- 如果更换了这个 key，历史上已经存入数据库的 provider credentials 将无法解密。
+
+生成示例：
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+建议把生成后的值写入项目 `.env`：
+
+```dotenv
+TOKEN_ENCRYPTION_KEY=your-generated-fernet-key
+```
 
 ### Configuration Migration (2026-02-15)
 The project has migrated from `.env` file configuration to YAML-based configuration with backward compatibility:
 
 - **New**: AI provider settings in `config/sites.yaml` under `ai_providers` section
 - **Backward Compatible**: `.env` file still supported for API keys and basic settings
-- **Flexible**: Mix and match - use `.env` for secrets and `sites.yaml` for structured config
+- **Flexible**: Mix and match - use `.env` for secrets (including `TOKEN_ENCRYPTION_KEY`) and `sites.yaml` for structured config
 - **Migration Guide**: See `docs/20260215_CONFIG_MIGRATION_PLAN.md`
 
 ### AI Provider Configuration
@@ -303,6 +327,14 @@ ai_providers:
     api_key: "${DEEPSEEK_API_KEY}"
     default_model: "deepseek-chat"
 ```
+
+Provider/model binding lives in `config/sites.yaml`, while secrets may still come from `.env`.
+
+Important for database-backed provider credentials:
+
+- Settings / FastAPI write APIs can persist provider credentials into the database.
+- Those stored credentials require a stable `TOKEN_ENCRYPTION_KEY` to remain readable across restarts and deployments.
+- `.env.example` documents the required variable.
 
 See `.env.example` for all available environment variables.
 

--- a/ai_actuarial/api/routers/ops_write.py
+++ b/ai_actuarial/api/routers/ops_write.py
@@ -20,8 +20,10 @@ from ..services.ops_write import (
     get_catalog_stats,
     get_chunk_generation_stats,
     get_markdown_conversion_stats,
+    import_provider_credentials_from_env,
     import_sites,
     list_backups,
+    reencrypt_provider_credentials,
     request_task_stop,
     reinitialize_scheduler,
     restore_backup,
@@ -233,6 +235,40 @@ def api_config_provider_credentials_upsert(
             if not provided_token or provided_token != expected_token:
                 return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return upsert_provider_credential(payload, db_path=_db_path(request))
+    except OpsWriteError as exc:
+        return _handle_ops_error(exc)
+
+
+@router.post("/config/provider-credentials/import-env")
+def api_config_provider_credentials_import_env(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        expected_token = os.getenv("CONFIG_WRITE_AUTH_TOKEN")
+        if expected_token:
+            provided_token = request.headers.get("X-Auth-Token")
+            if not provided_token or provided_token != expected_token:
+                return JSONResponse(status_code=403, content={"error": "Forbidden"})
+        return import_provider_credentials_from_env(payload, db_path=_db_path(request))
+    except OpsWriteError as exc:
+        return _handle_ops_error(exc)
+
+
+@router.post("/config/provider-credentials/re-encrypt")
+def api_config_provider_credentials_reencrypt(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        expected_token = os.getenv("CONFIG_WRITE_AUTH_TOKEN")
+        if expected_token:
+            provided_token = request.headers.get("X-Auth-Token")
+            if not provided_token or provided_token != expected_token:
+                return JSONResponse(status_code=403, content={"error": "Forbidden"})
+        return reencrypt_provider_credentials(payload, db_path=_db_path(request))
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
 

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from cryptography.fernet import Fernet
 
 from ai_actuarial import llm_models
 from ai_actuarial.ai_runtime import (
@@ -779,6 +780,147 @@ def _apply_default_provider_env(provider: str, default_row: dict[str, Any] | Non
         os.environ[key_env] = api_key
     if base_env and default_row.get("api_base_url"):
         os.environ[base_env] = str(default_row.get("api_base_url"))
+
+
+
+def import_provider_credentials_from_env(data: dict[str, Any] | None, *, db_path: str) -> dict[str, Any]:
+    payload = _coerce_required_dict(data or {})
+    overwrite = bool(payload.get("overwrite", False))
+    providers_filter = {
+        str(item).strip().lower()
+        for item in (payload.get("providers") or [])
+        if str(item).strip()
+    }
+
+    from ai_actuarial.services.token_encryption import TokenEncryption
+
+    storage = Storage(db_path)
+    imported: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    try:
+        for provider, (key_env, base_env) in sorted(PROVIDER_STARTUP_ENV_MAP.items()):
+            if providers_filter and provider not in providers_filter:
+                continue
+            api_key = str(os.getenv(key_env) or "").strip()
+            if not api_key:
+                continue
+            category = "search" if bool(KNOWN_LLM_PROVIDERS.get(provider, {}).get("is_search_provider")) else "llm"
+            existing = storage.get_llm_provider(provider, category=category, instance_id="default")
+            if existing and not overwrite:
+                skipped.append({"provider_id": provider, "category": category, "reason": "default_instance_exists"})
+                continue
+            encrypted_key = TokenEncryption().encrypt(api_key)
+            token_id = storage.upsert_llm_provider(
+                provider=provider,
+                api_key_encrypted=encrypted_key,
+                base_url=str(os.getenv(base_env) or "").strip() or None if base_env else None,
+                notes="imported from environment",
+                category=category,
+                instance_id="default",
+                label=f"{provider} ({category})",
+                is_default=True,
+            )
+            default_row = storage.get_llm_provider(provider, category=category, instance_id="default")
+            _apply_default_provider_env(provider, default_row)
+            imported.append(
+                {
+                    "provider_id": provider,
+                    "category": category,
+                    "credential_id": f"{provider}:{category}:db:{token_id}",
+                    "base_url": (default_row or {}).get("api_base_url"),
+                }
+            )
+    finally:
+        storage.close()
+
+    _reload_runtime_caches()
+    return {
+        "success": True,
+        "imported_count": len(imported),
+        "skipped_count": len(skipped),
+        "imported": imported,
+        "skipped": skipped,
+    }
+
+
+
+def reencrypt_provider_credentials(data: dict[str, Any] | None, *, db_path: str) -> dict[str, Any]:
+    payload = _coerce_required_dict(data or {})
+    old_key = str(payload.get("old_key") or "").strip()
+    new_key = str(payload.get("new_key") or "").strip() or str(os.getenv("TOKEN_ENCRYPTION_KEY") or "").strip()
+    category_filter = str(payload.get("category") or "").strip().lower() or None
+    providers_filter = {
+        str(item).strip().lower()
+        for item in (payload.get("providers") or [])
+        if str(item).strip()
+    }
+    if not old_key:
+        raise OpsWriteError("old_key is required")
+    if not new_key:
+        raise OpsWriteError("new_key is required or TOKEN_ENCRYPTION_KEY must be set")
+
+    try:
+        old_cipher = Fernet(old_key.encode())
+        new_cipher = Fernet(new_key.encode())
+    except Exception as exc:
+        raise OpsWriteError("Invalid encryption key format") from exc
+
+    storage = Storage(db_path)
+    rotated: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+    try:
+        categories = [category_filter] if category_filter else ["llm", "search"]
+        for category in categories:
+            for entry in storage.list_llm_providers(category=category):
+                provider_id = str(entry.get("provider") or "").strip().lower()
+                if providers_filter and provider_id not in providers_filter:
+                    continue
+                encrypted_value = str(entry.get("api_key_encrypted") or "")
+                if not encrypted_value:
+                    continue
+                try:
+                    plaintext = old_cipher.decrypt(encrypted_value.encode()).decode()
+                    reencrypted = new_cipher.encrypt(plaintext.encode()).decode()
+                except Exception:
+                    failed.append(
+                        {
+                            "provider_id": provider_id,
+                            "category": category,
+                            "instance_id": str(entry.get("instance_id") or "default").strip() or "default",
+                        }
+                    )
+                    continue
+                storage.upsert_llm_provider(
+                    provider=provider_id,
+                    api_key_encrypted=reencrypted,
+                    base_url=str(entry.get("api_base_url") or "").strip() or None,
+                    notes=entry.get("notes"),
+                    category=category,
+                    instance_id=str(entry.get("instance_id") or "default").strip() or "default",
+                    label=str(entry.get("label") or "").strip() or None,
+                    is_default=bool(entry.get("is_default", True)),
+                )
+                rotated.append(
+                    {
+                        "provider_id": str(entry.get("provider") or "").strip().lower(),
+                        "category": category,
+                        "instance_id": str(entry.get("instance_id") or "default").strip() or "default",
+                    }
+                )
+        for provider in {item["provider_id"] for item in rotated}:
+            default_row = storage.get_llm_provider(provider, category="llm") or storage.get_llm_provider(provider, category="search")
+            _apply_default_provider_env(provider, default_row)
+    finally:
+        storage.close()
+
+    _reload_runtime_caches()
+    return {
+        "success": True,
+        "rotated_count": len(rotated),
+        "failed_count": len(failed),
+        "rotated": rotated,
+        "failed": failed,
+    }
 
 
 

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -765,21 +765,26 @@ def _apply_default_provider_env(provider: str, default_row: dict[str, Any] | Non
         os.environ.pop(key_env, None)
     if base_env:
         os.environ.pop(base_env, None)
-    if not default_row:
+    if not default_row or not key_env:
         return
-    api_key: str | None = None
     try:
         from ai_actuarial.services.token_encryption import TokenEncryption
-
         api_key = TokenEncryption().decrypt(str(default_row.get("api_key_encrypted") or ""))
-        if api_key == OPTIONAL_API_KEY_SENTINEL:
-            api_key = None
     except Exception:
-        api_key = None
-    if key_env and api_key:
+        return
+    if api_key and api_key != OPTIONAL_API_KEY_SENTINEL:
         os.environ[key_env] = api_key
     if base_env and default_row.get("api_base_url"):
         os.environ[base_env] = str(default_row.get("api_base_url"))
+
+
+def _set_runtime_token_encryption_key(key: str) -> None:
+    normalized = str(key or "").strip()
+    if not normalized:
+        return
+    os.environ["TOKEN_ENCRYPTION_KEY"] = normalized
+    from ai_actuarial.services.token_encryption import TokenEncryption
+    TokenEncryption._instance = None
 
 
 
@@ -809,7 +814,13 @@ def import_provider_credentials_from_env(data: dict[str, Any] | None, *, db_path
             if existing and not overwrite:
                 skipped.append({"provider_id": provider, "category": category, "reason": "default_instance_exists"})
                 continue
-            encrypted_key = TokenEncryption().encrypt(api_key)
+            try:
+                encrypted_key = TokenEncryption().encrypt(api_key)
+            except ValueError as exc:
+                raise OpsWriteError(
+                    "Provider credential import is unavailable because token encryption is not configured correctly.",
+                    status=503,
+                ) from exc
             token_id = storage.upsert_llm_provider(
                 provider=provider,
                 api_key_encrypted=encrypted_key,
@@ -827,7 +838,7 @@ def import_provider_credentials_from_env(data: dict[str, Any] | None, *, db_path
                     "provider_id": provider,
                     "category": category,
                     "credential_id": f"{provider}:{category}:db:{token_id}",
-                    "base_url": (default_row or {}).get("api_base_url"),
+                    "api_base_url": (default_row or {}).get("api_base_url"),
                 }
             )
     finally:
@@ -864,6 +875,8 @@ def reencrypt_provider_credentials(data: dict[str, Any] | None, *, db_path: str)
         new_cipher = Fernet(new_key.encode())
     except Exception as exc:
         raise OpsWriteError("Invalid encryption key format") from exc
+
+    _set_runtime_token_encryption_key(new_key)
 
     storage = Storage(db_path)
     rotated: list[dict[str, Any]] = []
@@ -944,7 +957,13 @@ def upsert_provider_credential(data: dict[str, Any], *, db_path: str) -> dict[st
 
     from ai_actuarial.services.token_encryption import TokenEncryption
 
-    encrypted_key = TokenEncryption().encrypt(api_key or OPTIONAL_API_KEY_SENTINEL)
+    try:
+        encrypted_key = TokenEncryption().encrypt(api_key or OPTIONAL_API_KEY_SENTINEL)
+    except ValueError as exc:
+        raise OpsWriteError(
+            "Provider credential writes are unavailable because token encryption is not configured correctly.",
+            status=503,
+        ) from exc
     storage = Storage(db_path)
     try:
         token_id = storage.upsert_llm_provider(

--- a/ai_actuarial/services/token_encryption.py
+++ b/ai_actuarial/services/token_encryption.py
@@ -72,7 +72,7 @@ class TokenEncryption:
 
     def _get_env_or_dotenv_value(self, key_name: str) -> Optional[str]:
         """Return a config value from process env first, then project .env."""
-        env_value = os.getenv(key_name)
+        env_value = str(os.getenv(key_name) or "").strip()
         if env_value:
             return env_value
 

--- a/ai_actuarial/services/token_encryption.py
+++ b/ai_actuarial/services/token_encryption.py
@@ -7,11 +7,14 @@ Based on RAGFlow best practices for secure token storage.
 """
 import os
 import logging
+import shlex
 import threading
+from pathlib import Path
 from cryptography.fernet import Fernet
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 class TokenEncryption:
@@ -41,8 +44,13 @@ class TokenEncryption:
             with cls._lock:
                 # Double-check pattern for thread safety
                 if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._initialize()
+                    instance = super().__new__(cls)
+                    try:
+                        instance._initialize()
+                    except Exception:
+                        cls._instance = None
+                        raise
+                    cls._instance = instance
         return cls._instance
     
     def _initialize(self):
@@ -52,66 +60,45 @@ class TokenEncryption:
         logger.info("Token encryption service initialized")
     
     def _get_or_create_encryption_key(self) -> bytes:
-        """
-        Get encryption key from environment, persistent key file, or create one.
-
-        Priority:
-          1. TOKEN_ENCRYPTION_KEY env var (highest — set this in production)
-          2. Persistent key file (TOKEN_ENCRYPTION_KEY_FILE env var, or
-             data/token_encryption.key relative to CWD)
-          3. Generate a new key and save it to the key file so it survives restarts
-
-        Returns:
-            Encryption key as bytes
-        """
-        # 1. Explicit env var
-        key_str = os.getenv('TOKEN_ENCRYPTION_KEY')
+        """Get the encryption key from process env or project .env only."""
+        key_str = self._get_env_or_dotenv_value('TOKEN_ENCRYPTION_KEY')
         if key_str:
             return key_str.encode()
 
-        # 2. Persistent key file
-        key_file = self._get_key_file_path()
-        if key_file and os.path.exists(key_file):
-            try:
-                with open(key_file, 'rb') as f:
-                    key = f.read().strip()
-                if key:
-                    logger.info("Token encryption key loaded from key file: %s", key_file)
-                    return key
-            except Exception as exc:
-                logger.warning("Failed to read encryption key file %s: %s", key_file, exc)
-
-        # 3. Generate new key and persist it so the next restart can reuse it
-        logger.warning(
-            "TOKEN_ENCRYPTION_KEY is not set. Generating a new key. "
-            "For production, set TOKEN_ENCRYPTION_KEY in your .env file."
+        raise ValueError(
+            'TOKEN_ENCRYPTION_KEY is required. Set it in the process environment '
+            'or in the project .env file before starting the service.'
         )
-        key = Fernet.generate_key()
-        if key_file:
-            try:
-                os.makedirs(os.path.dirname(os.path.abspath(key_file)), exist_ok=True)
-                with open(key_file, 'wb') as f:
-                    f.write(key)
-                logger.warning(
-                    "Encryption key saved to %s so it persists across restarts. "
-                    "For production, copy this value and set TOKEN_ENCRYPTION_KEY "
-                    "in your .env file instead.", key_file
-                )
-            except Exception as exc:
-                logger.error(
-                    "Could not persist encryption key to %s: %s. "
-                    "All stored API keys will become unreadable on the next restart! "
-                    "Set TOKEN_ENCRYPTION_KEY in your .env file to fix this.", key_file, exc
-                )
-        return key
 
-    def _get_key_file_path(self) -> Optional[str]:
-        """Return the path to use for the persistent key file."""
-        explicit = os.getenv('TOKEN_ENCRYPTION_KEY_FILE')
-        if explicit:
-            return explicit
-        # Default: data/token_encryption.key (data/ is already gitignored)
-        return os.path.join(os.getcwd(), 'data', 'token_encryption.key')
+    def _get_env_or_dotenv_value(self, key_name: str) -> Optional[str]:
+        """Return a config value from process env first, then project .env."""
+        env_value = os.getenv(key_name)
+        if env_value:
+            return env_value
+
+        dotenv_path = PROJECT_ROOT / '.env'
+        if not dotenv_path.exists():
+            return None
+
+        try:
+            for raw_line in dotenv_path.read_text(encoding='utf-8').splitlines():
+                line = raw_line.strip()
+                if line.startswith('export '):
+                    line = line[len('export '):].strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                current_key, current_value = line.split('=', 1)
+                if current_key.strip() != key_name:
+                    continue
+                value = current_value.strip()
+                if value:
+                    parsed = shlex.split(value, comments=True, posix=True)
+                    value = parsed[0] if parsed else ''
+                return value or None
+        except Exception as exc:
+            logger.warning('Failed to read project .env for %s: %s', key_name, exc)
+
+        return None
     
     def encrypt(self, plaintext: str) -> str:
         """

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -8,6 +8,8 @@ import shutil
 import tempfile
 import unittest
 
+from cryptography.fernet import Fernet
+
 from ai_actuarial.ai_runtime import (
     get_ai_function_section,
     resolve_provider_credentials,
@@ -25,11 +27,14 @@ class TestAiRuntime(unittest.TestCase):
         self.original_env = dict(os.environ)
         self.temp_dir = tempfile.mkdtemp()
         self.db_path = os.path.join(self.temp_dir, "test.db")
+        os.environ["TOKEN_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
+        TokenEncryption._instance = None
         self.storage = Storage(self.db_path)
 
     def tearDown(self):
         os.environ.clear()
         os.environ.update(self.original_env)
+        TokenEncryption._instance = None
         self.storage.close()
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 

--- a/tests/test_fastapi_ops_read_endpoints.py
+++ b/tests/test_fastapi_ops_read_endpoints.py
@@ -202,8 +202,7 @@ def _build_test_client(tmp_path: Path, monkeypatch, *, require_auth: bool) -> tu
     seed = _seed_storage(db_path)
 
     TokenEncryption._instance = None
-    if not os.getenv("TOKEN_ENCRYPTION_KEY"):
-        monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
     monkeypatch.setenv("CONFIG_PATH", str(config_path))
     monkeypatch.setenv("CATEGORIES_CONFIG_PATH", str(categories_path))
     monkeypatch.setenv("FLASK_SECRET_KEY", "fastapi-ops-read-test-secret")

--- a/tests/test_fastapi_ops_read_endpoints.py
+++ b/tests/test_fastapi_ops_read_endpoints.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import threading
 from datetime import datetime, time, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
 import yaml
+from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
 
 from ai_actuarial.api.app import create_app
+from ai_actuarial.services.token_encryption import TokenEncryption
 from ai_actuarial.storage import Storage
 from ai_actuarial.web.app import _task_log_path
 
@@ -198,6 +201,9 @@ def _build_test_client(tmp_path: Path, monkeypatch, *, require_auth: bool) -> tu
     db_path, config_path, categories_path = _write_config_files(tmp_path)
     seed = _seed_storage(db_path)
 
+    TokenEncryption._instance = None
+    if not os.getenv("TOKEN_ENCRYPTION_KEY"):
+        monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
     monkeypatch.setenv("CONFIG_PATH", str(config_path))
     monkeypatch.setenv("CATEGORIES_CONFIG_PATH", str(categories_path))
     monkeypatch.setenv("FLASK_SECRET_KEY", "fastapi-ops-read-test-secret")

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -656,11 +656,12 @@ def test_provider_credentials_reencrypt_rotates_ciphertext(tmp_path: Path, monke
     _patch_available_models(monkeypatch)
     old_key = Fernet.generate_key().decode()
     new_key = Fernet.generate_key().decode()
-    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", old_key)
     TokenEncryption._instance = None
     client, app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
     recorder = _BridgeRecorder()
     _install_bridge(app, recorder)
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", old_key)
+    TokenEncryption._instance = None
 
     create = client.post(
         "/api/config/provider-credentials",

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import yaml
+from cryptography.fernet import Fernet
 
+from ai_actuarial.services.token_encryption import TokenEncryption
 from ai_actuarial.storage import Storage
 from test_fastapi_ops_read_endpoints import (
     _build_test_client,
@@ -619,6 +621,87 @@ def test_ai_routing_provider_change_clears_stale_credential_binding(tmp_path: Pa
     catalog_binding = next(item for item in second_update.json()["bindings"] if item["function_name"] == "catalog")
     assert catalog_binding["provider"] == "openai"
     assert catalog_binding.get("credential_id") in (None, "openai:llm:env") or str(catalog_binding.get("credential_id", "")).startswith("openai:")
+
+
+def test_provider_credentials_import_env_bootstraps_default_instance(tmp_path: Path, monkeypatch) -> None:
+    _patch_available_models(monkeypatch)
+    TokenEncryption._instance = None
+    monkeypatch.setenv("MISTRAL_API_KEY", "env-mistral-key")
+    monkeypatch.setenv("MISTRAL_BASE_URL", "https://env.mistral.example/v1")
+    client, app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
+    recorder = _BridgeRecorder()
+    _install_bridge(app, recorder)
+
+    response = client.post(
+        "/api/config/provider-credentials/import-env",
+        json={"providers": ["mistral"]},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["success"] is True
+    assert body["imported_count"] == 1
+    assert body["skipped_count"] == 0
+    assert body["imported"][0]["provider_id"] == "mistral"
+
+    rows = client.get("/api/config/provider-credentials").json()["credentials"]
+    imported = next(row for row in rows if row["provider_id"] == "mistral" and row["source"] == "db")
+    assert imported["instance_id"] == "default"
+    assert imported["is_default"] is True
+    assert imported["api_base_url"] == "https://env.mistral.example/v1"
+    TokenEncryption._instance = None
+
+
+
+def test_provider_credentials_reencrypt_rotates_ciphertext(tmp_path: Path, monkeypatch) -> None:
+    _patch_available_models(monkeypatch)
+    old_key = Fernet.generate_key().decode()
+    new_key = Fernet.generate_key().decode()
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", old_key)
+    TokenEncryption._instance = None
+    client, app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
+    recorder = _BridgeRecorder()
+    _install_bridge(app, recorder)
+
+    create = client.post(
+        "/api/config/provider-credentials",
+        json={
+            "provider_id": "mistral",
+            "instance_id": "default",
+            "label": "Mistral Default",
+            "api_key": "rotate-me",
+            "api_base_url": "https://api.mistral.ai/v1",
+        },
+    )
+    assert create.status_code == 200, create.text
+
+    storage = Storage(str(app.state.db_path))
+    try:
+        before = storage.get_llm_provider("mistral", category="llm", instance_id="default")
+        before_cipher = str(before["api_key_encrypted"])
+    finally:
+        storage.close()
+
+    rotate = client.post(
+        "/api/config/provider-credentials/re-encrypt",
+        json={"old_key": old_key, "new_key": new_key, "category": "llm", "providers": ["mistral"]},
+    )
+    assert rotate.status_code == 200, rotate.text
+    rotate_body = rotate.json()
+    assert rotate_body["success"] is True
+    assert rotate_body["rotated_count"] >= 1
+    assert rotate_body["failed_count"] == 0
+
+    storage = Storage(str(app.state.db_path))
+    try:
+        after = storage.get_llm_provider("mistral", category="llm", instance_id="default")
+        after_cipher = str(after["api_key_encrypted"])
+    finally:
+        storage.close()
+
+    assert before_cipher != after_cipher
+    assert Fernet(new_key.encode()).decrypt(after_cipher.encode()).decode() == "rotate-me"
+    TokenEncryption._instance = None
+
 
 
 def test_optional_api_key_provider_and_chatbot_alias_routing_write_endpoints(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_token_encryption.py
+++ b/tests/test_token_encryption.py
@@ -9,7 +9,7 @@ import os
 import pytest
 from cryptography.fernet import Fernet
 
-from ai_actuarial.services.token_encryption import PROJECT_ROOT, TokenEncryption
+from ai_actuarial.services.token_encryption import TokenEncryption
 
 
 class TestTokenEncryption:
@@ -146,10 +146,10 @@ class TestTokenEncryption:
         
         assert masked == "****"
     
-    def test_initialization_reads_key_from_project_dotenv(self):
+    def test_initialization_reads_key_from_project_dotenv(self, monkeypatch, tmp_path):
         """Test that TOKEN_ENCRYPTION_KEY can be read directly from project .env."""
-        dotenv_path = PROJECT_ROOT / '.env'
-        original_content = dotenv_path.read_text(encoding='utf-8') if dotenv_path.exists() else None
+        monkeypatch.setattr("ai_actuarial.services.token_encryption.PROJECT_ROOT", tmp_path)
+        dotenv_path = tmp_path / '.env'
         dotenv_key = Fernet.generate_key().decode()
 
         os.environ.pop('TOKEN_ENCRYPTION_KEY', None)
@@ -165,16 +165,12 @@ class TestTokenEncryption:
 
             assert decrypted == plaintext
         finally:
-            if original_content is None:
-                dotenv_path.unlink(missing_ok=True)
-            else:
-                dotenv_path.write_text(original_content, encoding='utf-8')
             TokenEncryption._instance = None
 
-    def test_initialization_reads_export_style_key_from_project_dotenv(self):
+    def test_initialization_reads_export_style_key_from_project_dotenv(self, monkeypatch, tmp_path):
         """Test that export-style dotenv lines and trailing comments are accepted."""
-        dotenv_path = PROJECT_ROOT / '.env'
-        original_content = dotenv_path.read_text(encoding='utf-8') if dotenv_path.exists() else None
+        monkeypatch.setattr("ai_actuarial.services.token_encryption.PROJECT_ROOT", tmp_path)
+        dotenv_path = tmp_path / '.env'
         dotenv_key = Fernet.generate_key().decode()
 
         os.environ.pop('TOKEN_ENCRYPTION_KEY', None)
@@ -193,16 +189,12 @@ class TestTokenEncryption:
 
             assert decrypted == plaintext
         finally:
-            if original_content is None:
-                dotenv_path.unlink(missing_ok=True)
-            else:
-                dotenv_path.write_text(original_content, encoding='utf-8')
             TokenEncryption._instance = None
 
-    def test_initialization_with_missing_key_raises_error(self):
+    def test_initialization_with_missing_key_raises_error(self, monkeypatch, tmp_path):
         """Test that missing TOKEN_ENCRYPTION_KEY fails instead of generating a new key."""
-        dotenv_path = PROJECT_ROOT / '.env'
-        original_content = dotenv_path.read_text(encoding='utf-8') if dotenv_path.exists() else None
+        monkeypatch.setattr("ai_actuarial.services.token_encryption.PROJECT_ROOT", tmp_path)
+        dotenv_path = tmp_path / '.env'
 
         os.environ.pop('TOKEN_ENCRYPTION_KEY', None)
         TokenEncryption._instance = None
@@ -213,10 +205,6 @@ class TestTokenEncryption:
             with pytest.raises(ValueError, match='TOKEN_ENCRYPTION_KEY is required'):
                 TokenEncryption()
         finally:
-            if original_content is None:
-                dotenv_path.unlink(missing_ok=True)
-            else:
-                dotenv_path.write_text(original_content, encoding='utf-8')
             TokenEncryption._instance = None
     
     def test_encrypt_decrypt_special_characters(self):

--- a/tests/test_token_encryption.py
+++ b/tests/test_token_encryption.py
@@ -5,9 +5,11 @@ Tests cover encryption, decryption, masking, singleton pattern,
 and error handling.
 """
 import os
+
 import pytest
 from cryptography.fernet import Fernet
-from ai_actuarial.services.token_encryption import TokenEncryption
+
+from ai_actuarial.services.token_encryption import PROJECT_ROOT, TokenEncryption
 
 
 class TestTokenEncryption:
@@ -144,34 +146,77 @@ class TestTokenEncryption:
         
         assert masked == "****"
     
-    def test_initialization_with_missing_key_generates_new(self, caplog, tmp_path):
-        """Test that missing TOKEN_ENCRYPTION_KEY still works (uses/creates key file)."""
-        import importlib
-        import ai_actuarial.services.token_encryption as te_mod
+    def test_initialization_reads_key_from_project_dotenv(self):
+        """Test that TOKEN_ENCRYPTION_KEY can be read directly from project .env."""
+        dotenv_path = PROJECT_ROOT / '.env'
+        original_content = dotenv_path.read_text(encoding='utf-8') if dotenv_path.exists() else None
+        dotenv_key = Fernet.generate_key().decode()
 
-        # Remove the env var
-        if 'TOKEN_ENCRYPTION_KEY' in os.environ:
-            del os.environ['TOKEN_ENCRYPTION_KEY']
-
-        # Point key file to a temp location so we don't interfere with real data
-        os.environ['TOKEN_ENCRYPTION_KEY_FILE'] = str(tmp_path / 'test.key')
-
+        os.environ.pop('TOKEN_ENCRYPTION_KEY', None)
         TokenEncryption._instance = None
 
         try:
-            encryption = TokenEncryption()
+            dotenv_path.write_text(f"TOKEN_ENCRYPTION_KEY={dotenv_key}\n", encoding='utf-8')
 
-            # Should still work with a generated key
-            plaintext = "test-api-key"
+            encryption = TokenEncryption()
+            plaintext = "dotenv-api-key"
             encrypted = encryption.encrypt(plaintext)
-            decrypted = encryption.decrypt(encrypted)
+            decrypted = Fernet(dotenv_key.encode()).decrypt(encrypted.encode()).decode()
 
             assert decrypted == plaintext
-
-            # Key file should have been created
-            assert (tmp_path / 'test.key').exists()
         finally:
-            os.environ.pop('TOKEN_ENCRYPTION_KEY_FILE', None)
+            if original_content is None:
+                dotenv_path.unlink(missing_ok=True)
+            else:
+                dotenv_path.write_text(original_content, encoding='utf-8')
+            TokenEncryption._instance = None
+
+    def test_initialization_reads_export_style_key_from_project_dotenv(self):
+        """Test that export-style dotenv lines and trailing comments are accepted."""
+        dotenv_path = PROJECT_ROOT / '.env'
+        original_content = dotenv_path.read_text(encoding='utf-8') if dotenv_path.exists() else None
+        dotenv_key = Fernet.generate_key().decode()
+
+        os.environ.pop('TOKEN_ENCRYPTION_KEY', None)
+        TokenEncryption._instance = None
+
+        try:
+            dotenv_path.write_text(
+                f'export TOKEN_ENCRYPTION_KEY="{dotenv_key}"  # prod key\n',
+                encoding='utf-8',
+            )
+
+            encryption = TokenEncryption()
+            plaintext = "dotenv-export-api-key"
+            encrypted = encryption.encrypt(plaintext)
+            decrypted = Fernet(dotenv_key.encode()).decrypt(encrypted.encode()).decode()
+
+            assert decrypted == plaintext
+        finally:
+            if original_content is None:
+                dotenv_path.unlink(missing_ok=True)
+            else:
+                dotenv_path.write_text(original_content, encoding='utf-8')
+            TokenEncryption._instance = None
+
+    def test_initialization_with_missing_key_raises_error(self):
+        """Test that missing TOKEN_ENCRYPTION_KEY fails instead of generating a new key."""
+        dotenv_path = PROJECT_ROOT / '.env'
+        original_content = dotenv_path.read_text(encoding='utf-8') if dotenv_path.exists() else None
+
+        os.environ.pop('TOKEN_ENCRYPTION_KEY', None)
+        TokenEncryption._instance = None
+
+        try:
+            dotenv_path.write_text('', encoding='utf-8')
+
+            with pytest.raises(ValueError, match='TOKEN_ENCRYPTION_KEY is required'):
+                TokenEncryption()
+        finally:
+            if original_content is None:
+                dotenv_path.unlink(missing_ok=True)
+            else:
+                dotenv_path.write_text(original_content, encoding='utf-8')
             TokenEncryption._instance = None
     
     def test_encrypt_decrypt_special_characters(self):


### PR DESCRIPTION
## Summary
- require `TOKEN_ENCRYPTION_KEY` from process env or project `.env` instead of generating or persisting fallback keys
- reset the `TokenEncryption` singleton when initialization fails to avoid half-initialized state leaking across requests/tests
- align affected runtime/FastAPI tests with the fixed-key contract and add dotenv parsing coverage for `export ...` lines with trailing comments

## Test Plan
- `source /home/ec2-user/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_token_encryption.py tests/test_ai_runtime.py tests/test_fastapi_ops_write_endpoints.py -q`

## Notes
- this intentionally removes automatic key generation and key-file fallback; startup now fails fast when `TOKEN_ENCRYPTION_KEY` is absent
