### PR TITLE
Address missed deployment review comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ TOKEN_ENCRYPTION_KEY=
 # CONTENT_SECURITY_POLICY=default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:
 # Comma-separated origins, not JSON.
 # FASTAPI_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
-# TRUST_PROXY=true
+# TRUST_PROXY=false
 # FASTAPI_HOST=0.0.0.0
 # FASTAPI_PORT=5000
 

--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -44,6 +44,11 @@ jobs:
           git config --global credential.helper "store --file ~/.git-credentials"
           printf 'protocol=https\nhost=gitee.com\nusername=%s\npassword=%s\n\n' "$GITEE_USER" "$GITEE_TOKEN" | git credential approve
 
+      - name: Configure Git identity
+        run: |
+          git config user.email "ferry.he@gmail.com"
+          git config user.name "jghe"
+
       - name: Sync main to Gitee
         env:
           GITEE_USER: ${{ vars.GITEE_USER }}

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -9,6 +9,7 @@
 - Security follow-up: Removed the tracked 0-byte `config/storage.db` placeholder and ignored runtime database extensions to prevent accidental future commits of user/auth/provider data.
 - Security hardening follow-up: Moving public deployment topology and production-only security policy into server-local environment variables; committed defaults should not expose real domains, fixed Docker bridge gateways, disabled CSRF, or empty CSP.
 - Gitee sync: PR #112 was merged; `.github/workflows/sync-gitee.yml` now fetches Gitee and uses `--force-with-lease` for the branch mirror instead of embedding credentials in the remote URL.
+- Gitee sync follow-up: main run 26338403088 still failed in `Sync main to Gitee`; added an explicit workflow Git identity (`ferry.he@gmail.com` / `jghe`) before the Gitee sync step.
 - Review follow-up: Verified PR #107 Caddy log path/healthcheck loopback, PR #108 markdown response typing, and PR #109 page-jump integer parsing are already addressed on main.
 - Review follow-up: Addressing remaining PR #111/#113 comments by using container-safe `FASTAPI_HOST=0.0.0.0` in the Docker entrypoint, defaulting `TRUST_PROXY` to false unless explicitly enabled, removing duplicated inline CSP defaults from Compose, using PEP 440-aware version parsing for the `mistralai` guard, and clarifying CSP pass-through docs.
 - Model catalog follow-up: Updated `mistralai` pin to `1.12.4` and moved DeepSeek fallback models to current `deepseek-v4-flash` / `deepseek-v4-pro` while retaining legacy aliases for existing configs.

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,18 +1,20 @@
 # Project Status
 
 - Date: 2026-05-23
-- Branch: codex/security-scan-gitee-sync
-- Scope: Repository configuration exposure scan and GitHub-to-Gitee sync workflow.
-- Latest baseline: main fast-forwarded to origin/main at 93a710f before branching.
+- Branch: codex/address-missed-review-comments
+- Scope: Follow-up for missed Copilot review comments on merged PRs #107-#111.
+- Latest baseline: branch created from origin/main at 3b03c1e after PR #111 was merged.
 - Security scan focus: tracked repository files for plaintext secrets, personal identifiers, runtime databases, deployment/server configuration, and CI secrets usage. Local `.env` files were not read.
 - Security scan result: No real plaintext API keys, SSH private keys, or GitHub/Gitee tokens were found in tracked runtime configuration. Tracked `.env` files are limited to `.env.example`.
 - Security follow-up: Removed the tracked 0-byte `config/storage.db` placeholder and ignored runtime database extensions to prevent accidental future commits of user/auth/provider data.
 - Security hardening follow-up: Moving public deployment topology and production-only security policy into server-local environment variables; committed defaults should not expose real domains, fixed Docker bridge gateways, disabled CSRF, or empty CSP.
 - Gitee sync: Added `.github/workflows/sync-gitee.yml` to push GitHub `main` and tags to `https://gitee.com/${GITEE_USER}/AI_actuarial_inforsearch.git` using GitHub repository variable `GITEE_USER` and repository secret `GITEE_TOKEN`.
+- Review follow-up: Verified PR #107 Caddy log path/healthcheck loopback, PR #108 markdown response typing, and PR #109 page-jump integer parsing are already addressed on main.
+- Review follow-up: Addressing remaining PR #111 comments by using container-safe `FASTAPI_HOST=0.0.0.0` in the Docker entrypoint, defaulting `TRUST_PROXY` to false unless explicitly enabled, removing duplicated inline CSP defaults from Compose, and relaxing the `mistralai` guard to pinned version >= 1.12.4.
 - Model catalog follow-up: Updated `mistralai` pin to `1.12.4` and moved DeepSeek fallback models to current `deepseek-v4-flash` / `deepseek-v4-pro` while retaining legacy aliases for existing configs.
 - CI follow-up: PR #111 `python-smoke` failed after enabling CSRF by default because the FastAPI-only auth roundtrip smoke test posted auth mutations without the frontend CSRF cookie/header flow. Updated the smoke test to seed `/api/auth/me` and send `X-CSRF-Token` on register/logout/login.
-- PR: https://github.com/ferryhe/AI_actuarial_inforsearch/pull/111 (draft, open, mergeable clean; latest remote python-smoke passed after CSRF smoke-test fix).
-- Verification: python -m pytest tests/test_deployment_config_source.py tests/test_gitee_sync_workflow_source.py tests/test_yaml_config.py tests/test_auth_react_source.py -q; python -m pytest tests/test_dependency_versions.py tests/test_llm_models.py tests/test_ai_runtime.py -q; python -m pytest tests/test_fastapi_ops_read_endpoints.py tests/test_settings_react_source.py -q; python -m pytest tests/test_fastapi_entrypoint.py tests/test_fastapi_no_flask_runtime.py tests/test_react_fastapi_authority.py -q; python -m pytest tests/test_deployment_config_source.py tests/test_auth_react_source.py -q; python -c YAML parse for docker-compose.yml, docker-compose.override.yml, and config/sites.yaml; rg checks for removed public topology values and updated DeepSeek/Mistral pins; git diff --check.
-- Verification gap: `docker compose config` could not run locally because Docker is not installed on this Windows environment.
+- PR: follow-up PR pending for missed review comments.
+- Verification: python -m pytest tests/test_deployment_config_source.py tests/test_dependency_versions.py -q; python -c YAML parse for docker-compose.yml, docker-compose.override.yml, and config/sites.yaml; rg checks for removed duplicated CSP defaults, unsafe TRUST_PROXY default, old entrypoint host default, and exact mistralai test pin; git diff --check.
+- Verification gap: `docker compose config` could not run locally because Docker is not installed on this Windows environment; raw GitHub Actions logs could not be retrieved because local `gh` auth token is invalid.
 - Pre-PR review gate: Blocked because `codex --help` fails with `Program 'codex.exe' failed to run: Access is denied`.
 - Notes: No sibling repositories were read or modified.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,7 @@
 #   export CADDY_APP_SITE_HOSTS=<public-app-host>[,www.<public-app-host>]
 #   export CADDY_CROSS_SITE_HOST=<optional-secondary-host>
 #   export CADDY_CROSS_UPSTREAM=<host-or-service>:<port>
+#   export TRUST_PROXY=true  # only when API access is restricted to trusted proxy traffic
 
 version: "3.9"
 
@@ -26,8 +27,8 @@ services:
       - FASTAPI_CORS_ORIGINS=${FASTAPI_CORS_ORIGINS:?FASTAPI_CORS_ORIGINS is required in production}
       - ENABLE_CSRF=${ENABLE_CSRF:-true}
       - FASTAPI_SESSION_COOKIE_SECURE=${FASTAPI_SESSION_COOKIE_SECURE:-true}
-      - TRUST_PROXY=${TRUST_PROXY:-true}
-      - "CONTENT_SECURITY_POLICY=${CONTENT_SECURITY_POLICY:-default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:}"
+      - TRUST_PROXY=${TRUST_PROXY:-false}
+      - CONTENT_SECURITY_POLICY
     volumes:
       - ai-data:/app/data:rw
       - /etc/localtime:/etc/localtime:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - CADDY_APP_SITE_HOSTS=${CADDY_APP_SITE_HOSTS:-http://localhost:8080}
       - CADDY_CROSS_SITE_HOST=${CADDY_CROSS_SITE_HOST:-http://localhost:8081}
       - CADDY_CROSS_UPSTREAM=${CADDY_CROSS_UPSTREAM:-host.docker.internal:8501}
-      - "CONTENT_SECURITY_POLICY=${CONTENT_SECURITY_POLICY:-default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:}"
+      - CONTENT_SECURITY_POLICY
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,4 +23,4 @@ if ! dpkg -s libxcb1 >/dev/null 2>&1; then
 fi
 
 echo "Starting application..."
-exec python -m ai_actuarial api --host "${FASTAPI_HOST:-127.0.0.1}" --port "${FASTAPI_PORT:-5000}"
+exec python -m ai_actuarial api --host "${FASTAPI_HOST:-0.0.0.0}" --port "${FASTAPI_PORT:-5000}"

--- a/docs/guides/PRODUCTION_SECURITY_CONFIG.md
+++ b/docs/guides/PRODUCTION_SECURITY_CONFIG.md
@@ -17,7 +17,8 @@ Set these only on the deployment server:
 - `TOKEN_ENCRYPTION_KEY`: stable Fernet key for encrypted provider credentials.
 - `ENABLE_CSRF`: keep `true` in production unless there is a documented exception.
 - `FASTAPI_SESSION_COOKIE_SECURE`: keep `true` behind HTTPS.
-- `CONTENT_SECURITY_POLICY`: override only when the frontend needs an explicit CSP change.
+- `TRUST_PROXY`: set `true` only when direct API access is restricted to trusted reverse proxy traffic.
+- `CONTENT_SECURITY_POLICY`: optional override when the frontend needs an explicit CSP change.
 
 Do not commit the server's real `.env` file.
 
@@ -28,8 +29,9 @@ Do not commit the server's real `.env` file.
 - Docker Compose uses `host.docker.internal:host-gateway` for host-side
   upstreams instead of publishing a fixed bridge subnet or gateway.
 - `config/sites.yaml` keeps safe public defaults for CSRF, CSP, and loopback
-  server binding. Production Compose can still override those values through
-  environment variables at startup.
+  server binding. Production Compose passes `CONTENT_SECURITY_POLICY` only when
+  the server environment sets it, so the committed Compose files do not carry a
+  second inline CSP default.
 
 ## Production startup
 

--- a/tests/test_dependency_versions.py
+++ b/tests/test_dependency_versions.py
@@ -4,8 +4,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_mistralai_is_pinned_to_current_supported_version() -> None:
+def test_mistralai_is_pinned_to_supported_version() -> None:
     requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+    pins = [line for line in requirements if line.startswith("mistralai==")]
 
-    assert "mistralai==1.12.4" in requirements
+    assert len(pins) == 1
+    version = pins[0].split("==", 1)[1]
+    assert tuple(int(part) for part in version.split(".")) >= (1, 12, 4)
     assert "mistralai==1.0.0" not in requirements

--- a/tests/test_deployment_config_source.py
+++ b/tests/test_deployment_config_source.py
@@ -18,6 +18,9 @@ def test_production_compose_uses_fastapi_env_and_keeps_features_in_yaml():
     assert "VITE_API_BASE_URL=${VITE_API_BASE_URL:?VITE_API_BASE_URL is required in production}" in src
     assert "ENABLE_CSRF=${ENABLE_CSRF:-true}" in src
     assert "FASTAPI_SESSION_COOKIE_SECURE=${FASTAPI_SESSION_COOKIE_SECURE:-true}" in src
+    assert "TRUST_PROXY=${TRUST_PROXY:-false}" in src
+    assert "CONTENT_SECURITY_POLICY=${CONTENT_SECURITY_POLICY:-default-src" not in src
+    assert "- CONTENT_SECURITY_POLICY" in src
     assert "CADDY_DOMAIN" not in src
 
 
@@ -54,6 +57,15 @@ def test_compose_does_not_pin_public_bridge_topology():
     assert "host.docker.internal:host-gateway" in src
     assert "CADDY_APP_SITE_HOSTS=${CADDY_APP_SITE_HOSTS:-http://localhost:8080}" in src
     assert "CADDY_CROSS_UPSTREAM=${CADDY_CROSS_UPSTREAM:-host.docker.internal:8501}" in src
+    assert "CONTENT_SECURITY_POLICY=${CONTENT_SECURITY_POLICY:-default-src" not in src
+    assert "- CONTENT_SECURITY_POLICY" in src
+
+
+def test_container_entrypoint_keeps_container_bind_reachable():
+    src = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+
+    assert 'FASTAPI_HOST:-0.0.0.0' in src
+    assert 'FASTAPI_HOST:-127.0.0.1' not in src
 
 
 def test_committed_sites_yaml_uses_safe_public_security_defaults():

--- a/tests/test_gitee_sync_workflow_source.py
+++ b/tests/test_gitee_sync_workflow_source.py
@@ -30,6 +30,8 @@ def test_gitee_sync_workflow_uses_token_auth_and_safe_push():
     assert "secrets.GITEE_TOKEN" in src
     assert "vars.GITEE_USER" in src
     assert any("git credential approve" in line for line in run_lines)
+    assert 'git config user.email "ferry.he@gmail.com"' in run_lines
+    assert 'git config user.name "jghe"' in run_lines
     assert 'git remote add gitee "https://gitee.com/${GITEE_USER}/${GITEE_REPOSITORY}.git"' in run_lines
     assert "git fetch --prune gitee" in run_lines
     assert "git push --force-with-lease gitee HEAD:main" in run_lines


### PR DESCRIPTION
## Summary
- keep the Docker entrypoint reachable for ad-hoc container runs by defaulting `FASTAPI_HOST` to `0.0.0.0`
- default `TRUST_PROXY` to `false` in production Compose unless the server explicitly enables trusted-proxy behavior
- stop duplicating the CSP inline default in Compose; pass `CONTENT_SECURITY_POLICY` only when the server environment sets it
- relax the `mistralai` guard to require a pinned version at or above `1.12.4` instead of one exact version

## Comment triage
- PR #107 Caddy log path and healthcheck loopback comments are already addressed on `main`
- PR #108 markdown response typing comment is already addressed on `main`
- PR #109 page-jump integer parsing comment is already addressed on `main`
- PR #111 PR-description mismatch is stale because the PR is merged; the remaining deployment/test comments are addressed here

## Verification
- `python -m pytest tests/test_deployment_config_source.py tests/test_dependency_versions.py -q`
- `python -c "from pathlib import Path; import yaml; [yaml.safe_load(Path(path).read_text(encoding='utf-8')) for path in ['docker-compose.yml','docker-compose.override.yml','config/sites.yaml']]; print('yaml ok')"`
- `rg -n "CONTENT_SECURITY_POLICY=\\$\\{CONTENT_SECURITY_POLICY:-default-src|TRUST_PROXY=\\$\\{TRUST_PROXY:-true|FASTAPI_HOST:-127\\.0\\.0\\.1|mistralai==1\\.12\\.4" docker-compose.yml docker-compose.override.yml docker-entrypoint.sh tests/test_dependency_versions.py tests/test_deployment_config_source.py`
- `git diff --check`

## Notes
- `docker compose config` could not run locally because Docker is not installed in this Windows environment.
- The mandatory local Codex CLI review gate is still blocked by `codex.exe` returning `Access is denied`.