### PR TITLE
feat: complete FastAPI migration - add 5 missing endpoints

### DIFF
--- a/ai_actuarial/api/routers/ops_read.py
+++ b/ai_actuarial/api/routers/ops_read.py
@@ -221,3 +221,44 @@ def api_config_categories(
     _auth: AuthContext = Depends(require_permissions("config.read")),
 ) -> dict[str, object]:
     return get_config_categories()
+
+
+@router.get("/search")
+def api_search(
+    request: Request,
+    q: str = "",
+    kb_id: str | None = None,
+    limit: int = 20,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+) -> dict[str, object]:
+    if not q:
+        return {"results": [], "count": 0}
+    storage = Storage(_get_db_path(request))
+    try:
+        query_lower = q.lower()
+        cursor = storage._conn.execute(
+            """
+            SELECT kb_id, name, description, created_at FROM rag_knowledge_bases
+            WHERE kb_mode = 'category' OR kb_mode = 'hybrid'
+            """
+        )
+        results = []
+        for row in cursor.fetchall():
+            kb_id_row, name, description, created_at = row
+            score = 0
+            if name and query_lower in name.lower():
+                score += 10
+            if description and query_lower in description.lower():
+                score += 5
+            if score > 0:
+                results.append({
+                    "kb_id": kb_id_row,
+                    "name": name,
+                    "description": description,
+                    "created_at": created_at,
+                    "score": score,
+                })
+        results.sort(key=lambda x: x["score"], reverse=True)
+        return {"results": results[:limit], "count": len(results)}
+    finally:
+        storage.close()

--- a/ai_actuarial/api/routers/ops_read.py
+++ b/ai_actuarial/api/routers/ops_read.py
@@ -233,15 +233,22 @@ def api_search(
 ) -> dict[str, object]:
     if not q:
         return {"results": [], "count": 0}
+    # Clamp limit to prevent abuse
+    limit = min(max(1, limit), 100)
     storage = Storage(_get_db_path(request))
     try:
         query_lower = q.lower()
-        cursor = storage._conn.execute(
-            """
+        # Build query with optional kb_id filter
+        sql = """
             SELECT kb_id, name, description, created_at FROM rag_knowledge_bases
-            WHERE kb_mode = 'category' OR kb_mode = 'hybrid'
-            """
-        )
+            WHERE (kb_mode = 'category' OR kb_mode = 'hybrid')
+        """
+        params: list[str | int] = []
+        if kb_id:
+            sql += " AND kb_id = ?"
+            params.append(kb_id)
+        # Fetch more than limit since we filter in Python for scoring
+        cursor = storage._conn.execute(sql + " LIMIT 1000", params)
         results = []
         for row in cursor.fetchall():
             kb_id_row, name, description, created_at = row

--- a/ai_actuarial/api/routers/ops_write.py
+++ b/ai_actuarial/api/routers/ops_write.py
@@ -12,6 +12,7 @@ from ..services.ops_write import (
     add_scheduled_task,
     add_site,
     browse_folder,
+    create_backup,
     delete_backup,
     delete_provider_credential,
     delete_scheduled_task,
@@ -143,6 +144,20 @@ def api_config_backups(
 ):
     try:
         return list_backups()
+    except OpsWriteError as exc:
+        return _handle_ops_error(exc)
+
+
+@router.post("/config/backups")
+def api_config_backups_create(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+):
+    try:
+        label = str(payload.get("label", "manual") or "manual")
+        result = create_backup(label)
+        return JSONResponse(status_code=201, content=result)
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
 

--- a/ai_actuarial/api/routers/rag_admin.py
+++ b/ai_actuarial/api/routers/rag_admin.py
@@ -14,6 +14,8 @@ from ..services.rag_admin import (
     create_knowledge_base,
     delete_chunk_profile,
     delete_knowledge_base,
+    get_categories_mapping,
+    get_kb_bindings,
     get_knowledge_base,
     get_knowledge_base_categories,
     get_knowledge_base_stats,
@@ -25,6 +27,7 @@ from ..services.rag_admin import (
     list_selectable_files,
     remove_knowledge_base_file,
     set_knowledge_base_categories,
+    update_chunk_profile,
     update_knowledge_base,
 )
 
@@ -66,6 +69,19 @@ def api_create_chunk_profile(
     try:
         result = create_chunk_profile(db_path=_db_path(request), payload=payload, headers=dict(request.headers))
         return JSONResponse(status_code=201, content=result)
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.put("/chunk/profiles/{profile_id}")
+def api_update_chunk_profile(
+    profile_id: str,
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        return update_chunk_profile(db_path=_db_path(request), profile_id=profile_id, payload=payload, headers=dict(request.headers))
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -216,6 +232,17 @@ def api_unmapped_categories(
         return _error_response(exc)
 
 
+@router.get("/rag/categories/mapping")
+def api_categories_mapping(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return get_categories_mapping(db_path=_db_path(request))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
 @router.get("/rag/files/selectable")
 def api_selectable_files(
     request: Request,
@@ -273,6 +300,18 @@ def api_bind_chunk_sets(
 ):
     try:
         return bind_chunk_sets(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+    except RagAdminError as exc:
+        return _error_response(exc)
+
+
+@router.get("/rag/knowledge-bases/{kb_id}/bindings")
+def api_get_kb_bindings(
+    kb_id: str,
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return get_kb_bindings(db_path=_db_path(request), kb_id=kb_id)
     except RagAdminError as exc:
         return _error_response(exc)
 

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -491,16 +491,24 @@ def list_backups() -> dict[str, list[dict[str, Any]]]:
 
 
 def create_backup(label: str = "manual") -> dict[str, Any]:
-    backup_name = _backup_config(label)
+    # Sanitize label to prevent path traversal
+    import re
+    safe_label = re.sub(r'[^a-zA-Z0-9_-]', '_', label)[:50]
+    if not safe_label:
+        safe_label = "manual"
+    backup_name = _backup_config(safe_label)
     backups_dir = _ensure_backup_dir()
     backup_path = backups_dir / backup_name
-    stat = backup_path.stat()
-    return {
-        "filename": backup_name,
-        "timestamp": datetime.fromtimestamp(stat.st_mtime).isoformat(),
-        "size_bytes": stat.st_size,
-        "size": stat.st_size,
-    }
+    try:
+        stat = backup_path.stat()
+        return {
+            "filename": backup_name,
+            "timestamp": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+            "size_bytes": stat.st_size,
+            "size": stat.st_size,
+        }
+    except FileNotFoundError:
+        raise OpsWriteError("Backup file was not created", status_code=500)
 
 
 def restore_backup(filename: str, *, bridge: BridgeState | None = None) -> dict[str, Any]:

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -490,6 +490,19 @@ def list_backups() -> dict[str, list[dict[str, Any]]]:
     return {"backups": backups}
 
 
+def create_backup(label: str = "manual") -> dict[str, Any]:
+    backup_name = _backup_config(label)
+    backups_dir = _ensure_backup_dir()
+    backup_path = backups_dir / backup_name
+    stat = backup_path.stat()
+    return {
+        "filename": backup_name,
+        "timestamp": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+        "size_bytes": stat.st_size,
+        "size": stat.st_size,
+    }
+
+
 def restore_backup(filename: str, *, bridge: BridgeState | None = None) -> dict[str, Any]:
     backup_path = _validate_backup_filename(filename)
     if not backup_path.exists():

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -232,6 +232,53 @@ def delete_chunk_profile(*, db_path: str, profile_id: str, headers: Mapping[str,
         storage.close()
 
 
+def update_chunk_profile(*, db_path: str, profile_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
+    _require_config_write_token(headers)
+    normalized_profile_id = _norm(profile_id)
+    if not normalized_profile_id:
+        raise RagAdminError("profile_id is required")
+    if not isinstance(payload, dict):
+        raise RagAdminError("Invalid JSON body")
+    storage = Storage(db_path)
+    try:
+        profile = storage.get_chunk_profile(normalized_profile_id)
+        if not profile:
+            raise RagAdminError("chunk profile not found", status_code=404)
+        if "name" in payload:
+            storage.update_chunk_profile_name(normalized_profile_id, _norm(payload["name"]))
+        if "chunk_size" in payload:
+            storage.update_chunk_profile_chunk_size(normalized_profile_id, int(payload["chunk_size"]))
+        if "chunk_overlap" in payload:
+            storage.update_chunk_profile_chunk_overlap(normalized_profile_id, int(payload["chunk_overlap"]))
+        updated = storage.get_chunk_profile(normalized_profile_id)
+        return {"profile": updated}
+    finally:
+        storage.close()
+
+
+def get_kb_bindings(*, db_path: str, kb_id: str) -> dict[str, Any]:
+    kid = _kb_id(kb_id)
+    storage = Storage(db_path)
+    try:
+        bindings = storage.list_kb_chunk_bindings(kid)
+        return {"kb_id": kid, "bindings": bindings, "count": len(bindings)}
+    finally:
+        storage.close()
+
+
+def get_categories_mapping(*, db_path: str) -> dict[str, Any]:
+    storage = Storage(db_path)
+    try:
+        cursor = storage._conn.execute(
+            """
+            SELECT DISTINCT category FROM source_metadata WHERE category IS NOT NULL AND category != ''
+            """
+        )
+        mapped_categories = [row[0] for row in cursor.fetchall() if row[0]]
+        return {"categories": mapped_categories, "count": len(mapped_categories)}
+    finally:
+        storage.close()
+
 
 def list_knowledge_bases(*, db_path: str, query: Mapping[str, Any]) -> dict[str, Any]:
     KnowledgeBase, _manager, storage = _manager_and_storage(db_path)

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -244,12 +244,27 @@ def update_chunk_profile(*, db_path: str, profile_id: str, payload: dict[str, An
         profile = storage.get_chunk_profile(normalized_profile_id)
         if not profile:
             raise RagAdminError("chunk profile not found", status_code=404)
+        updates = []
+        values = []
         if "name" in payload:
-            storage.update_chunk_profile_name(normalized_profile_id, _norm(payload["name"]))
+            updates.append("name = ?")
+            values.append(_norm(payload["name"]))
         if "chunk_size" in payload:
-            storage.update_chunk_profile_chunk_size(normalized_profile_id, int(payload["chunk_size"]))
+            updates.append("chunk_size = ?")
+            values.append(int(payload["chunk_size"]))
         if "chunk_overlap" in payload:
-            storage.update_chunk_profile_chunk_overlap(normalized_profile_id, int(payload["chunk_overlap"]))
+            updates.append("chunk_overlap = ?")
+            values.append(int(payload["chunk_overlap"]))
+        if updates:
+            import time as time_module
+            updates.append("updated_at = ?")
+            values.append(time_module.time())
+            values.append(normalized_profile_id)
+            storage._conn.execute(
+                f"UPDATE chunk_profiles SET {', '.join(updates)} WHERE profile_id = ?",
+                values,
+            )
+            storage._conn.commit()
         updated = storage.get_chunk_profile(normalized_profile_id)
         return {"profile": updated}
     finally:


### PR DESCRIPTION
## Summary
Complete FastAPI migration by adding 5 missing endpoints that were returning legacy Flask fallback errors:

- **GET /api/rag/knowledge-bases/{kb_id}/bindings** - List KB bindings
- **PUT /api/chunk/profiles/{profile_id}** - Update chunk profile
- **GET /api/rag/categories/mapping** - Get categories mapping
- **GET /api/search** - Search knowledge bases
- **POST /api/config/backups** - Create manual backup

## Changes
- ai_actuarial/api/routers/rag_admin.py - Added 3 endpoints
- ai_actuarial/api/services/rag_admin.py - Added 3 service functions
- ai_actuarial/api/routers/ops_read.py - Added search endpoint
- ai_actuarial/api/services/ops_write.py - Added create_backup function
- ai_actuarial/api/routers/ops_write.py - Added backup create endpoint

## Testing
All new endpoints return proper FastAPI JSON responses instead of legacy Flask fallback errors.