### PR TITLE
fix: harden crawler URL fetches against SSRF

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,21 +1,19 @@
 # Project Status
 
 - Date: 2026-05-24
-- Branch: `feat/browser-file-import-batches`
-- Latest baseline: latest `origin/main` when this branch was created.
-- Scope: PR1 security hardening for browser-selected local file import batches. Sibling repositories were not read or modified.
-- Backend: Added `/api/files/import-batches` multipart upload endpoint gated by `tasks.run`; uploaded files are staged under an import-batch root with per-file/total limits, path traversal checks, owner checks, duplicate relative-path checks, and an allowlist covering supported import extensions including EPUB.
-- Backend: Immediate file collections now require `upload_batch_id`; `directory_path` is rejected and removed from task payloads so the server no longer imports arbitrary server filesystem paths from user input.
-- Backend: Runtime file collection consumes staged batch file paths and applies the selected extension filter during collection. Browser-selected original relative paths and filenames are preserved for staged files.
-- Backend: Scheduled `file` tasks are rejected server-side because browser upload batches are one-shot immediate imports and cannot be safely replayed by the scheduler.
-- Frontend: File import UI now uses browser file/folder pickers plus `FormData`, removes the server-side `FolderBrowser`, filters selected files by the chosen extensions before upload, and disables scheduling for file imports.
-- Frontend i18n: Added Chinese/English strings for browser-based file upload labels, hints, errors, and uploading state.
-- Local browser smoke passed on Vite/FastAPI: `/tasks` as operator, opened File Import, uploaded a PDF plus TXT sidecar batch through `/api/files/import-batches`, launched `/api/collections/run` with `upload_batch_id`, and confirmed task completion with no browser console errors.
-- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_fastapi_ops_write_endpoints.py tests/test_fastapi_ops_read_endpoints.py tests/test_tasks_react_source.py -q` (39 passed, 3 warnings).
-- Verification passed: `npm run build` (passed with existing Vite large-chunk warning).
-- Verification passed: `git diff --check` (passed).
-- PR follow-up: Copilot comments were reviewed against the current diff. Confirmed and fixed: upload-batch API response no longer returns absolute `stored_path` values; frontend import response type no longer models unreachable `{error}` success bodies and relies on HTTP error handling.
-- CI follow-up: `python-smoke` had failed because CI lacked `python-multipart`; added it to `requirements.txt`. Also updated the no-Flask runtime smoke to use upload batches instead of legacy `directory_path`.
-- CI smoke reproduced locally with CI-equivalent required env present: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_fastapi_entrypoint.py tests/test_fastapi_no_flask_runtime.py tests/test_react_fastapi_authority.py -q` (13 passed, 3 warnings).
-- Local Codex review gate: first run found valid issues around scheduled file tasks and upload allowlist; fixes were applied. Latest `codex -c 'model="gpt-5.5"' review --uncommitted` completed with no discrete correctness issues.
-- Next step: commit/push PR1 follow-up and wait for refreshed GitHub CI/review state before moving to PR2 SSRF protection.
+- Branch: `feat/ssrf-url-safety`
+- Latest baseline: latest `origin/main` when this branch was created after PR118 merged.
+- Scope: PR2 security hardening for SSRF protection on user/crawler URLs. Sibling repositories were not read or modified.
+- Backend security: Added centralized `ai_actuarial.security.url_safety` validator for HTTP/HTTPS-only URL validation, malformed URL/port normalization, localhost/private/link-local/metadata/non-global IP rejection, and DNS resolution checks.
+- Backend security: Site configuration writes now validate URLs on add/update/import/preview paths and map unsafe URLs to controlled ops-write validation errors instead of server errors.
+- Crawler security: `Crawler._request` and `_download_file` now validate each request and each redirect hop, manually enforce redirect revalidation, and reject unsafe redirects.
+- Crawler security: Removed crawler fetch/download use of independent DNS resolution clients. Actual connections are opened directly to the already validated IP address while preserving the original host for Host/SNI, avoiding DNS-rebinding gaps without process-global DNS monkey-patching.
+- Crawler security: Web page collection now reuses the crawler request path instead of calling `urllib.request.urlopen` directly, so page fetches inherit URL validation, redirect revalidation, and DNS pinning.
+- Follow-up fix: Local Codex review found IPv6 literal Host headers needed bracket preservation in the pinned HTTP path; fixed and covered with a regression test.
+- Tests: Added `tests/test_url_safety.py` covering public URL allow, scheme/local/private/metadata blocking, private DNS blocking, malformed URLs, invalid ports, crawler DNS pinning handoff, redirect-to-private rejection for request/download paths, and IPv6 literal Host header formatting.
+- Tests: Extended FastAPI ops-write endpoint tests to cover unsafe site URL rejection in add/update/import flows with deterministic public DNS resolver fixtures.
+- Tests: Extended WebPageCollector tests to prove `_fetch_html` uses `Crawler._request` and rejects unsafe loopback URLs before network access.
+- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_url_safety.py tests/test_web_page_collector.py tests/test_fastapi_ops_write_endpoints.py tests/test_crawler_allow_patterns.py -q && git diff --check` (55 passed, 3 warnings).
+- Full suite status: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest -q` currently reports 462 passed, 11 failed, 4 warnings. Failures are in pre-existing non-SSRF areas (`ai_actuarial/web` cleanup expectations, FastAPI entrypoint 503 responses, one RAG admin dirty-state assertion, and safe-pickle tests); no evidence links them to this PR2 SSRF diff.
+- Local Codex review gate: Latest `codex -c 'model="gpt-5.5"' review --uncommitted` completed with no discrete correctness/security/maintainability issues after the IPv6 Host header fix.
+- Next step: commit, push, create the PR from `feat/ssrf-url-safety`, then check remote Copilot/comments after the requested wait window.

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -43,6 +43,7 @@ from ai_actuarial.shared_runtime import (
 )
 from ai_actuarial.config import settings
 from ai_actuarial.api.services.import_batches import ImportBatchError, load_import_batch
+from ai_actuarial.security import UnsafeUrlError, ensure_safe_http_url
 from ai_actuarial.storage import Storage
 
 logger = logging.getLogger(__name__)
@@ -336,6 +337,7 @@ def add_site(data: dict[str, Any], *, bridge: BridgeState | None = None) -> dict
         "name": str(data["name"]).strip(),
         "url": str(data["url"]).strip(),
     }
+    _validate_site_url(new_site["url"])
     max_pages = _coerce_optional_int(data.get("max_pages"))
     max_depth = _coerce_optional_int(data.get("max_depth"))
     if max_pages is not None:
@@ -382,6 +384,7 @@ def update_site(data: dict[str, Any], *, bridge: BridgeState | None = None) -> d
             continue
         site["name"] = new_name
         site["url"] = str(data.get("url") or "").strip()
+        _validate_site_url(site["url"])
         max_pages = _coerce_optional_int(data.get("max_pages"))
         max_depth = _coerce_optional_int(data.get("max_depth"))
         if max_pages is not None:
@@ -472,7 +475,12 @@ def import_sites(data: dict[str, Any], *, bridge: BridgeState | None = None) -> 
         raise OpsWriteError("sites array is required (provide 'sites' or 'yaml_text')")
 
     if preview_only:
-        valid = [site for site in incoming_sites if isinstance(site, dict) and site.get("name") and site.get("url")]
+        valid = []
+        for site in incoming_sites:
+            if not isinstance(site, dict) or not site.get("name") or not site.get("url"):
+                continue
+            if _site_url_is_safe(str(site.get("url") or "")):
+                valid.append(site)
         return {"success": True, "count": len(valid), "names": [str(site.get("name") or "") for site in valid]}
 
     _backup_config("before_import")
@@ -490,6 +498,8 @@ def import_sites(data: dict[str, Any], *, bridge: BridgeState | None = None) -> 
             if not isinstance(site, dict) or not site.get("name") or not site.get("url"):
                 errors.append(f"Invalid site entry: {site}")
                 continue
+            if not _site_url_is_safe(str(site.get("url") or ""), errors=errors, site_name=str(site.get("name") or "")):
+                continue
             valid_sites.append(site)
         config_data["sites"] = valid_sites
         imported = len(valid_sites)
@@ -498,6 +508,8 @@ def import_sites(data: dict[str, Any], *, bridge: BridgeState | None = None) -> 
         for site in incoming_sites:
             if not isinstance(site, dict) or not site.get("name") or not site.get("url"):
                 errors.append(f"Invalid site entry: {site}")
+                continue
+            if not _site_url_is_safe(str(site.get("url") or ""), errors=errors, site_name=str(site.get("name") or "")):
                 continue
             site_name = str(site["name"])
             if site_name in existing_names:
@@ -519,6 +531,24 @@ def import_sites(data: dict[str, Any], *, bridge: BridgeState | None = None) -> 
     if errors:
         result["errors"] = errors
     return result
+
+
+def _validate_site_url(url: str) -> None:
+    try:
+        ensure_safe_http_url(url)
+    except UnsafeUrlError as exc:
+        raise OpsWriteError(f"Unsafe site URL: {exc}") from exc
+
+
+def _site_url_is_safe(url: str, *, errors: list[str] | None = None, site_name: str = "") -> bool:
+    try:
+        ensure_safe_http_url(url)
+        return True
+    except UnsafeUrlError as exc:
+        if errors is not None:
+            label = f" for site '{site_name}'" if site_name else ""
+            errors.append(f"Unsafe site URL{label}: {exc}")
+        return False
 
 
 def export_sites_yaml() -> tuple[str, str]:

--- a/ai_actuarial/collectors/web_page.py
+++ b/ai_actuarial/collectors/web_page.py
@@ -185,7 +185,7 @@ class WebPageCollector(BaseCollector):
             download_dir=str(self.download_dir),
             user_agent=self.user_agent,
         )
-        return crawler._request(url)
+        return crawler._request(url, timeout=_DEFAULT_FETCH_TIMEOUT)
 
     def _extract_text(self, html: str, url: str) -> str | None:
         """Extract clean article text from *html* using trafilatura.

--- a/ai_actuarial/collectors/web_page.py
+++ b/ai_actuarial/collectors/web_page.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
-import urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
 from .base import BaseCollector, CollectionConfig, CollectionResult
+from ..crawler import Crawler
 from ..storage import Storage
 from ..utils import extract_metadata
 
@@ -174,15 +174,18 @@ class WebPageCollector(BaseCollector):
             Tuple of ``(raw_bytes, response_headers, final_url)``.
 
         Raises:
-            urllib.error.URLError: On network errors.
+            UnsafeUrlError: When the URL or any redirect target is unsafe.
+            OSError/HTTPError-like exceptions: On network errors.
         """
-        req = urllib.request.Request(
-            url, headers={"User-Agent": self.user_agent}
+        # Reuse the crawler request path so web-page collection gets the same
+        # SSRF protections as crawl/download flows: HTTP(S)-only validation,
+        # per-hop redirect revalidation, and per-connection pinned DNS.
+        crawler = Crawler(
+            storage=self.storage,
+            download_dir=str(self.download_dir),
+            user_agent=self.user_agent,
         )
-        with urllib.request.urlopen(req, timeout=_DEFAULT_FETCH_TIMEOUT) as resp:
-            data = resp.read()
-            headers = {k.lower(): v for k, v in resp.headers.items()}
-            return data, headers, resp.geturl()
+        return crawler._request(url)
 
     def _extract_text(self, html: str, url: str) -> str | None:
         """Extract clean article text from *html* using trafilatura.

--- a/ai_actuarial/crawler.py
+++ b/ai_actuarial/crawler.py
@@ -30,6 +30,7 @@ from .utils import (
 
 DEFAULT_FILE_EXTS = {".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"}
 _MAX_REDIRECT_HOPS = 10
+_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 
 
 class _PinnedHTTPResponse:
@@ -110,11 +111,11 @@ class Crawler:
         if cleaned > 0:
             logger.info("Cleaned up %d stale temporary files", cleaned)
 
-    def _request(self, url: str) -> tuple[bytes, dict[str, str], str]:
+    def _request(self, url: str, *, timeout: int = 30) -> tuple[bytes, dict[str, str], str]:
         current_url = url
         for _hop in range(_MAX_REDIRECT_HOPS):
             resolution = resolve_safe_http_url(current_url)
-            with self._open_pinned_http(current_url, resolution, timeout=30) as resp:
+            with self._open_pinned_http(current_url, resolution, timeout=timeout) as resp:
                 headers = {k.lower(): str(v) for k, v in resp.headers.items()}
                 redirect_target = self._redirect_target(current_url, self._response_code(resp), headers)
                 if redirect_target:
@@ -186,12 +187,13 @@ class Crawler:
             host_header = f"{host_header}:{port}"
 
         last_error: Exception | None = None
+        ssl_context = ssl.create_default_context() if scheme == "https" else None
         for address in resolution.addresses:
             conn = http.client.HTTPConnection(resolution.host, port=port, timeout=timeout)
             try:
                 sock = socket.create_connection((str(address), port), timeout=timeout)
-                if scheme == "https":
-                    sock = ssl.create_default_context().wrap_socket(sock, server_hostname=resolution.host)
+                if ssl_context is not None:
+                    sock = ssl_context.wrap_socket(sock, server_hostname=resolution.host)
                 conn.sock = sock
                 conn.request("GET", target, headers={"User-Agent": self.user_agent, "Host": host_header})
                 response = conn.getresponse()
@@ -212,7 +214,7 @@ class Crawler:
 
     @staticmethod
     def _redirect_target(current_url: str, status_code: int | None, headers: dict[str, str]) -> str | None:
-        if status_code is None or not (300 <= int(status_code) < 400):
+        if status_code is None or int(status_code) not in _REDIRECT_STATUS_CODES:
             return None
         location = str(headers.get("location") or "").strip()
         if not location:

--- a/ai_actuarial/crawler.py
+++ b/ai_actuarial/crawler.py
@@ -1,28 +1,24 @@
 from __future__ import annotations
 
+import http.client
+import ipaddress
 import logging
 import os
 import re
+import socket
+import ssl
 import time
-import urllib.request
 import xml.etree.ElementTree as ET
 import hashlib
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
-try:
-    import curl_cffi.requests as _curl_requests  # type: ignore
-    _CURL_CFFI_AVAILABLE = True
-    logger.debug("curl_cffi available; using Chrome impersonation for HTTP requests")
-except ImportError:
-    _curl_requests = None  # type: ignore
-    _CURL_CFFI_AVAILABLE = False
-
 from .storage import Storage
+from .security import SafeUrlResolution, UnsafeUrlError, resolve_safe_http_url
 from .utils import (
     extract_metadata,
     html_to_text,
@@ -33,6 +29,34 @@ from .utils import (
 
 
 DEFAULT_FILE_EXTS = {".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"}
+_MAX_REDIRECT_HOPS = 10
+
+
+class _PinnedHTTPResponse:
+    def __init__(self, conn: http.client.HTTPConnection, response: http.client.HTTPResponse, url: str) -> None:
+        self._conn = conn
+        self._response = response
+        self._url = url
+        self.status = response.status
+        self.headers = {k.lower(): v for k, v in response.getheaders()}
+
+    def read(self, size: int = -1) -> bytes:
+        return self._response.read(size)
+
+    def geturl(self) -> str:
+        return self._url
+
+    def getcode(self) -> int:
+        return self.status
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
 
 
 @dataclass
@@ -87,30 +111,20 @@ class Crawler:
             logger.info("Cleaned up %d stale temporary files", cleaned)
 
     def _request(self, url: str) -> tuple[bytes, dict[str, str], str]:
-        if _CURL_CFFI_AVAILABLE:
-            try:
-                resp = _curl_requests.get(
-                    url,
-                    impersonate="chrome",
-                    headers={"User-Agent": self.user_agent},
-                    timeout=30,
-                    allow_redirects=True,
-                )
-                resp.raise_for_status()
-                data = resp.content
-                headers = {k.lower(): v for k, v in resp.headers.items()}
-                return data, headers, resp.url
-            except Exception as exc:
-                logger.debug("curl_cffi request failed for %s, falling back to urllib: %s", url, exc)
+        current_url = url
+        for _hop in range(_MAX_REDIRECT_HOPS):
+            resolution = resolve_safe_http_url(current_url)
+            with self._open_pinned_http(current_url, resolution, timeout=30) as resp:
+                headers = {k.lower(): str(v) for k, v in resp.headers.items()}
+                redirect_target = self._redirect_target(current_url, self._response_code(resp), headers)
+                if redirect_target:
+                    current_url = redirect_target
+                    continue
+                self._raise_for_status(current_url, self._response_code(resp))
+                data = resp.read()
+                return data, headers, resp.geturl()
 
-        req = urllib.request.Request(
-            url,
-            headers={"User-Agent": self.user_agent},
-        )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = resp.read()
-            headers = {k.lower(): v for k, v in resp.headers.items()}
-            return data, headers, resp.geturl()
+        raise UnsafeUrlError(f"Too many redirects while fetching {url}")
 
     def _download_file(self, url: str, target_dir: Path) -> tuple[Path, dict[str, str], str, str, int]:
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -121,58 +135,30 @@ class Crawler:
         size = 0
         success = False
         try:
-            if _CURL_CFFI_AVAILABLE:
-                try:
-                    resp = _curl_requests.get(
-                        url,
-                        impersonate="chrome",
-                        headers={"User-Agent": self.user_agent},
-                        timeout=60,
-                        allow_redirects=True,
-                        stream=True,
-                    )
-                    resp.raise_for_status()
-                    headers = {k.lower(): v for k, v in resp.headers.items()}
-                    final_url = resp.url
+            current_url = url
+            for _hop in range(_MAX_REDIRECT_HOPS):
+                resolution = resolve_safe_http_url(current_url)
+                with self._open_pinned_http(current_url, resolution, timeout=60) as resp:
+                    headers = {k.lower(): str(v) for k, v in resp.headers.items()}
+                    redirect_target = self._redirect_target(current_url, self._response_code(resp), headers)
+                    if redirect_target:
+                        current_url = redirect_target
+                        continue
+                    self._raise_for_status(current_url, self._response_code(resp))
+                    final_url = resp.geturl()
                     with open(tmp_path, "wb") as f:
-                        for chunk in resp.iter_content(chunk_size=1024 * 128):
-                            if chunk:
-                                f.write(chunk)
-                                hasher.update(chunk)
-                                size += len(chunk)
-                    success = True
-                    logger.debug("Downloaded %s (%d bytes) via curl_cffi", url, size)
-                    return tmp_path, headers, final_url, hasher.hexdigest(), size
-                except Exception as exc:
-                    logger.debug("curl_cffi download failed for %s, falling back to urllib: %s", url, exc)
-                    # Reset state for fallback attempt
-                    try:
-                        if tmp_path.exists():
-                            tmp_path.unlink()
-                    except Exception:
-                        pass
-                    tmp_path = tmp_dir / f"download_{time.time_ns()}.part"
-                    hasher = hashlib.sha256()
-                    size = 0
+                        while True:
+                            chunk = resp.read(1024 * 128)
+                            if not chunk:
+                                break
+                            f.write(chunk)
+                            hasher.update(chunk)
+                            size += len(chunk)
+                success = True
+                logger.debug("Downloaded %s (%d bytes)", current_url, size)
+                return tmp_path, headers, final_url, hasher.hexdigest(), size
 
-            req = urllib.request.Request(
-                url,
-                headers={"User-Agent": self.user_agent},
-            )
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                headers = {k.lower(): v for k, v in resp.headers.items()}
-                final_url = resp.geturl()
-                with open(tmp_path, "wb") as f:
-                    while True:
-                        chunk = resp.read(1024 * 128)
-                        if not chunk:
-                            break
-                        f.write(chunk)
-                        hasher.update(chunk)
-                        size += len(chunk)
-            success = True
-            logger.debug("Downloaded %s (%d bytes)", url, size)
-            return tmp_path, headers, final_url, hasher.hexdigest(), size
+            raise UnsafeUrlError(f"Too many redirects while downloading {url}")
         finally:
             if not success and tmp_path.exists():
                 try:
@@ -184,6 +170,59 @@ class Crawler:
     def _is_file_url(self, url: str, exts: set[str]) -> bool:
         path = urlparse(url).path.lower()
         return any(path.endswith(ext) for ext in exts)
+
+    def _open_pinned_http(self, url: str, resolution: SafeUrlResolution, *, timeout: int):
+        parsed = urlsplit(url)
+        scheme = parsed.scheme.lower()
+        port = parsed.port or (443 if scheme == "https" else 80)
+        target = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+        host_header = resolution.host
+        try:
+            if isinstance(ipaddress.ip_address(resolution.host), ipaddress.IPv6Address):
+                host_header = f"[{resolution.host}]"
+        except ValueError:
+            pass
+        if (scheme == "http" and port != 80) or (scheme == "https" and port != 443):
+            host_header = f"{host_header}:{port}"
+
+        last_error: Exception | None = None
+        for address in resolution.addresses:
+            conn = http.client.HTTPConnection(resolution.host, port=port, timeout=timeout)
+            try:
+                sock = socket.create_connection((str(address), port), timeout=timeout)
+                if scheme == "https":
+                    sock = ssl.create_default_context().wrap_socket(sock, server_hostname=resolution.host)
+                conn.sock = sock
+                conn.request("GET", target, headers={"User-Agent": self.user_agent, "Host": host_header})
+                response = conn.getresponse()
+                return _PinnedHTTPResponse(conn, response, url)
+            except Exception as exc:
+                conn.close()
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        raise UnsafeUrlError(f"No validated address available for {url}")
+
+    @staticmethod
+    def _response_code(resp) -> int:
+        code = getattr(resp, "status", None)
+        if code is None:
+            code = resp.getcode()
+        return int(code)
+
+    @staticmethod
+    def _redirect_target(current_url: str, status_code: int | None, headers: dict[str, str]) -> str | None:
+        if status_code is None or not (300 <= int(status_code) < 400):
+            return None
+        location = str(headers.get("location") or "").strip()
+        if not location:
+            raise UnsafeUrlError(f"Redirect response from {current_url} is missing Location header")
+        return urljoin(current_url, location)
+
+    @staticmethod
+    def _raise_for_status(url: str, status_code: int) -> None:
+        if status_code >= 400:
+            raise RuntimeError(f"HTTP Error {status_code} for {url}")
 
     def _is_excluded(self, text: str, exclude: list[str]) -> bool:
         """Check if text contains any excluded keyword."""

--- a/ai_actuarial/security/__init__.py
+++ b/ai_actuarial/security/__init__.py
@@ -1,0 +1,3 @@
+from .url_safety import SafeUrlResolution, UnsafeUrlError, ensure_safe_http_url, resolve_safe_http_url
+
+__all__ = ["SafeUrlResolution", "UnsafeUrlError", "ensure_safe_http_url", "resolve_safe_http_url"]

--- a/ai_actuarial/security/url_safety.py
+++ b/ai_actuarial/security/url_safety.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+import socket
+from dataclasses import dataclass
+from typing import Callable
+from urllib.parse import unquote, urlsplit
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when a URL is not safe to fetch."""
+
+
+Resolver = Callable[..., list[tuple]]
+
+
+@dataclass(frozen=True)
+class SafeUrlResolution:
+    url: str
+    host: str
+    addresses: tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...]
+
+
+_ALLOWED_SCHEMES = {"http", "https"}
+_HEX_RE = re.compile(r"^0x[0-9a-f]+$", re.IGNORECASE)
+_OCTAL_RE = re.compile(r"^0[0-7]+$")
+_DECIMAL_RE = re.compile(r"^[0-9]+$")
+
+
+def ensure_safe_http_url(url: str, *, resolver: Resolver | None = None) -> str:
+    return resolve_safe_http_url(url, resolver=resolver).url
+
+
+def resolve_safe_http_url(url: str, *, resolver: Resolver | None = None) -> SafeUrlResolution:
+    candidate = str(url or "").strip()
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError as exc:
+        raise UnsafeUrlError(f"Invalid URL: {exc}") from exc
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise UnsafeUrlError(f"URL scheme '{parsed.scheme or '<missing>'}' is not allowed")
+
+    host = _normalized_host(parsed.hostname)
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise UnsafeUrlError(f"Invalid URL port: {exc}") from exc
+    if not host:
+        raise UnsafeUrlError("URL host is required")
+    if host == "localhost":
+        raise UnsafeUrlError("localhost is not allowed")
+
+    addresses = tuple(_resolved_ip_addresses(host, resolver=resolver))
+    for address in addresses:
+        if _is_disallowed_ip(address):
+            raise UnsafeUrlError(f"URL resolves to a non-public IP address: {address}")
+
+    return SafeUrlResolution(url=candidate, host=host, addresses=addresses)
+
+
+def _normalized_host(host: str | None) -> str:
+    if not host:
+        return ""
+    return unquote(host).strip().rstrip(".").lower()
+
+
+def _resolved_ip_addresses(host: str, *, resolver: Resolver | None = None) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    direct_ip = _parse_ip_literal(host)
+    if direct_ip is not None:
+        return [direct_ip]
+
+    lookup = resolver or socket.getaddrinfo
+    try:
+        infos = lookup(host, None, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise UnsafeUrlError(f"Failed to resolve host '{host}': {exc}") from exc
+
+    for family, _, _, _, sockaddr in infos:
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            continue
+        raw_ip = str(sockaddr[0])
+        try:
+            addresses.append(ipaddress.ip_address(raw_ip.split('%', 1)[0]))
+        except ValueError:
+            continue
+
+    if not addresses:
+        raise UnsafeUrlError(f"Host '{host}' did not resolve to an IP address")
+    return addresses
+
+
+def _parse_ip_literal(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(host)
+    except ValueError:
+        pass
+
+    try:
+        if _DECIMAL_RE.fullmatch(host):
+            value = int(host, 10)
+            if 0 <= value <= (2**32 - 1):
+                return ipaddress.IPv4Address(value)
+        if _HEX_RE.fullmatch(host):
+            value = int(host, 16)
+            if 0 <= value <= (2**32 - 1):
+                return ipaddress.IPv4Address(value)
+        if _OCTAL_RE.fullmatch(host):
+            value = int(host, 8)
+            if 0 <= value <= (2**32 - 1):
+                return ipaddress.IPv4Address(value)
+    except ValueError:
+        return None
+
+    return None
+
+
+def _is_disallowed_ip(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        str(address) == "169.254.169.254"
+        or address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+        or not address.is_global
+    )

--- a/ai_actuarial/security/url_safety.py
+++ b/ai_actuarial/security/url_safety.py
@@ -44,9 +44,11 @@ def resolve_safe_http_url(url: str, *, resolver: Resolver | None = None) -> Safe
 
     host = _normalized_host(parsed.hostname)
     try:
-        parsed.port
+        port = parsed.port
     except ValueError as exc:
         raise UnsafeUrlError(f"Invalid URL port: {exc}") from exc
+    if port == 0:
+        raise UnsafeUrlError("Invalid URL port: port must be in the range 1-65535")
     if not host:
         raise UnsafeUrlError("URL host is required")
     if host == "localhost":

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -82,6 +82,17 @@ def _seed_stats_data(db_path: Path) -> None:
         storage.close()
 
 
+
+def _install_public_dns_resolver(monkeypatch, *hosts: str) -> None:
+    def fake_getaddrinfo(host, port, type=0, proto=0, *args, **kwargs):
+        if host in set(hosts):
+            return [(2, type, proto, "", ("93.184.216.34", 0))]
+        raise AssertionError(f"Unexpected DNS lookup in test: {host}")
+
+    monkeypatch.setattr("ai_actuarial.security.url_safety.socket.getaddrinfo", fake_getaddrinfo)
+
+
+
 class _BridgeRecorder:
     def __init__(self) -> None:
         self.started: list[tuple[str, dict[str, object], str | None, dict[str, object] | None]] = []
@@ -128,6 +139,13 @@ def test_ops_write_routes_are_listed_in_native_inventory(tmp_path: Path, monkeyp
 
 def test_config_sites_crud_import_export_and_backups_roundtrip(tmp_path: Path, monkeypatch) -> None:
     _patch_available_models(monkeypatch)
+    _install_public_dns_resolver(
+        monkeypatch,
+        "www.soa.org",
+        "preview.example",
+        "import.example",
+        "duplicate.example",
+    )
     client, app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
     recorder = _BridgeRecorder()
     _install_bridge(app, recorder)
@@ -221,6 +239,78 @@ def test_config_sites_crud_import_export_and_backups_roundtrip(tmp_path: Path, m
     restore_filename = restore_source.json()["backups"][0]["filename"]
     restore_response = client.post("/api/config/backups/restore", json={"filename": restore_filename}, headers=headers)
     assert restore_response.status_code == 200, restore_response.text
+
+
+
+def test_site_config_write_rejects_unsafe_urls(tmp_path: Path, monkeypatch) -> None:
+    _patch_available_models(monkeypatch)
+    _install_public_dns_resolver(monkeypatch, "safe.example", "preview.example", "import.example")
+    client, app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
+    config_path = Path(os.environ["CONFIG_PATH"])
+    headers = {"X-Auth-Token": seed["operator_token"]}
+
+    add_response = client.post(
+        "/api/config/sites/add",
+        json={"name": "Blocked", "url": "http://127.0.0.1/internal"},
+        headers=headers,
+    )
+    assert add_response.status_code == 400, add_response.text
+    assert "Unsafe site URL" in add_response.text
+
+    safe_add = client.post(
+        "/api/config/sites/add",
+        json={"name": "Safe", "url": "https://safe.example/reports"},
+        headers=headers,
+    )
+    assert safe_add.status_code == 200, safe_add.text
+
+    update_response = client.post(
+        "/api/config/sites/update",
+        json={"original_name": "Safe", "name": "Safe", "url": "http://localhost/admin"},
+        headers=headers,
+    )
+    assert update_response.status_code == 400, update_response.text
+    safe_site = next(site for site in _read_sites(config_path) if site["name"] == "Safe")
+    assert safe_site["url"] == "https://safe.example/reports"
+
+    preview_response = client.post(
+        "/api/config/sites/import",
+        json={
+            "preview": True,
+            "yaml_text": (
+                "sites:\n"
+                "  - name: Preview Safe\n"
+                "    url: https://preview.example\n"
+                "  - name: Preview Blocked\n"
+                "    url: http://127.0.0.1/hidden\n"
+            ),
+        },
+        headers=headers,
+    )
+    assert preview_response.status_code == 200, preview_response.text
+    assert preview_response.json()["count"] == 1
+
+    import_response = client.post(
+        "/api/config/sites/import",
+        json={
+            "mode": "merge",
+            "yaml_text": (
+                "sites:\n"
+                "  - name: Import Safe\n"
+                "    url: https://import.example\n"
+                "  - name: Import Blocked\n"
+                "    url: http://127.0.0.1/secret\n"
+            ),
+        },
+        headers=headers,
+    )
+    assert import_response.status_code == 200, import_response.text
+    body = import_response.json()
+    assert body["imported"] == 1
+    assert any("Unsafe site URL" in message for message in body.get("errors", []))
+    site_names = {site["name"] for site in _read_sites(config_path)}
+    assert "Import Safe" in site_names
+    assert "Import Blocked" not in site_names
 
 
 
@@ -617,6 +707,7 @@ def test_schedule_reinit_and_file_collection_work_with_native_bridge(tmp_path: P
 
 def test_ops_write_routes_require_operator_when_auth_enabled(tmp_path: Path, monkeypatch) -> None:
     _patch_available_models(monkeypatch)
+    _install_public_dns_resolver(monkeypatch, "blocked.example", "allowed.example")
     client, app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
     recorder = _BridgeRecorder()
     _install_bridge(app, recorder)

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import ipaddress
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from ai_actuarial.crawler import Crawler
+from ai_actuarial.security.url_safety import SafeUrlResolution, UnsafeUrlError, ensure_safe_http_url
+from ai_actuarial.storage import Storage
+
+
+class _FakeResponse:
+    def __init__(self, code: int, headers: dict[str, str] | None = None, body: bytes = b"", url: str = "") -> None:
+        self.status = code
+        self.headers = headers or {}
+        self._body = body
+        self._url = url
+        self.closed = False
+
+    def read(self, _size: int = -1) -> bytes:
+        if _size is None or _size < 0:
+            return self._body
+        if not self._body:
+            return b""
+        chunk = self._body[:_size]
+        self._body = self._body[_size:]
+        return chunk
+
+    def geturl(self) -> str:
+        return self._url
+
+    def getcode(self) -> int:
+        return self.status
+
+    def getheaders(self):
+        return list(self.headers.items())
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+def _resolver(host: str, _port=None, type=None, proto=None):
+    mapping = {
+        "public.example": [(2, type, proto, "", ("93.184.216.34", 0))],
+        "safe.example": [(2, type, proto, "", ("93.184.216.34", 0))],
+        "private.example": [(2, type, proto, "", ("10.0.0.8", 0))],
+    }
+    if host not in mapping:
+        raise AssertionError(f"Unexpected host lookup: {host}")
+    return mapping[host]
+
+
+class TestEnsureSafeHttpUrl(unittest.TestCase):
+    def test_allows_public_https_url(self) -> None:
+        self.assertEqual(
+            ensure_safe_http_url("https://public.example/report.pdf", resolver=_resolver),
+            "https://public.example/report.pdf",
+        )
+
+    def test_blocks_local_and_private_targets(self) -> None:
+        blocked_urls = [
+            "file:///etc/passwd",
+            "http://localhost/admin",
+            "http://localhost./admin",
+            "http://127.0.0.1/admin",
+            "http://[::1]/admin",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.5/report.pdf",
+            "http://2130706433/decimal-loopback",
+        ]
+        for url in blocked_urls:
+            with self.subTest(url=url):
+                with self.assertRaises(UnsafeUrlError):
+                    ensure_safe_http_url(url, resolver=_resolver)
+
+    def test_blocks_private_dns_resolution(self) -> None:
+        with self.assertRaises(UnsafeUrlError):
+            ensure_safe_http_url("https://private.example/report.pdf", resolver=_resolver)
+
+    def test_malformed_url_raises_unsafe_url_error(self) -> None:
+        with self.assertRaises(UnsafeUrlError):
+            ensure_safe_http_url("http://[::1", resolver=_resolver)
+
+    def test_invalid_port_raises_unsafe_url_error(self) -> None:
+        for url in ("http://public.example:abc", "http://public.example:99999"):
+            with self.subTest(url=url):
+                with self.assertRaises(UnsafeUrlError):
+                    ensure_safe_http_url(url, resolver=_resolver)
+
+
+class TestCrawlerRedirectRevalidation(unittest.TestCase):
+    def _make_crawler(self, tmp_dir: str) -> Crawler:
+        storage = Storage(str(Path(tmp_dir) / "test.db"))
+        self.addCleanup(storage.close)
+        return Crawler(storage=storage, download_dir=tmp_dir, user_agent="TestAgent/1.0")
+
+    def test_request_pins_validated_dns_for_connection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            crawler = self._make_crawler(tmp_dir)
+            resolved_during_open: list[str] = []
+
+            def fake_open(url, resolution, *, timeout: int):
+                resolved_during_open.extend(str(address) for address in resolution.addresses)
+                return _FakeResponse(200, headers={"Content-Type": "text/html"}, body=b"ok", url=url)
+
+            with patch(
+                "ai_actuarial.security.url_safety.socket.getaddrinfo",
+                side_effect=_resolver,
+            ), patch.object(crawler, "_open_pinned_http", side_effect=fake_open):
+                body, _headers, final_url = crawler._request("https://public.example/start")
+
+            self.assertEqual(b"ok", body)
+            self.assertEqual("https://public.example/start", final_url)
+            self.assertEqual(["93.184.216.34"], resolved_during_open)
+
+    def test_request_rejects_redirect_to_private_ip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            crawler = self._make_crawler(tmp_dir)
+            seen_urls: list[str] = []
+
+            def fake_open(url, resolution, *, timeout: int):
+                seen_urls.append(url)
+                return _FakeResponse(
+                    302,
+                    headers={"Location": "http://127.0.0.1/admin"},
+                    url=url,
+                )
+
+            with patch(
+                "ai_actuarial.security.url_safety.socket.getaddrinfo",
+                side_effect=_resolver,
+            ), patch.object(crawler, "_open_pinned_http", side_effect=fake_open):
+                with self.assertRaises(UnsafeUrlError):
+                    crawler._request("https://public.example/start")
+
+            self.assertEqual(["https://public.example/start"], seen_urls)
+
+    def test_download_rejects_redirect_to_private_ip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            crawler = self._make_crawler(tmp_dir)
+            seen_urls: list[str] = []
+            target_dir = Path(tmp_dir) / "downloads"
+
+            def fake_open(url, resolution, *, timeout: int):
+                seen_urls.append(url)
+                return _FakeResponse(
+                    302,
+                    headers={"Location": "http://127.0.0.1/file.pdf"},
+                    url=url,
+                )
+
+            with patch(
+                "ai_actuarial.security.url_safety.socket.getaddrinfo",
+                side_effect=_resolver,
+            ), patch.object(crawler, "_open_pinned_http", side_effect=fake_open):
+                with self.assertRaises(UnsafeUrlError):
+                    crawler._download_file("https://public.example/file.pdf", target_dir)
+
+            self.assertEqual(["https://public.example/file.pdf"], seen_urls)
+            self.assertFalse(any(target_dir.rglob("*.part")))
+
+    def test_pinned_http_preserves_ipv6_literal_brackets_in_host_header(self) -> None:
+        class FakeHTTPConnection:
+            calls: list[dict] = []
+
+            def __init__(self, host: str, *, port: int, timeout: int):
+                self.host = host
+                self.port = port
+                self.timeout = timeout
+                self.sock = None
+
+            def request(self, method: str, target: str, headers: dict[str, str]):
+                self.__class__.calls.append(
+                    {"method": method, "target": target, "headers": headers, "host": self.host, "port": self.port}
+                )
+
+            def getresponse(self):
+                return _FakeResponse(200, headers={"Content-Type": "text/plain"}, body=b"ok")
+
+            def close(self) -> None:
+                pass
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            crawler = self._make_crawler(tmp_dir)
+            resolution = SafeUrlResolution(
+                url="http://[2001:4860:4860::8888]:8080/report",
+                host="2001:4860:4860::8888",
+                addresses=(ipaddress.ip_address("2001:4860:4860::8888"),),
+            )
+            with patch("ai_actuarial.crawler.http.client.HTTPConnection", FakeHTTPConnection), patch(
+                "ai_actuarial.crawler.socket.create_connection", return_value=object()
+            ):
+                with crawler._open_pinned_http(resolution.url, resolution, timeout=30):
+                    pass
+
+        self.assertEqual("[2001:4860:4860::8888]:8080", FakeHTTPConnection.calls[0]["headers"]["Host"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -90,7 +90,7 @@ class TestEnsureSafeHttpUrl(unittest.TestCase):
             ensure_safe_http_url("http://[::1", resolver=_resolver)
 
     def test_invalid_port_raises_unsafe_url_error(self) -> None:
-        for url in ("http://public.example:abc", "http://public.example:99999"):
+        for url in ("http://public.example:abc", "http://public.example:99999", "http://public.example:0"):
             with self.subTest(url=url):
                 with self.assertRaises(UnsafeUrlError):
                     ensure_safe_http_url(url, resolver=_resolver)
@@ -142,6 +142,27 @@ class TestCrawlerRedirectRevalidation(unittest.TestCase):
                     crawler._request("https://public.example/start")
 
             self.assertEqual(["https://public.example/start"], seen_urls)
+
+    def test_request_treats_non_redirect_3xx_without_location_as_final_response(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            crawler = self._make_crawler(tmp_dir)
+
+            def fake_open(url, resolution, *, timeout: int):
+                return _FakeResponse(
+                    304,
+                    headers={},
+                    body=b"",
+                    url=url,
+                )
+
+            with patch(
+                "ai_actuarial.security.url_safety.socket.getaddrinfo",
+                side_effect=_resolver,
+            ), patch.object(crawler, "_open_pinned_http", side_effect=fake_open):
+                body, _headers, final_url = crawler._request("https://public.example/not-modified")
+
+            self.assertEqual(b"", body)
+            self.assertEqual("https://public.example/not-modified", final_url)
 
     def test_download_rejects_redirect_to_private_ip(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_web_page_collector.py
+++ b/tests/test_web_page_collector.py
@@ -15,6 +15,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from ai_actuarial.collectors import CollectionConfig, WebPageCollector
+from ai_actuarial.security import UnsafeUrlError
 from ai_actuarial.storage import Storage
 
 
@@ -248,6 +249,27 @@ class TestWebPageCollectorBasics(unittest.TestCase):
                 CollectionConfig(name="Test", source_type="web_page"),
             )
         self.assertIsNone(result)
+
+    def test_fetch_html_uses_crawler_safe_request_path(self):
+        """_fetch_html should reuse crawler SSRF-safe request/download logic."""
+        with patch("ai_actuarial.collectors.web_page.Crawler._request") as request:
+            request.return_value = (
+                SAMPLE_HTML.encode("utf-8"),
+                {"content-type": "text/html"},
+                "https://example.com/article",
+            )
+
+            data, headers, final_url = self.collector._fetch_html("https://example.com/article")
+
+        request.assert_called_once_with("https://example.com/article")
+        self.assertIn(b"AI in Actuarial Science", data)
+        self.assertEqual("text/html", headers["content-type"])
+        self.assertEqual("https://example.com/article", final_url)
+
+    def test_fetch_html_rejects_unsafe_url_before_network(self):
+        """Localhost/private URLs should be rejected by the shared URL safety layer."""
+        with self.assertRaises(UnsafeUrlError):
+            self.collector._fetch_html("http://127.0.0.1/admin")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_page_collector.py
+++ b/tests/test_web_page_collector.py
@@ -261,7 +261,7 @@ class TestWebPageCollectorBasics(unittest.TestCase):
 
             data, headers, final_url = self.collector._fetch_html("https://example.com/article")
 
-        request.assert_called_once_with("https://example.com/article")
+        request.assert_called_once_with("https://example.com/article", timeout=30)
         self.assertIn(b"AI in Actuarial Science", data)
         self.assertEqual("text/html", headers["content-type"])
         self.assertEqual("https://example.com/article", final_url)


### PR DESCRIPTION
## Summary
- Add centralized SSRF URL validation for crawler/user-provided HTTP URLs.
- Rework crawler fetch/download requests to validate initial URLs and each redirect hop, then connect to a validated pinned IP while preserving Host/SNI.
- Route WebPageCollector fetches through the shared crawler request path instead of direct `urllib.request.urlopen`.
- Validate site URLs in ops-write add/update/import/preview flows with controlled errors for unsafe URLs.

## Security notes
- Allows only HTTP/HTTPS URLs.
- Rejects localhost, loopback, private, link-local, metadata, reserved, unspecified, multicast, and non-global IP targets.
- Handles decimal/hex/octal IPv4 literals and malformed URL/port cases.
- Revalidates redirects before following them.
- Avoids DNS-rebinding gaps by connecting to the already validated address per request.
- Preserves bracketed IPv6 literal Host headers in the pinned HTTP path.

## Verification
- `codex -c 'model="gpt-5.5"' review --uncommitted` — passed, no discrete correctness/security/maintainability issues after the IPv6 Host header follow-up fix.
- `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_url_safety.py tests/test_web_page_collector.py tests/test_fastapi_ops_write_endpoints.py tests/test_crawler_allow_patterns.py -q && git diff --check` — 55 passed, 3 warnings.
- `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest -q` — currently 462 passed, 11 failed, 4 warnings.

## Full-suite note
The 11 full-suite failures are outside this PR2 SSRF diff and appear to be pre-existing/non-SSRF areas:
- `tests/test_code_review_fixes.py::TestPathTraversalProtection::test_path_validation_in_code`
- `tests/test_fastapi_entrypoint.py::*` six 503/expected-status failures
- `tests/test_fastapi_rag_admin_endpoints.py::test_fastapi_rag_admin_kb_add_marks_dirty_and_delete_soft_applies`
- `tests/test_fastapi_react_cleanup.py::test_runtime_tree_no_longer_contains_legacy_web_assets`
- `tests/unit/test_safe_pickle.py::TestSafeUnpickler::test_malicious_os_system_blocked`
- `tests/unit/test_safe_pickle.py::TestSafeUnpickler::test_malicious_pickle_loads_bypassed`
