### PR TITLE
fix: preserve scheduled fallback diagnostics

### DIFF
--- a/ai_actuarial/collectors/scheduled.py
+++ b/ai_actuarial/collectors/scheduled.py
@@ -22,6 +22,30 @@ _BLOCKED_ERROR_PATTERNS = (
 )
 
 
+def _crawler_diagnostic_error_text(crawler: Crawler) -> str:
+    diagnostic: dict[str, object] = {}
+    get_diagnostic = getattr(crawler, "get_last_crawl_diagnostic", None)
+    if callable(get_diagnostic):
+        try:
+            raw = get_diagnostic()
+            if isinstance(raw, dict):
+                diagnostic = raw
+        except Exception:  # noqa: BLE001
+            diagnostic = {}
+    if not diagnostic:
+        raw = getattr(crawler, "last_crawl_diagnostic", None)
+        if isinstance(raw, dict):
+            diagnostic = raw
+
+    error_text = str(diagnostic.get("error_text") or "").strip()
+    if error_text:
+        return error_text
+    request_errors = diagnostic.get("request_errors")
+    if isinstance(request_errors, (list, tuple)):
+        return "; ".join(str(error).strip() for error in request_errors if str(error).strip())
+    return ""
+
+
 def _classify_site_outcome(error_text: str, *, items_found: int) -> tuple[str, bool]:
     """Classify direct crawl outcome for later fallback decisions."""
     haystack = str(error_text or "")
@@ -102,7 +126,8 @@ class ScheduledCollector(BaseCollector):
                             site_items_skipped += 1
                             items_skipped += 1
 
-                    reason, blocked = _classify_site_outcome("", items_found=site_items_found)
+                    diagnostic_error_text = _crawler_diagnostic_error_text(self.crawler) if site_items_found <= 0 else ""
+                    reason, blocked = _classify_site_outcome(diagnostic_error_text, items_found=site_items_found)
                     site_results.append(
                         {
                             "name": site_config.name,
@@ -110,10 +135,10 @@ class ScheduledCollector(BaseCollector):
                             "items_found": site_items_found,
                             "items_downloaded": site_items_downloaded,
                             "items_skipped": site_items_skipped,
-                            "success": True,
-                            "failed": False,
-                            "error": "",
-                            "error_text": "",
+                            "success": not blocked,
+                            "failed": blocked,
+                            "error": diagnostic_error_text,
+                            "error_text": diagnostic_error_text,
                             "blocked": blocked,
                             "classification": reason,
                             "fallback_reason": reason,

--- a/ai_actuarial/collectors/scheduled.py
+++ b/ai_actuarial/collectors/scheduled.py
@@ -59,6 +59,10 @@ def _classify_site_outcome(error_text: str, *, items_found: int) -> tuple[str, b
     return "success", False
 
 
+def _site_outcome_failed(reason: str) -> bool:
+    return reason not in {"success", "zero_results"}
+
+
 class ScheduledCollector(BaseCollector):
     """Collector for scheduled/periodic site crawling."""
     
@@ -128,6 +132,9 @@ class ScheduledCollector(BaseCollector):
 
                     diagnostic_error_text = _crawler_diagnostic_error_text(self.crawler) if site_items_found <= 0 else ""
                     reason, blocked = _classify_site_outcome(diagnostic_error_text, items_found=site_items_found)
+                    failed = _site_outcome_failed(reason)
+                    if failed and diagnostic_error_text:
+                        errors.append(f"Error crawling {site_config.name}: {diagnostic_error_text}")
                     site_results.append(
                         {
                             "name": site_config.name,
@@ -135,8 +142,8 @@ class ScheduledCollector(BaseCollector):
                             "items_found": site_items_found,
                             "items_downloaded": site_items_downloaded,
                             "items_skipped": site_items_skipped,
-                            "success": not blocked,
-                            "failed": blocked,
+                            "success": not failed,
+                            "failed": failed,
                             "error": diagnostic_error_text,
                             "error_text": diagnostic_error_text,
                             "blocked": blocked,
@@ -169,7 +176,7 @@ class ScheduledCollector(BaseCollector):
             if progress_callback:
                 progress_callback(total_sites, total_sites, "Completed")
             
-            success = len(errors) == 0 or items_found > 0
+            success = len(errors) == 0
             
             return CollectionResult(
                 success=success,

--- a/ai_actuarial/crawler.py
+++ b/ai_actuarial/crawler.py
@@ -354,11 +354,13 @@ class Crawler:
 
         seen_pages: set[str] = set()
         pages_fetched = 0
+        stopped = False
 
         while page_queue and pages_fetched < cfg.max_pages:
             # Check stop signal in loop
             if self.stop_check and self.stop_check():
                 logger.info("Crawl stopped by user signal.")
+                stopped = True
                 break
 
             url, depth = page_queue.popleft()
@@ -511,7 +513,7 @@ class Crawler:
             "pages_visited": pages_fetched,
             "request_errors": request_errors,
             "error_text": "; ".join(request_errors),
-            "stopped": False,
+            "stopped": stopped,
         }
         return new_items
 

--- a/ai_actuarial/crawler.py
+++ b/ai_actuarial/crawler.py
@@ -59,7 +59,12 @@ class Crawler:
         self.download_dir = download_dir
         self.user_agent = user_agent
         self.stop_check = stop_check
+        self.last_crawl_diagnostic: dict[str, object] = {}
         self._cleanup_old_temp_files()
+
+    def get_last_crawl_diagnostic(self) -> dict[str, object]:
+        """Return non-contract crawl diagnostics from the most recent site crawl."""
+        return dict(self.last_crawl_diagnostic or {})
 
     def _cleanup_old_temp_files(self, max_age_hours: int = 24) -> None:
         """Clean up stale .part files from previous failed downloads."""
@@ -283,9 +288,20 @@ class Crawler:
         return urls
 
     def crawl_site(self, cfg: SiteConfig, progress_callback=None) -> list[dict]:
+        request_errors: list[str] = []
+        self.last_crawl_diagnostic = {}
+
         # Check stop signal at start
         if self.stop_check and self.stop_check():
             logger.info("Crawl stopped by user signal.")
+            self.last_crawl_diagnostic = {
+                "site_name": cfg.name,
+                "site_url": cfg.url,
+                "pages_visited": 0,
+                "request_errors": [],
+                "error_text": "",
+                "stopped": True,
+            }
             return []
 
         logger.info("Starting crawl of site: %s (max_pages=%d, max_depth=%d)", 
@@ -360,7 +376,8 @@ class Crawler:
 
             try:
                 data, headers, final_url = self._request(url)
-            except Exception:
+            except Exception as exc:
+                request_errors.append(f"{url}: {exc}")
                 continue
 
             pages_fetched += 1
@@ -488,6 +505,14 @@ class Crawler:
 
         logger.info("Crawl completed for %s: %d new files found, %d pages visited", 
                    cfg.name, len(new_items), pages_fetched)
+        self.last_crawl_diagnostic = {
+            "site_name": cfg.name,
+            "site_url": cfg.url,
+            "pages_visited": pages_fetched,
+            "request_errors": request_errors,
+            "error_text": "; ".join(request_errors),
+            "stopped": False,
+        }
         return new_items
 
     def _extract_text_from_html(self, html: str, url: str) -> str | None:

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import secrets
 import threading
 import time
@@ -29,6 +30,8 @@ from ai_actuarial.shared_runtime import append_task_log, get_sites_config_path, 
 from ai_actuarial.storage import Storage
 
 logger = logging.getLogger(__name__)
+
+_QUERY_SITE_FILTER_RE = re.compile(r"(?:^|\s)site:([^\s)]+)", re.IGNORECASE)
 
 _CONVERTIBLE_MARKDOWN_PREDICATE = """
     f.local_path IS NOT NULL AND f.local_path != ''
@@ -578,7 +581,7 @@ class NativeTaskRuntime:
     ) -> dict[str, Any]:
         search_cfg = dict(config.get("search") or {})
         engine = str(data.get("engine") or search_cfg.get("engine") or "brave").strip().lower() or "brave"
-        site_host = urlparse(site_config.url).netloc.strip()
+        site_host = self._site_filter_for_query(site_config.url, query)
 
         return {
             "name": site_config.name,
@@ -592,6 +595,26 @@ class NativeTaskRuntime:
             "search_exclude_keywords": list(site_config.exclude_keywords or []),
             "check_database": bool(data.get("check_database", True)),
         }
+
+    def _site_filter_for_query(self, site_url: str, query: str) -> str:
+        query_site = self._site_filter_from_query(query)
+        if query_site:
+            return query_site
+        return self._normalized_site_host(urlparse(site_url).netloc)
+
+    def _site_filter_from_query(self, query: str) -> str:
+        match = _QUERY_SITE_FILTER_RE.search(str(query or ""))
+        if not match:
+            return ""
+        return self._normalized_site_host(match.group(1))
+
+    def _normalized_site_host(self, host: str) -> str:
+        site = str(host or "").strip().lower().removeprefix("site:")
+        site = site.removeprefix("http://").removeprefix("https://").split("/", 1)[0]
+        site = site.split(":", 1)[0].strip(".")
+        if site.startswith("www."):
+            return site[4:]
+        return site
 
     def _site_outcomes_by_key(self, result: CollectionResult) -> dict[str, dict[str, Any]]:
         outcomes: dict[str, dict[str, Any]] = {}
@@ -1187,14 +1210,14 @@ class NativeTaskRuntime:
     def _dedupe_search_results(self, results: list[Any], *, site_filter: str = "") -> list[Any]:
         seen: set[str] = set()
         out: list[Any] = []
-        site = str(site_filter or "").strip().lower().removeprefix("site:")
+        site = self._normalized_site_host(site_filter)
         for result in results:
             url = str(getattr(result, "url", "") or "").strip()
             if not url or url in seen:
                 continue
             if site:
-                host = urlparse(url).netloc.lower()
-                if site not in host and not host.endswith(site.lstrip(".")):
+                host = self._normalized_site_host(urlparse(url).netloc)
+                if host != site and not host.endswith(f".{site}"):
                     continue
             seen.add(url)
             out.append(result)

--- a/tests/test_scheduled_collector.py
+++ b/tests/test_scheduled_collector.py
@@ -73,9 +73,41 @@ def test_scheduled_collector_preserves_crawler_diagnostic_for_swallowed_empty_fa
     )
 
     site_result = result.metadata["site_results"][0]
+    assert result.success is False
+    assert any("HTTP Error 429" in error for error in result.errors)
     assert site_result["items_found"] == 0
     assert site_result["success"] is False
     assert site_result["failed"] is True
     assert site_result["blocked"] is True
     assert site_result["fallback_reason"] == "http_429"
     assert "HTTP Error 429" in site_result["error_text"]
+
+
+def test_scheduled_collector_marks_generic_diagnostic_error_failed() -> None:
+    storage = MagicMock()
+    crawler = MagicMock()
+    crawler.crawl_site.return_value = []
+    crawler.get_last_crawl_diagnostic.return_value = {
+        "pages_visited": 0,
+        "request_errors": ["https://error.example: connection reset by peer"],
+        "error_text": "https://error.example: connection reset by peer",
+    }
+    collector = ScheduledCollector(storage, crawler)
+
+    result = collector.collect(
+        CollectionConfig(
+            name="Scheduled",
+            source_type="scheduled",
+            metadata={"site_configs": [SiteConfig(name="Errored Empty", url="https://error.example")]},
+        )
+    )
+
+    site_result = result.metadata["site_results"][0]
+    assert result.success is False
+    assert any("connection reset" in error for error in result.errors)
+    assert site_result["items_found"] == 0
+    assert site_result["success"] is False
+    assert site_result["failed"] is True
+    assert site_result["blocked"] is False
+    assert site_result["fallback_reason"] == "error"
+    assert "connection reset" in site_result["error_text"]

--- a/tests/test_scheduled_collector.py
+++ b/tests/test_scheduled_collector.py
@@ -51,3 +51,31 @@ def test_scheduled_collector_records_site_outcome_metadata_for_zero_and_blocked_
     assert site_results[2]["blocked"] is True
     assert site_results[2]["fallback_reason"] == "http_403"
     assert "403 Forbidden" in site_results[2]["error_text"]
+
+
+def test_scheduled_collector_preserves_crawler_diagnostic_for_swallowed_empty_failure() -> None:
+    storage = MagicMock()
+    crawler = MagicMock()
+    crawler.crawl_site.return_value = []
+    crawler.get_last_crawl_diagnostic.return_value = {
+        "pages_visited": 0,
+        "request_errors": ["https://blocked.example: HTTP Error 429: Too Many Requests"],
+        "error_text": "https://blocked.example: HTTP Error 429: Too Many Requests",
+    }
+    collector = ScheduledCollector(storage, crawler)
+
+    result = collector.collect(
+        CollectionConfig(
+            name="Scheduled",
+            source_type="scheduled",
+            metadata={"site_configs": [SiteConfig(name="Blocked Empty", url="https://blocked.example")]},
+        )
+    )
+
+    site_result = result.metadata["site_results"][0]
+    assert site_result["items_found"] == 0
+    assert site_result["success"] is False
+    assert site_result["failed"] is True
+    assert site_result["blocked"] is True
+    assert site_result["fallback_reason"] == "http_429"
+    assert "HTTP Error 429" in site_result["error_text"]

--- a/tests/test_task_stop_support.py
+++ b/tests/test_task_stop_support.py
@@ -884,6 +884,41 @@ def test_native_task_runtime_scheduled_blocked_outcome_enqueues_search_fallback(
     assert "enqueued search fallback task child-search-1" in log_text
 
 
+def test_native_task_runtime_search_fallback_prefers_query_site_domain_for_www_site_config() -> None:
+    from ai_actuarial.search import SearchResult
+    from ai_actuarial.task_runtime import NativeTaskRuntime
+
+    runtime = NativeTaskRuntime()
+    site_config = SiteConfig(
+        name="SOA",
+        url="https://www.soa.org",
+        file_exts=[".pdf"],
+        queries=["site:soa.org actuarial report"],
+    )
+
+    payload = runtime._site_query_search_task_data(
+        site_config,
+        "site:soa.org actuarial report",
+        {"search": {"enabled": True, "max_results": 5}},
+        {},
+    )
+
+    assert payload["site"] == "soa.org"
+    assert payload["query"] == "site:soa.org actuarial report"
+    assert runtime._query_with_site_filter(payload["query"], payload["site"]) == "site:soa.org actuarial report"
+    assert runtime._dedupe_search_results(
+        [
+            SearchResult(url="https://soa.org/resources/research-report.pdf", source="test"),
+            SearchResult(url="https://www.soa.org/news/article", source="test"),
+            SearchResult(url="https://example.com/other.pdf", source="test"),
+        ],
+        site_filter=payload["site"],
+    ) == [
+        SearchResult(url="https://soa.org/resources/research-report.pdf", source="test"),
+        SearchResult(url="https://www.soa.org/news/article", source="test"),
+    ]
+
+
 def test_native_task_runtime_scheduled_zero_result_outcome_enqueues_brave_search_fallback(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "sites.yaml"

--- a/tests/test_task_stop_support.py
+++ b/tests/test_task_stop_support.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 from ai_actuarial.catalog import CatalogItem
 from ai_actuarial.catalog_incremental import run_catalog_for_urls, run_incremental_catalog
 from ai_actuarial.collectors.base import CollectionResult
-from ai_actuarial.crawler import SiteConfig
+from ai_actuarial.crawler import Crawler, SiteConfig
 from ai_actuarial.rag.indexing import IndexingPipeline
 from ai_actuarial.storage import Storage
 
@@ -203,6 +203,35 @@ def test_indexing_pipeline_immediate_stop_preserves_existing_index(tmp_path) -> 
     assert stats["stopped"] is True
     assert index_path.read_text(encoding="utf-8") == "existing-index"
     mock_vector_store.assert_not_called()
+
+
+def test_crawler_records_mid_crawl_stop_diagnostic(tmp_path) -> None:
+    storage = Storage(str(tmp_path / "crawler-stop.db"))
+    stop_calls = 0
+
+    def stop_check() -> bool:
+        nonlocal stop_calls
+        stop_calls += 1
+        return stop_calls >= 2
+
+    crawler = Crawler(
+        storage=storage,
+        download_dir=str(tmp_path),
+        user_agent="TestAgent/1.0",
+        stop_check=stop_check,
+    )
+    cfg = SiteConfig(name="Stop Site", url="https://example.com", max_pages=5, delay_seconds=0)
+
+    try:
+        with patch.object(crawler, "_load_sitemap", return_value=[]):
+            result = crawler.crawl_site(cfg)
+    finally:
+        storage.close()
+
+    assert result == []
+    diagnostic = crawler.get_last_crawl_diagnostic()
+    assert diagnostic["stopped"] is True
+    assert diagnostic["pages_visited"] == 0
 
 
 def test_indexing_pipeline_records_current_embedding_index_version(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Preserve crawler request failure diagnostics so scheduled site outcomes classify blocked/HTTP failures instead of plain zero_results
- Prefer site: query domains for scheduled search fallback payloads and allow bare/www host aliases during result filtering
- Add focused tests for blocked diagnostics and SOA www/bare-domain fallback behavior

## Test Plan
- python -m py_compile ai_actuarial/crawler.py ai_actuarial/collectors/scheduled.py ai_actuarial/task_runtime.py tests/test_scheduled_collector.py tests/test_task_stop_support.py
- python -m pytest -o addopts='' tests/test_task_stop_support.py tests/test_ai_runtime.py tests/test_scheduled_collector.py -q
- codex --model gpt-5.5 review --uncommitted
