### PR TITLE
feat: enqueue search fallback after blocked crawls

### DIFF
--- a/ai_actuarial/ai_runtime.py
+++ b/ai_actuarial/ai_runtime.py
@@ -256,6 +256,12 @@ SEARCH_ENGINE_PROVIDER_MAP = {
     "tavily": "tavily",
 }
 
+SEARCH_CREDENTIAL_FALLBACK_PROVIDERS = {
+    provider
+    for provider in SEARCH_ENGINE_PROVIDER_MAP.values()
+    if bool(KNOWN_LLM_PROVIDERS.get(provider, {}).get("is_search_provider"))
+}
+
 CHAT_OPENAI_COMPATIBLE_PROVIDERS = {
     "openai",
     "azure_openai",
@@ -636,7 +642,14 @@ def resolve_search_engine_credentials(
     provider = SEARCH_ENGINE_PROVIDER_MAP.get(str(engine_id or "").strip().lower())
     if not provider:
         return _missing_credentials(str(engine_id or "").strip().lower(), category="search")
-    return resolve_provider_credentials(provider, storage=storage, category="search")
+    credentials = resolve_provider_credentials(provider, storage=storage, category="search")
+    if credentials.configured or provider not in SEARCH_CREDENTIAL_FALLBACK_PROVIDERS:
+        return credentials
+
+    legacy_credentials = resolve_provider_credentials(provider, storage=storage, category="llm")
+    if legacy_credentials.source == "db" and legacy_credentials.configured:
+        return legacy_credentials
+    return credentials
 
 
 def get_search_runtime_credentials(*, storage: Any | None = None) -> dict[str, str | None]:

--- a/ai_actuarial/collectors/scheduled.py
+++ b/ai_actuarial/collectors/scheduled.py
@@ -3,13 +3,36 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+import re
 
 from .base import BaseCollector, CollectionConfig, CollectionResult
 from ..crawler import Crawler, SiteConfig
 from ..storage import Storage
 
 logger = logging.getLogger(__name__)
+
+_BLOCKED_ERROR_PATTERNS = (
+    ("http_403", re.compile(r"\b403\b|forbidden", re.IGNORECASE)),
+    ("http_429", re.compile(r"\b429\b|too many requests|rate limit", re.IGNORECASE)),
+    ("access_denied", re.compile(r"access denied", re.IGNORECASE)),
+    ("cloudflare", re.compile(r"cloudflare", re.IGNORECASE)),
+    ("sucuri", re.compile(r"sucuri", re.IGNORECASE)),
+    ("timeout", re.compile(r"timed?\s*out|timeout", re.IGNORECASE)),
+    ("zero_pages_visited", re.compile(r"\b0\s+pages?\s+visited\b", re.IGNORECASE)),
+)
+
+
+def _classify_site_outcome(error_text: str, *, items_found: int) -> tuple[str, bool]:
+    """Classify direct crawl outcome for later fallback decisions."""
+    haystack = str(error_text or "")
+    for reason, pattern in _BLOCKED_ERROR_PATTERNS:
+        if pattern.search(haystack):
+            return reason, True
+    if haystack:
+        return "error", False
+    if items_found <= 0:
+        return "zero_results", False
+    return "success", False
 
 
 class ScheduledCollector(BaseCollector):
@@ -41,6 +64,7 @@ class ScheduledCollector(BaseCollector):
         items_found = 0
         items_downloaded = 0
         items_skipped = 0
+        site_results = []
         
         try:
             # Get site configuration from metadata
@@ -64,19 +88,58 @@ class ScheduledCollector(BaseCollector):
                 
                 try:
                     new_items = self.crawler.crawl_site(site_config, progress_callback=site_progress)
-                    items_found += len(new_items)
+                    site_items_found = len(new_items)
+                    site_items_downloaded = 0
+                    site_items_skipped = 0
+                    items_found += site_items_found
                     
                     # Count downloaded vs skipped
                     for item in new_items:
                         if item.get("local_path"):
+                            site_items_downloaded += 1
                             items_downloaded += 1
                         else:
+                            site_items_skipped += 1
                             items_skipped += 1
-                            
+
+                    reason, blocked = _classify_site_outcome("", items_found=site_items_found)
+                    site_results.append(
+                        {
+                            "name": site_config.name,
+                            "url": site_config.url,
+                            "items_found": site_items_found,
+                            "items_downloaded": site_items_downloaded,
+                            "items_skipped": site_items_skipped,
+                            "success": True,
+                            "failed": False,
+                            "error": "",
+                            "error_text": "",
+                            "blocked": blocked,
+                            "classification": reason,
+                            "fallback_reason": reason,
+                        }
+                    )
                 except Exception as e:
                     error_msg = f"Error crawling {site_config.name}: {e}"
                     logger.error(error_msg)
                     errors.append(error_msg)
+                    reason, blocked = _classify_site_outcome(error_msg, items_found=0)
+                    site_results.append(
+                        {
+                            "name": site_config.name,
+                            "url": site_config.url,
+                            "items_found": 0,
+                            "items_downloaded": 0,
+                            "items_skipped": 0,
+                            "success": False,
+                            "failed": True,
+                            "error": error_msg,
+                            "error_text": error_msg,
+                            "blocked": blocked,
+                            "classification": reason,
+                            "fallback_reason": reason,
+                        }
+                    )
             
             if progress_callback:
                 progress_callback(total_sites, total_sites, "Completed")
@@ -90,8 +153,9 @@ class ScheduledCollector(BaseCollector):
                 items_skipped=items_skipped,
                 errors=errors,
                 metadata={
-                    "source_type": "scheduled",
+                    "source_type": config.source_type,
                     "sites_processed": len(site_configs),
+                    "site_results": site_results,
                 }
             )
             
@@ -104,7 +168,7 @@ class ScheduledCollector(BaseCollector):
                 items_skipped=0,
                 errors=[str(e)],
             )
-    
+
     def should_download(self, url: str, sha256: str | None = None) -> bool:
         """Check if file should be downloaded.
         

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -543,12 +543,14 @@ class NativeTaskRuntime:
             if not fallback_reason:
                 continue
 
-            for query in queries:
+            total_queries = len(queries)
+            for query_index, query in enumerate(queries, start=1):
                 task_data = self._site_query_search_task_data(site_config, query, config, data)
+                query_label = query if len(query) <= 80 else f"{query[:77]}..."
                 child_task_id = self.start_background_task(
                     "search",
                     task_data,
-                    task_name=f"Search fallback: {site_config.name}",
+                    task_name=f"Search fallback: {site_config.name} ({query_index}/{total_queries}): {query_label}",
                     extra_fields={
                         "parent_task_id": task_id,
                         "trigger": "crawler_fallback",

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -16,7 +16,6 @@ from urllib.parse import urlparse
 import schedule
 
 from ai_actuarial.ai_runtime import get_search_runtime_credentials, resolve_ocr_runtime
-from ai_actuarial.api.services.files_write import generate_file_chunk_sets
 from ai_actuarial.catalog_incremental import run_catalog_for_urls, run_incremental_catalog
 from ai_actuarial.collectors.base import CollectionConfig, CollectionResult
 from ai_actuarial.collectors.file import FileCollector
@@ -51,6 +50,12 @@ _CONVERTIBLE_MARKDOWN_PREDICATE = """
         OR LOWER(IFNULL(f.original_filename,'')) LIKE '%.bmp'
     )
 """
+
+
+def generate_file_chunk_sets(*, db_path: str, file_url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    from ai_actuarial.api.services.files_write import generate_file_chunk_sets as _generate_file_chunk_sets
+
+    return _generate_file_chunk_sets(db_path=db_path, file_url=file_url, payload=payload)
 
 
 def _convert_document_path(path: Path, **kwargs: Any) -> Any:
@@ -392,10 +397,11 @@ class NativeTaskRuntime:
                 return self._run_search_task(task_id, storage, config, download_dir, data)
 
             if collection_type in {"scheduled", "adhoc", "quick_check"}:
+                defaults = dict(config.get("defaults") or {})
                 crawler = Crawler(
                     storage,
                     download_dir,
-                    str((config.get("defaults") or {}).get("user_agent") or "AI-Actuarial/1.0"),
+                    str(defaults.get("user_agent") or "AI-Actuarial/1.0"),
                     stop_check=lambda: self._stop_requested(task_id),
                 )
                 collector = ScheduledCollector(storage, crawler)
@@ -410,7 +416,16 @@ class NativeTaskRuntime:
                     check_database=bool(data.get("check_database", True)),
                     metadata={"site_configs": site_configs},
                 )
-                return collector.collect(cfg, progress_callback=self._progress_callback(task_id))
+                result = collector.collect(cfg, progress_callback=self._progress_callback(task_id))
+                if collection_type in {"scheduled", "adhoc"}:
+                    self._enqueue_site_query_search_fallbacks(
+                        task_id,
+                        config,
+                        result,
+                        site_configs,
+                        data,
+                    )
+                return result
 
             if collection_type == "catalog":
                 category = str(data.get("category") or "").strip() or None
@@ -499,6 +514,118 @@ class NativeTaskRuntime:
             raise RuntimeError(f"Native runtime does not yet support collection type '{collection_type}'")
         finally:
             storage.close()
+
+    def _enqueue_site_query_search_fallbacks(
+        self,
+        task_id: str,
+        config: dict[str, Any],
+        result: CollectionResult,
+        site_configs: list[SiteConfig],
+        data: dict[str, Any],
+    ) -> None:
+        search_cfg = dict(config.get("search") or {})
+        if result.metadata is None:
+            result.metadata = {}
+        result.metadata["search_fallback_enqueued"] = 0
+        result.metadata["search_fallback_task_ids"] = []
+        if not bool(search_cfg.get("enabled", False)):
+            return
+
+        site_outcomes = self._site_outcomes_by_key(result)
+        enqueued = 0
+        child_task_ids: list[str] = []
+
+        for site_config in site_configs:
+            queries = [str(query).strip() for query in (site_config.queries or []) if str(query).strip()]
+            if not queries:
+                continue
+            fallback_reason = self._site_search_fallback_reason(site_config, site_outcomes)
+            if not fallback_reason:
+                continue
+
+            for query in queries:
+                task_data = self._site_query_search_task_data(site_config, query, config, data)
+                child_task_id = self.start_background_task(
+                    "search",
+                    task_data,
+                    task_name=f"Search fallback: {site_config.name}",
+                    extra_fields={
+                        "parent_task_id": task_id,
+                        "trigger": "crawler_fallback",
+                        "fallback_reason": fallback_reason,
+                    },
+                )
+                enqueued += 1
+                child_task_ids.append(child_task_id)
+                message = (
+                    f"{site_config.name}: enqueued search fallback task {child_task_id} "
+                    f"(reason={fallback_reason}, query={query})"
+                )
+                logger.info(message)
+                append_task_log(task_id, "INFO", message)
+
+        result.metadata["search_fallback_enqueued"] = enqueued
+        result.metadata["search_fallback_task_ids"] = child_task_ids
+
+    def _site_query_search_task_data(
+        self,
+        site_config: SiteConfig,
+        query: str,
+        config: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        search_cfg = dict(config.get("search") or {})
+        engine = str(data.get("engine") or search_cfg.get("engine") or "brave").strip().lower() or "brave"
+        site_host = urlparse(site_config.url).netloc.strip()
+
+        return {
+            "name": site_config.name,
+            "query": query,
+            "site": site_host,
+            "engine": engine,
+            "count": search_cfg.get("max_results"),
+            "use_search_defaults": True,
+            "file_exts": list(site_config.file_exts or []),
+            "keywords": list(site_config.keywords or []),
+            "search_exclude_keywords": list(site_config.exclude_keywords or []),
+            "check_database": bool(data.get("check_database", True)),
+        }
+
+    def _site_outcomes_by_key(self, result: CollectionResult) -> dict[str, dict[str, Any]]:
+        outcomes: dict[str, dict[str, Any]] = {}
+        for row in list((result.metadata or {}).get("site_results") or []):
+            if not isinstance(row, dict):
+                continue
+            name = str(row.get("name") or "").strip().lower()
+            url = str(row.get("url") or "").strip().lower()
+            if name:
+                outcomes[f"name:{name}"] = row
+            if url:
+                outcomes[f"url:{url}"] = row
+        return outcomes
+
+    def _site_search_fallback_reason(
+        self,
+        site_config: SiteConfig,
+        site_outcomes: dict[str, dict[str, Any]],
+    ) -> str | None:
+        outcome = site_outcomes.get(f"name:{site_config.name.strip().lower()}") or site_outcomes.get(
+            f"url:{site_config.url.strip().lower()}"
+        )
+        if not outcome:
+            return None
+        reason = str(outcome.get("fallback_reason") or "").strip()
+        if bool(outcome.get("blocked")):
+            return reason or "blocked"
+        if bool(outcome.get("failed")) or not bool(outcome.get("success", True)):
+            return reason or "failed"
+        try:
+            items_found = int(outcome.get("items_found") or 0)
+        except (TypeError, ValueError):
+            items_found = 0
+        if items_found <= 0:
+            return reason or "zero_results"
+        return None
 
     def _run_rag_indexing(self, task_id: str, storage: Storage, data: dict[str, Any]) -> CollectionResult:
         kb_id = str(data.get("kb_id") or "").strip()
@@ -671,7 +798,7 @@ class NativeTaskRuntime:
                     keywords=keywords,
                     file_exts=file_exts,
                     exclude_keywords=exclude_keywords,
-                    check_database=True,
+                    check_database=bool(data.get("check_database", True)),
                 )
                 new_items = crawler.scan_page_for_files(result.url, site_config, source_site=result.source)
                 items_found += len(new_items)

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -13,6 +13,9 @@ from cryptography.fernet import Fernet
 
 from ai_actuarial.ai_runtime import (
     get_ai_function_section,
+    get_search_runtime_credentials,
+    list_provider_credentials,
+    resolve_search_engine_credentials,
     resolve_provider_credentials,
     resolve_ai_function_runtime,
     resolve_ocr_runtime,
@@ -246,6 +249,51 @@ class TestAiRuntime(unittest.TestCase):
         self.assertEqual(credentials.source, "env")
         self.assertEqual(credentials.api_key, "env-openai-key")
         self.assertEqual(credentials.stable_credential_id, "openai:llm:env")
+
+    def test_search_runtime_credentials_accept_brave_legacy_llm_token(self):
+        secret = "legacy-brave-search-key"
+        encrypted = TokenEncryption().encrypt(secret)
+        self.storage.upsert_llm_provider(
+            provider="brave_search",
+            api_key_encrypted=encrypted,
+            category="llm",
+            instance_id="default",
+            label="Legacy Brave",
+        )
+
+        credentials = get_search_runtime_credentials(storage=self.storage)
+        brave_credentials = resolve_search_engine_credentials("brave", storage=self.storage)
+        credential_rows = list_provider_credentials(storage=self.storage)["credentials"]
+
+        self.assertEqual(credentials["brave"], secret)
+        self.assertEqual(brave_credentials.provider, "brave_search")
+        self.assertEqual(brave_credentials.source, "db")
+        self.assertEqual(brave_credentials.api_key, secret)
+        self.assertEqual(brave_credentials.stable_credential_id, "brave_search:llm:instance:default")
+        self.assertNotIn(secret, repr(credential_rows))
+
+    def test_search_runtime_credentials_prefer_search_category_over_legacy_llm_token(self):
+        legacy_secret = "legacy-brave-search-key"
+        search_secret = "search-brave-key"
+        self.storage.upsert_llm_provider(
+            provider="brave_search",
+            api_key_encrypted=TokenEncryption().encrypt(legacy_secret),
+            category="llm",
+            instance_id="default",
+        )
+        self.storage.upsert_llm_provider(
+            provider="brave_search",
+            api_key_encrypted=TokenEncryption().encrypt(search_secret),
+            category="search",
+            instance_id="default",
+        )
+
+        credentials = get_search_runtime_credentials(storage=self.storage)
+        brave_credentials = resolve_search_engine_credentials("brave", storage=self.storage)
+
+        self.assertEqual(credentials["brave"], search_secret)
+        self.assertEqual(brave_credentials.source, "db")
+        self.assertEqual(brave_credentials.stable_credential_id, "brave_search:search:instance:default")
 
     def test_resolve_provider_credentials_preserves_base_url_when_key_missing(self):
         self.storage.upsert_llm_provider(

--- a/tests/test_scheduled_collector.py
+++ b/tests/test_scheduled_collector.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+
+from ai_actuarial.collectors.base import CollectionConfig
+from ai_actuarial.collectors.scheduled import ScheduledCollector
+from ai_actuarial.crawler import SiteConfig
+
+
+def test_scheduled_collector_records_site_outcome_metadata_for_zero_and_blocked_results() -> None:
+    storage = MagicMock()
+    crawler = MagicMock()
+    crawler.crawl_site.side_effect = [
+        [],
+        RuntimeError("0 pages visited"),
+        RuntimeError("403 Forbidden by Cloudflare"),
+    ]
+    collector = ScheduledCollector(storage, crawler)
+
+    result = collector.collect(
+        CollectionConfig(
+            name="Scheduled",
+            source_type="adhoc",
+            metadata={
+                "site_configs": [
+                    SiteConfig(name="Empty Site", url="https://empty.example"),
+                    SiteConfig(name="No Pages Site", url="https://nopages.example"),
+                    SiteConfig(name="Blocked Site", url="https://blocked.example"),
+                ]
+            },
+        )
+    )
+
+    site_results = result.metadata["site_results"]
+    assert site_results[0]["name"] == "Empty Site"
+    assert site_results[0]["items_found"] == 0
+    assert site_results[0]["success"] is True
+    assert site_results[0]["failed"] is False
+    assert site_results[0]["fallback_reason"] == "zero_results"
+
+    assert site_results[1]["name"] == "No Pages Site"
+    assert site_results[1]["items_found"] == 0
+    assert site_results[1]["success"] is False
+    assert site_results[1]["failed"] is True
+    assert site_results[1]["blocked"] is True
+    assert site_results[1]["fallback_reason"] == "zero_pages_visited"
+    assert "0 pages visited" in site_results[1]["error_text"]
+
+    assert site_results[2]["name"] == "Blocked Site"
+    assert site_results[2]["items_found"] == 0
+    assert site_results[2]["success"] is False
+    assert site_results[2]["failed"] is True
+    assert site_results[2]["blocked"] is True
+    assert site_results[2]["fallback_reason"] == "http_403"
+    assert "403 Forbidden" in site_results[2]["error_text"]

--- a/tests/test_task_stop_support.py
+++ b/tests/test_task_stop_support.py
@@ -869,7 +869,10 @@ def test_native_task_runtime_scheduled_blocked_outcome_enqueues_search_fallback(
         "search_exclude_keywords": ["draft"],
         "check_database": True,
     }
-    assert runtime.start_background_task.call_args.kwargs["task_name"] == "Search fallback: Anti Bot Site"
+    assert (
+        runtime.start_background_task.call_args.kwargs["task_name"]
+        == "Search fallback: Anti Bot Site (1/1): site:anti.example actuarial report"
+    )
     assert runtime.start_background_task.call_args.kwargs["extra_fields"] == {
         "parent_task_id": "task-scheduled-blocked",
         "trigger": "crawler_fallback",
@@ -1097,6 +1100,11 @@ def test_native_task_runtime_scheduled_multiple_queries_enqueue_multiple_child_t
     assert all(payload["count"] == 3 for payload in payloads)
     assert all(payload["file_exts"] == [".pdf"] for payload in payloads)
     assert all(payload["keywords"] == ["solvency"] for payload in payloads)
+    task_names = [call.kwargs["task_name"] for call in runtime.start_background_task.call_args_list]
+    assert task_names == [
+        "Search fallback: Multi Query Site (1/2): actuarial annual report",
+        "Search fallback: Multi Query Site (2/2): solvency filing",
+    ]
     assert [call.kwargs["extra_fields"]["fallback_reason"] for call in runtime.start_background_task.call_args_list] == [
         "zero_results",
         "zero_results",

--- a/tests/test_task_stop_support.py
+++ b/tests/test_task_stop_support.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from ai_actuarial.catalog import CatalogItem
 from ai_actuarial.catalog_incremental import run_catalog_for_urls, run_incremental_catalog
+from ai_actuarial.collectors.base import CollectionResult
+from ai_actuarial.crawler import SiteConfig
 from ai_actuarial.rag.indexing import IndexingPipeline
 from ai_actuarial.storage import Storage
 
@@ -607,6 +609,546 @@ def test_native_task_runtime_search_uses_selected_engine_and_db_credentials(tmp_
     site_cfg = fake_crawler.scan_page_for_files.call_args.args[1]
     assert site_cfg.file_exts == [".pdf"]
     assert site_cfg.exclude_keywords == ["newsletter"]
+    assert site_cfg.check_database is True
+
+
+def test_native_task_runtime_search_passes_check_database_false_to_scan_config(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-search-no-db-check.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "search:",
+                "  max_results: 5",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    fake_crawler = MagicMock()
+    fake_crawler.scan_page_for_files.return_value = [{"local_path": str(tmp_path / "report.pdf")}]
+    runtime = NativeTaskRuntime()
+    search_result = SimpleNamespace(url="https://example.com/report", source="Search")
+    with patch(
+        "ai_actuarial.task_runtime.get_search_runtime_credentials",
+        return_value={"brave": "brave-key", "google": None, "serper": None, "tavily": None},
+    ), patch("ai_actuarial.task_runtime.search_all", return_value=[search_result]), patch(
+        "ai_actuarial.task_runtime.Crawler",
+        return_value=fake_crawler,
+    ):
+        result = runtime._run_collection(
+            "task-search-no-db-check",
+            "search",
+            {
+                "query": "actuarial AI",
+                "engine": "brave",
+                "check_database": False,
+            },
+        )
+
+    assert result.success is True
+    site_cfg = fake_crawler.scan_page_for_files.call_args.args[1]
+    assert site_cfg.check_database is False
+
+
+def test_native_task_runtime_missing_site_results_do_not_enqueue_search_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-not-used")
+    result = CollectionResult(
+        success=True,
+        items_found=0,
+        items_downloaded=0,
+        items_skipped=0,
+        errors=[],
+        metadata=None,
+    )
+    site_configs = [
+        SiteConfig(
+            name="Configured Site",
+            url="https://configured.example",
+            queries=["actuarial report"],
+        )
+    ]
+
+    runtime._enqueue_site_query_search_fallbacks(
+        "task-missing-site-results",
+        {"search": {"enabled": True}},
+        result,
+        site_configs,
+        {},
+    )
+
+    assert result.metadata == {
+        "search_fallback_enqueued": 0,
+        "search_fallback_task_ids": [],
+    }
+    runtime.start_background_task.assert_not_called()
+
+
+def test_native_task_runtime_unmatched_site_result_does_not_enqueue_search_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-not-used")
+    result = CollectionResult(
+        success=True,
+        items_found=0,
+        items_downloaded=0,
+        items_skipped=0,
+        errors=[],
+        metadata={
+            "site_results": [
+                {
+                    "name": "Different Site",
+                    "url": "https://different.example",
+                    "items_found": 0,
+                    "success": True,
+                    "fallback_reason": "zero_results",
+                }
+            ]
+        },
+    )
+    site_configs = [
+        SiteConfig(
+            name="Configured Site",
+            url="https://configured.example",
+            queries=["actuarial report"],
+        )
+    ]
+
+    runtime._enqueue_site_query_search_fallbacks(
+        "task-unmatched-site-results",
+        {"search": {"enabled": True}},
+        result,
+        site_configs,
+        {},
+    )
+
+    assert result.metadata["search_fallback_enqueued"] == 0
+    assert result.metadata["search_fallback_task_ids"] == []
+    runtime.start_background_task.assert_not_called()
+
+
+def test_native_task_runtime_scheduled_success_with_queries_does_not_enqueue_search_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-scheduled-success.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "defaults:",
+                "  user_agent: test-agent/1.0",
+                "  keywords: [actuarial]",
+                "  file_exts: ['.pdf']",
+                "  exclude_keywords: [draft]",
+                "search:",
+                "  enabled: true",
+                "  max_results: 4",
+                "sites:",
+                "  - name: Direct Site",
+                "    url: https://direct.example",
+                "    queries:",
+                "      - site:direct.example actuarial report",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    fake_crawler = MagicMock()
+    fake_crawler.crawl_site.return_value = [{"local_path": str(tmp_path / "direct.pdf")}]
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-not-used")
+
+    with patch.object(runtime, "_run_search_task", wraps=runtime._run_search_task) as mock_run_search_task, patch(
+        "ai_actuarial.task_runtime.search_all"
+    ) as mock_search, patch(
+        "ai_actuarial.task_runtime.Crawler",
+        return_value=fake_crawler,
+    ):
+        result = runtime._run_collection("task-scheduled-success", "scheduled", {"check_database": False})
+
+    assert result.success is True
+    assert result.items_found == 1
+    assert result.items_downloaded == 1
+    assert result.metadata["search_fallback_enqueued"] == 0
+    assert result.metadata["search_fallback_task_ids"] == []
+    assert result.metadata["site_results"][0]["fallback_reason"] == "success"
+    runtime.start_background_task.assert_not_called()
+    mock_run_search_task.assert_not_called()
+    mock_search.assert_not_called()
+
+
+def test_native_task_runtime_scheduled_blocked_outcome_enqueues_search_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-scheduled-blocked.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "defaults:",
+                "  user_agent: test-agent/1.0",
+                "  keywords: [actuarial]",
+                "  file_exts: ['.pdf']",
+                "  exclude_keywords: [draft]",
+                "search:",
+                "  enabled: true",
+                "  engine: serper",
+                "  max_results: 4",
+                "sites:",
+                "  - name: Anti Bot Site",
+                "    url: https://anti.example",
+                "    queries: ['site:anti.example actuarial report']",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    fake_crawler = MagicMock()
+    fake_crawler.crawl_site.side_effect = RuntimeError("403 Forbidden by Cloudflare")
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-search-1")
+
+    with patch.object(runtime, "_run_search_task", wraps=runtime._run_search_task) as mock_run_search_task, patch(
+        "ai_actuarial.task_runtime.search_all"
+    ) as mock_search, patch(
+        "ai_actuarial.task_runtime.Crawler",
+        return_value=fake_crawler,
+    ):
+        result = runtime._run_collection("task-scheduled-blocked", "scheduled", {})
+
+    assert result.success is False
+    assert result.items_found == 0
+    assert result.metadata["search_fallback_enqueued"] == 1
+    assert result.metadata["search_fallback_task_ids"] == ["child-search-1"]
+    site_result = result.metadata["site_results"][0]
+    assert site_result["failed"] is True
+    assert site_result["blocked"] is True
+    assert site_result["fallback_reason"] == "http_403"
+    runtime.start_background_task.assert_called_once()
+    collection_type, payload = runtime.start_background_task.call_args.args
+    assert collection_type == "search"
+    assert payload == {
+        "name": "Anti Bot Site",
+        "query": "site:anti.example actuarial report",
+        "site": "anti.example",
+        "engine": "serper",
+        "count": 4,
+        "use_search_defaults": True,
+        "file_exts": [".pdf"],
+        "keywords": ["actuarial"],
+        "search_exclude_keywords": ["draft"],
+        "check_database": True,
+    }
+    assert runtime.start_background_task.call_args.kwargs["task_name"] == "Search fallback: Anti Bot Site"
+    assert runtime.start_background_task.call_args.kwargs["extra_fields"] == {
+        "parent_task_id": "task-scheduled-blocked",
+        "trigger": "crawler_fallback",
+        "fallback_reason": "http_403",
+    }
+    mock_run_search_task.assert_not_called()
+    mock_search.assert_not_called()
+    log_text = (tmp_path / "data" / "task_logs" / "task-scheduled-blocked.log").read_text(encoding="utf-8")
+    assert "enqueued search fallback task child-search-1" in log_text
+
+
+def test_native_task_runtime_scheduled_zero_result_outcome_enqueues_brave_search_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-scheduled-zero.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "defaults:",
+                "  user_agent: test-agent/1.0",
+                "  file_exts: ['.pdf']",
+                "search:",
+                "  enabled: true",
+                "sites:",
+                "  - name: Empty Site",
+                "    url: https://empty.example",
+                "    queries: ['actuarial report']",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    fake_crawler = MagicMock()
+    fake_crawler.crawl_site.return_value = []
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-search-zero")
+
+    with patch.object(runtime, "_run_search_task", wraps=runtime._run_search_task) as mock_run_search_task, patch(
+        "ai_actuarial.task_runtime.search_all"
+    ) as mock_search, patch(
+        "ai_actuarial.task_runtime.Crawler",
+        return_value=fake_crawler,
+    ):
+        result = runtime._run_collection("task-scheduled-zero", "scheduled", {})
+
+    assert result.success is True
+    assert result.items_found == 0
+    assert result.metadata["search_fallback_enqueued"] == 1
+    assert result.metadata["site_results"][0]["fallback_reason"] == "zero_results"
+    collection_type, payload = runtime.start_background_task.call_args.args
+    assert collection_type == "search"
+    assert payload["engine"] == "brave"
+    assert payload["query"] == "actuarial report"
+    assert payload["site"] == "empty.example"
+    assert payload["use_search_defaults"] is True
+    assert payload["check_database"] is True
+    assert runtime.start_background_task.call_args.kwargs["extra_fields"] == {
+        "parent_task_id": "task-scheduled-zero",
+        "trigger": "crawler_fallback",
+        "fallback_reason": "zero_results",
+    }
+    mock_run_search_task.assert_not_called()
+    mock_search.assert_not_called()
+
+
+def test_native_task_runtime_scheduled_search_disabled_does_not_enqueue_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-scheduled-disabled.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "search:",
+                "  enabled: false",
+                "sites:",
+                "  - name: Disabled Fallback Site",
+                "    url: https://disabled.example",
+                "    queries: ['actuarial report']",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    fake_crawler = MagicMock()
+    fake_crawler.crawl_site.return_value = []
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-not-used")
+
+    with patch.object(runtime, "_run_search_task", wraps=runtime._run_search_task) as mock_run_search_task, patch(
+        "ai_actuarial.task_runtime.search_all"
+    ) as mock_search, patch(
+        "ai_actuarial.task_runtime.Crawler",
+        return_value=fake_crawler,
+    ):
+        result = runtime._run_collection("task-scheduled-disabled", "scheduled", {})
+
+    assert result.success is True
+    assert result.items_found == 0
+    assert result.metadata["site_results"][0]["fallback_reason"] == "zero_results"
+    assert result.metadata["search_fallback_enqueued"] == 0
+    assert result.metadata["search_fallback_task_ids"] == []
+    runtime.start_background_task.assert_not_called()
+    mock_run_search_task.assert_not_called()
+    mock_search.assert_not_called()
+
+
+def test_native_task_runtime_scheduled_site_without_queries_does_not_enqueue_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-scheduled-no-queries.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "search:",
+                "  enabled: true",
+                "sites:",
+                "  - name: No Query Site",
+                "    url: https://no-query.example",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    fake_crawler = MagicMock()
+    fake_crawler.crawl_site.side_effect = RuntimeError("403 Forbidden")
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-not-used")
+
+    with patch.object(runtime, "_run_search_task", wraps=runtime._run_search_task) as mock_run_search_task, patch(
+        "ai_actuarial.task_runtime.search_all"
+    ) as mock_search, patch(
+        "ai_actuarial.task_runtime.Crawler",
+        return_value=fake_crawler,
+    ):
+        result = runtime._run_collection("task-scheduled-no-queries", "scheduled", {})
+
+    assert result.success is False
+    assert result.metadata["site_results"][0]["fallback_reason"] == "http_403"
+    assert result.metadata["search_fallback_enqueued"] == 0
+    assert result.metadata["search_fallback_task_ids"] == []
+    runtime.start_background_task.assert_not_called()
+    mock_run_search_task.assert_not_called()
+    mock_search.assert_not_called()
+
+
+def test_native_task_runtime_scheduled_multiple_queries_enqueue_multiple_child_tasks(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-scheduled-multi-query.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "defaults:",
+                "  keywords: [solvency]",
+                "  file_exts: ['.pdf']",
+                "search:",
+                "  enabled: true",
+                "  engine: tavily",
+                "  max_results: 3",
+                "sites:",
+                "  - name: Multi Query Site",
+                "    url: https://multi.example",
+                "    queries:",
+                "      - actuarial annual report",
+                "      - solvency filing",
+                "      - ''",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    fake_crawler = MagicMock()
+    fake_crawler.crawl_site.return_value = []
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(side_effect=["child-search-1", "child-search-2"])
+
+    with patch.object(runtime, "_run_search_task", wraps=runtime._run_search_task) as mock_run_search_task, patch(
+        "ai_actuarial.task_runtime.search_all"
+    ) as mock_search, patch(
+        "ai_actuarial.task_runtime.Crawler",
+        return_value=fake_crawler,
+    ):
+        result = runtime._run_collection("task-scheduled-multi-query", "scheduled", {})
+
+    assert result.success is True
+    assert result.metadata["search_fallback_enqueued"] == 2
+    assert result.metadata["search_fallback_task_ids"] == ["child-search-1", "child-search-2"]
+    assert runtime.start_background_task.call_count == 2
+    payloads = [call.args[1] for call in runtime.start_background_task.call_args_list]
+    assert [payload["query"] for payload in payloads] == ["actuarial annual report", "solvency filing"]
+    assert all(payload["site"] == "multi.example" for payload in payloads)
+    assert all(payload["engine"] == "tavily" for payload in payloads)
+    assert all(payload["count"] == 3 for payload in payloads)
+    assert all(payload["file_exts"] == [".pdf"] for payload in payloads)
+    assert all(payload["keywords"] == ["solvency"] for payload in payloads)
+    assert [call.kwargs["extra_fields"]["fallback_reason"] for call in runtime.start_background_task.call_args_list] == [
+        "zero_results",
+        "zero_results",
+    ]
+    mock_run_search_task.assert_not_called()
+    mock_search.assert_not_called()
+
+
+def test_native_task_runtime_search_task_does_not_enqueue_recursive_fallback(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "sites.yaml"
+    db_path = tmp_path / "runtime-search-no-recursion.db"
+    download_dir = tmp_path / "files"
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  db: {db_path.as_posix()}",
+                f"  download_dir: {download_dir.as_posix()}",
+                "search:",
+                "  enabled: true",
+                "  max_results: 5",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    runtime = NativeTaskRuntime()
+    runtime.start_background_task = MagicMock(return_value="child-not-used")
+    with patch(
+        "ai_actuarial.task_runtime.get_search_runtime_credentials",
+        return_value={"brave": "brave-key", "google": None, "serper": None, "tavily": None},
+    ), patch("ai_actuarial.task_runtime.search_all", return_value=[]) as mock_search, patch(
+        "ai_actuarial.task_runtime.Crawler"
+    ) as mock_crawler:
+        result = runtime._run_collection(
+            "task-search-no-recursion",
+            "search",
+            {"query": "actuarial report", "engine": "brave", "site": "example.com"},
+        )
+
+    assert result.success is True
+    assert result.items_found == 0
+    assert result.metadata["source_type"] == "search"
+    assert result.metadata["search_results"] == 0
+    assert "search_fallback_enqueued" not in result.metadata
+    runtime.start_background_task.assert_not_called()
+    mock_search.assert_called_once()
+    mock_crawler.return_value.scan_page_for_files.assert_not_called()
 
 
 def test_native_task_runtime_markdown_conversion_writes_db_markdown(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Record per-site direct crawler outcomes for scheduled/adhoc tasks.
- Enqueue standard search child tasks only when direct crawl feedback indicates blocked/failed/zero-result sites with configured queries.
- Reuse backend search task parameters, including Brave engine defaults and database de-duplication.
- Add compatibility for legacy Brave search credentials stored under the LLM category.
- Fix task_runtime import cycle via lazy import while preserving the existing test patch point.

## Test Plan
- `git diff --check`
- `python -m pytest -o addopts='' tests/test_task_stop_support.py tests/test_ai_runtime.py tests/test_scheduled_collector.py -q`

## Notes
- `ANTI_CRAWLER_RESEARCH.md` is intentionally left untracked and not included.
- The 3 pytest warnings are third-party `faiss-cpu` / SWIG deprecation warnings.