### PR TITLE
fix: persist production proxy configuration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,13 @@
 www.aiinforsearch.com, aiinforsearch.com {
     handle /api/* {
-        reverse_proxy 172.18.0.2:5000
+        reverse_proxy ai-api:5000
     }
 
     handle {
-        reverse_proxy 172.18.0.3:5173
+        reverse_proxy ai-frontend:5173
     }
+}
+
+cross.aiactuary.cn {
+    reverse_proxy 172.28.0.1:8501
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,14 +1,14 @@
 www.aiinforsearch.com, aiinforsearch.com {
-    handle /api/* {
-        reverse_proxy api:5000
-    }
+	handle /api/* {
+		reverse_proxy api:5000
+	}
 
-    handle {
-        reverse_proxy frontend:5173
-    }
+	handle {
+		reverse_proxy frontend:5173
+	}
 }
 
 cross.aiactuary.cn {
-    # C-Ross runs on the host and binds to the ai-net bridge gateway.
-    reverse_proxy 172.28.0.1:8501
+	# C-Ross runs on the host and binds to the ai-net bridge gateway.
+	reverse_proxy 172.28.0.1:8501
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,13 +1,14 @@
 www.aiinforsearch.com, aiinforsearch.com {
     handle /api/* {
-        reverse_proxy ai-api:5000
+        reverse_proxy api:5000
     }
 
     handle {
-        reverse_proxy ai-frontend:5173
+        reverse_proxy frontend:5173
     }
 }
 
 cross.aiactuary.cn {
+    # C-Ross runs on the host and binds to the ai-net bridge gateway.
     reverse_proxy 172.28.0.1:8501
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       dockerfile: Dockerfile
     container_name: ai-api
     restart: unless-stopped
-    ports:
-      - "${API_PORT:-5000}:5000"
+    expose:
+      - "5000"
     environment:
       - FASTAPI_ENV=${FASTAPI_ENV:-development}
       - FASTAPI_SESSION_SECRET=${FASTAPI_SESSION_SECRET:?FASTAPI_SESSION_SECRET is required}
@@ -46,8 +46,8 @@ services:
     restart: unless-stopped
     working_dir: /app
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
-    ports:
-      - "${FRONTEND_PORT:-5173}:5173"
+    expose:
+      - "5173"
     environment:
       - VITE_API_BASE_URL=${VITE_API_BASE_URL:-http://api:5000}
       - NODE_ENV=development
@@ -55,7 +55,7 @@ services:
       - ./:/app
       - /app/node_modules
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:5173", "-o", "/dev/null"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:5173"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,3 +116,4 @@ networks:
       driver: default
       config:
         - subnet: 172.28.0.0/16
+          gateway: 172.28.0.1


### PR DESCRIPTION
## Summary
- Use Docker service names for aiinforsearch Caddy upstreams instead of container IPs
- Expose api/frontend only inside the Docker network
- Add cross.aiactuary.cn reverse proxy config
- Use wget for frontend healthcheck

## Test Plan
- git diff --check -- Caddyfile docker-compose.yml
- curl https://www.aiinforsearch.com/api/health -> 200
- curl https://www.aiinforsearch.com/ -> 200
- curl https://cross.aiactuary.cn/ -> 200

Note: local AGENTS.md and ANTI_CRAWLER_RESEARCH.md were intentionally left out of this PR.