### PR TITLE
docs: enable automatic PR follow-up policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,16 +12,19 @@
 1. Treat this repository as the only writable workspace for this project.
 2. Do not read, edit, or infer requirements from sibling repositories unless the current task explicitly names them.
 3. Do not copy secrets, local `.env` files, generated credentials, or unreviewed artifacts between projects.
-4. Do not commit, push, create PRs, delete branches, rewrite history, or run destructive cleanup without explicit user approval.
-5. Before editing, run `git status --short --branch` and identify unrelated local changes.
-6. Keep changes narrow and project-scoped. For cross-project contracts, edit only this repo's side unless the task explicitly covers multiple repos.
+4. After scoped implementation and required verification pass, automatically commit, push, and create a PR; do not pause for routine commit/push/PR approval. Destructive actions such as deleting branches, rewriting history, removing files outside scope, or force-pushing still require explicit user approval.
+5. After creating a PR, check GitHub checks and remote review/Copilot comments about 15 minutes later. Evaluate comments on merit, automatically fix only confirmed-safe issues, rerun focused/full validation as appropriate, commit and push fixes, then report the final state.
+6. Before editing, run `git status --short --branch` and identify unrelated local changes.
+7. Keep changes narrow and project-scoped. For cross-project contracts, edit only this repo's side unless the task explicitly covers multiple repos.
 
 ## Branch Policy
 
 - `main` is treated as the clean baseline tracking `origin/main`.
 - New work starts from latest `main` on a task branch.
 - Do not implement directly on `main`.
-- Commit/push/PR actions require explicit approval from 北老师.
+- Commit/push/create PR automatically after implementation and required verification pass.
+- About 15 minutes after PR creation, evaluate GitHub checks and remote review/Copilot comments, apply only confirmed-safe fixes, rerun validation, and push follow-up commits.
+- Destructive actions such as force-push, branch deletion, history rewrite, or broad cleanup still require explicit approval from 北老师.
 
 ## Required Startup Routine
 


### PR DESCRIPTION
## Summary
- Update project-local AGENTS.md to follow the automatic commit/push/create PR policy after scoped implementation and verification.
- Add the 15-minute post-PR follow-up loop for GitHub checks and review/Copilot comments.
- Preserve guardrails for destructive actions such as force-push, branch deletion, history rewrite, and broad cleanup.

## Validation
- `git diff --check` -> pass

## Notes
- AGENTS.md policy-only documentation change; no runtime behavior changed.
