### PR TITLE
feat: split site and server import permissions

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,19 +1,17 @@
 # Project Status
 
-- Date: 2026-05-24
-- Branch: `feat/ssrf-url-safety`
-- Latest baseline: latest `origin/main` when this branch was created after PR118 merged.
-- Scope: PR2 security hardening for SSRF protection on user/crawler URLs. Sibling repositories were not read or modified.
-- Backend security: Added centralized `ai_actuarial.security.url_safety` validator for HTTP/HTTPS-only URL validation, malformed URL/port normalization, localhost/private/link-local/metadata/non-global IP rejection, and DNS resolution checks.
-- Backend security: Site configuration writes now validate URLs on add/update/import/preview paths and map unsafe URLs to controlled ops-write validation errors instead of server errors.
-- Crawler security: `Crawler._request` and `_download_file` now validate each request and each redirect hop, manually enforce redirect revalidation, and reject unsafe redirects.
-- Crawler security: Removed crawler fetch/download use of independent DNS resolution clients. Actual connections are opened directly to the already validated IP address while preserving the original host for Host/SNI, avoiding DNS-rebinding gaps without process-global DNS monkey-patching.
-- Crawler security: Web page collection now reuses the crawler request path instead of calling `urllib.request.urlopen` directly, so page fetches inherit URL validation, redirect revalidation, and DNS pinning.
-- Follow-up fix: Local Codex review found IPv6 literal Host headers needed bracket preservation in the pinned HTTP path; fixed and covered with a regression test.
-- Tests: Added `tests/test_url_safety.py` covering public URL allow, scheme/local/private/metadata blocking, private DNS blocking, malformed URLs, invalid ports, crawler DNS pinning handoff, redirect-to-private rejection for request/download paths, and IPv6 literal Host header formatting.
-- Tests: Extended FastAPI ops-write endpoint tests to cover unsafe site URL rejection in add/update/import flows with deterministic public DNS resolver fixtures.
-- Tests: Extended WebPageCollector tests to prove `_fetch_html` uses `Crawler._request` and rejects unsafe loopback URLs before network access.
-- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_url_safety.py tests/test_web_page_collector.py tests/test_fastapi_ops_write_endpoints.py tests/test_crawler_allow_patterns.py -q && git diff --check` (55 passed, 3 warnings).
-- Full suite status: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest -q` currently reports 462 passed, 11 failed, 4 warnings. Failures are in pre-existing non-SSRF areas (`ai_actuarial/web` cleanup expectations, FastAPI entrypoint 503 responses, one RAG admin dirty-state assertion, and safe-pickle tests); no evidence links them to this PR2 SSRF diff.
-- Local Codex review gate: Latest `codex -c 'model="gpt-5.5"' review --uncommitted` completed with no discrete correctness/security/maintainability issues after the IPv6 Host header fix.
-- Next step: commit, push, create the PR from `feat/ssrf-url-safety`, then check remote Copilot/comments after the requested wait window.
+- Date: 2026-05-25
+- Branch: `feat/permission-split-sites-import`
+- Latest baseline: `origin/main` after PR119 SSRF hardening merged.
+- Scope: PR3 security hardening permission split for monitored-site maintenance and legacy server filesystem import. Sibling repositories were not read or modified.
+- Backend authorization: Added `sites.write` and `files.import.server` to the canonical permission set. Admin retains the complete permission set; operator receives `sites.write` but not `files.import.server`.
+- Backend authorization: Monitored site add/update/delete/import/export/sample and site backup list/create/restore/delete endpoints now require `sites.write` instead of `schedule.write`.
+- Backend authorization: `/api/utils/browse-folder` now requires `files.import.server`, keeping legacy server filesystem browsing admin-only.
+- Backend authorization: `/api/collections/run` rejects legacy `type=file` + `directory_path` requests for callers without `files.import.server`, while preserving safe upload-batch imports even if a stale `directory_path` field is present.
+- Frontend authorization: Tasks page now hides the site configuration task card unless the caller has `sites.write`; scheduled-task controls remain gated by `schedule.write`.
+- Tests: Permission unit tests cover operator `sites.write`, operator exclusion from `files.import.server`, and read-only tiers lacking both write permissions.
+- Tests: FastAPI ops-write tests cover operator site maintenance, operator denial for backend settings/server-folder browse/legacy server-path imports, admin retention of server-path boundary behavior, and upload-batch imports with stale directory_path sanitized by runtime.
+- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/unit/test_permissions.py tests/test_fastapi_ops_write_endpoints.py tests/test_tasks_react_source.py -q && git diff --check` (54 passed, 3 warnings).
+- Frontend build passed: `npm run build`.
+- Local Codex review gate: first review found a stale `directory_path` + valid `upload_batch_id` regression; fixed and retested. Latest `codex -c 'model="gpt-5.5"' review --uncommitted` completed with no discrete correctness/security/maintainability issues.
+- Next step: commit, push, create PR for `feat/permission-split-sites-import`, then check remote CI/Copilot comments after the requested 10-minute window.

--- a/ai_actuarial/api/routers/ops_write.py
+++ b/ai_actuarial/api/routers/ops_write.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
 from ai_actuarial.config import settings
@@ -65,7 +65,7 @@ def _handle_ops_error(exc: OpsWriteError) -> JSONResponse:
 def api_config_sites_add(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     """
     Add a new site (data source) to the sites configuration.
@@ -83,7 +83,7 @@ def api_config_sites_add(
     Raises:
         400: If the payload is malformed or validation fails.
         401: If the request is not authenticated.
-        403: If the caller lacks the ``schedule.write`` permission.
+        403: If the caller lacks the ``sites.write`` permission.
         409: If a site with the same name already exists.
     """
     try:
@@ -96,7 +96,7 @@ def api_config_sites_add(
 def api_config_sites_update(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         return update_site(payload, bridge=_bridge(request))
@@ -108,7 +108,7 @@ def api_config_sites_update(
 def api_config_sites_delete(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         return delete_site(str(payload.get("name") or ""), bridge=_bridge(request))
@@ -120,7 +120,7 @@ def api_config_sites_delete(
 def api_config_sites_import(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         return import_sites(payload, bridge=_bridge(request))
@@ -131,7 +131,7 @@ def api_config_sites_import(
 @router.get("/config/sites/export")
 def api_config_sites_export(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         content, filename = export_sites_yaml()
@@ -147,7 +147,7 @@ def api_config_sites_export(
 @router.get("/config/sites/sample")
 def api_config_sites_sample(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         content, filename = sample_sites_yaml()
@@ -163,7 +163,7 @@ def api_config_sites_sample(
 @router.get("/config/backups")
 def api_config_backups(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         return list_backups()
@@ -175,7 +175,7 @@ def api_config_backups(
 def api_config_backups_create(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         label = str(payload.get("label", "manual") or "manual")
@@ -189,7 +189,7 @@ def api_config_backups_create(
 def api_config_backups_restore(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         return restore_backup(str(payload.get("filename") or ""), bridge=_bridge(request))
@@ -201,7 +201,7 @@ def api_config_backups_restore(
 def api_config_backups_delete(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("schedule.write")),
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
 ):
     try:
         return delete_backup(str(payload.get("filename") or ""))
@@ -478,6 +478,15 @@ def api_collections_run(
         403: If the caller lacks the ``tasks.run`` permission.
     """
     try:
+        has_server_path = str(payload.get("directory_path") or "").strip()
+        has_upload_batch = str(payload.get("upload_batch_id") or "").strip()
+        if (
+            str(payload.get("type") or "").strip() == "file"
+            and has_server_path
+            and not has_upload_batch
+            and "files.import.server" not in auth.permissions
+        ):
+            raise HTTPException(status_code=403, detail="Forbidden")
         return start_collection(payload, bridge=_bridge(request), auth_token=auth.token)
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -486,7 +495,7 @@ def api_collections_run(
 @router.get("/utils/browse-folder")
 def api_utils_browse_folder(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("tasks.run")),
+    _auth: AuthContext = Depends(require_permissions("files.import.server")),
 ):
     try:
         return browse_folder(request.query_params.get("path"))

--- a/ai_actuarial/shared_auth.py
+++ b/ai_actuarial/shared_auth.py
@@ -21,7 +21,9 @@ PERMISSIONS: frozenset[str] = frozenset(
         "markdown.write",     # Write markdown content
         "config.read",        # Read system config
         "config.write",       # Write system config
+        "sites.write",        # Manage monitored site definitions and site-level crawl settings
         "schedule.write",    # Manage scheduled tasks
+        "files.import.server", # Use legacy server-side filesystem import helpers
         "tasks.view",        # View tasks (list/details)
         "tasks.run",         # Run/create tasks
         "tasks.stop",        # Stop tasks
@@ -81,9 +83,10 @@ REGISTERED_PERMISSIONS: frozenset[str] = frozenset(
 # now organized around anonymous, registered, operator, and admin.
 PREMIUM_PERMISSIONS: frozenset[str] = REGISTERED_PERMISSIONS
 
-# Operator: can operate the ingestion/RAG task workflow and task settings, but
-# cannot edit important system settings, model/provider credentials, API tokens,
-# users, or global/system logs.
+# Operator: can operate the ingestion/RAG task workflow, task settings, and
+# monitored site definitions, but cannot edit important system settings,
+# model/provider credentials, API tokens, users, server filesystem import, or
+# global/system logs.
 OPERATOR_PERMISSIONS: frozenset[str] = frozenset(
     {
         "stats.read",
@@ -94,6 +97,7 @@ OPERATOR_PERMISSIONS: frozenset[str] = frozenset(
         "catalog.write",
         "markdown.read",
         "markdown.write",
+        "sites.write",
         "schedule.write",
         "tasks.view",
         "tasks.run",

--- a/client/src/pages/Tasks.tsx
+++ b/client/src/pages/Tasks.tsx
@@ -58,6 +58,7 @@ export default function Tasks() {
   const canRunTasks = permissions.includes("tasks.run");
   const canStopTasks = permissions.includes("tasks.stop");
   const canManageSchedules = permissions.includes("schedule.write");
+  const canManageSites = permissions.includes("sites.write");
   const canReadTaskLogs = permissions.includes("logs.task.read");
   const [activeTasks, setActiveTasks] = useState<Task[]>([]);
   const [sites, setSites] = useState<SiteConfig[]>([]);
@@ -250,7 +251,8 @@ export default function Tasks() {
     }
   }
 
-  const activeTaskType = taskTypes.find((tt) => tt.type === activeForm);
+  const visibleTaskTypes = taskTypes.filter((tt) => tt.type !== "site_config" || canManageSites);
+  const activeTaskType = visibleTaskTypes.find((tt) => tt.type === activeForm);
 
   return (
     <div className="space-y-8">
@@ -331,7 +333,7 @@ export default function Tasks() {
           ) : (
             <motion.div key="grid" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
               className="grid grid-cols-3 sm:grid-cols-5 gap-3">
-              {taskTypes.map(({ type, icon: Icon, color, route }, i) => (
+              {visibleTaskTypes.map(({ type, icon: Icon, color, route }, i) => (
                 <motion.button key={type} custom={i} variants={fadeUp} initial="hidden" animate="visible"
                   onClick={() => {
                     if (route) {

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -542,7 +542,8 @@ def test_browse_folder_and_stats_endpoints_return_real_values(tmp_path: Path, mo
     _install_bridge(app, recorder)
     db_path = Path(app.state.db_path)
     _seed_stats_data(db_path)
-    headers = {"X-Auth-Token": seed["operator_token"]}
+    headers = {"X-Auth-Token": str(seed["admin_token"])}
+    operator_headers = {"X-Auth-Token": str(seed["operator_token"])}
 
     allowed_root = tmp_path / "files"
     nested = allowed_root / "nested"
@@ -557,6 +558,9 @@ def test_browse_folder_and_stats_endpoints_return_real_values(tmp_path: Path, mo
 
     denied_response = client.get("/api/utils/browse-folder", params={"path": str(Path("/").resolve())}, headers=headers)
     assert denied_response.status_code == 403, denied_response.text
+
+    operator_browse = client.get(f"/api/utils/browse-folder?path={nested}", headers=operator_headers)
+    assert operator_browse.status_code == 403
 
     catalog_stats = client.get("/api/catalog/stats", headers=headers)
     assert catalog_stats.status_code == 200, catalog_stats.text
@@ -597,8 +601,15 @@ def test_upload_batch_then_run_file_collection_uses_batch_not_server_path(tmp_pa
     assert active_tasks["task-live"]["stop_requested"] is True
 
     server_path_response = client.post("/api/collections/run", json={"type": "file", "directory_path": "/does/not/exist"}, headers=headers)
-    assert server_path_response.status_code == 400
-    assert server_path_response.json()["error"] == "File imports must use an upload batch"
+    assert server_path_response.status_code == 403
+
+    admin_server_path_response = client.post(
+        "/api/collections/run",
+        json={"type": "file", "directory_path": "/does/not/exist"},
+        headers={"X-Auth-Token": str(seed["admin_token"])},
+    )
+    assert admin_server_path_response.status_code == 400
+    assert admin_server_path_response.json()["error"] == "File imports must use an upload batch"
 
     upload_response = client.post(
         "/api/files/import-batches",
@@ -627,6 +638,7 @@ def test_upload_batch_then_run_file_collection_uses_batch_not_server_path(tmp_pa
             "type": "file",
             "name": "Import PDFs",
             "upload_batch_id": batch_id,
+            "directory_path": "/stale/legacy/path",
         },
         headers=headers,
     )
@@ -733,6 +745,10 @@ def test_ops_write_routes_require_operator_when_auth_enabled(tmp_path: Path, mon
         json={"name": "Allowed Site", "url": "https://allowed.example"},
     )
     assert operator.status_code == 200, operator.text
+
+    operator_config_write = client.post("/api/config/backend-settings", json={"defaults": {"max_pages": 12}})
+    assert operator_config_write.status_code == 403
+
 
 
 def test_ai_provider_credentials_and_routing_write_endpoints_roundtrip(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -43,7 +43,9 @@ class TestPermissionGroups:
         assert "tasks.run" in OPERATOR_PERMISSIONS
         assert "tasks.stop" in OPERATOR_PERMISSIONS
         assert "schedule.write" in OPERATOR_PERMISSIONS
+        assert "sites.write" in OPERATOR_PERMISSIONS
         assert "config.write" not in OPERATOR_PERMISSIONS
+        assert "files.import.server" not in OPERATOR_PERMISSIONS
         assert "tokens.manage" not in OPERATOR_PERMISSIONS
         assert "users.manage" not in OPERATOR_PERMISSIONS
 
@@ -62,7 +64,7 @@ class TestPermissionGroups:
     def test_guest_cannot_write(self):
         """Guest should not have any write permissions."""
         write_perms = ["files.delete", "catalog.write", "markdown.write",
-                       "config.write", "schedule.write", "tasks.run",
+                       "config.write", "sites.write", "schedule.write", "files.import.server", "tasks.run",
                        "tasks.stop", "logs.system.read", "export.read",
                        "tokens.manage", "users.manage"]
         for perm in write_perms:
@@ -71,7 +73,7 @@ class TestPermissionGroups:
     def test_registered_cannot_write(self):
         """Registered should not have write permissions."""
         write_perms = ["files.delete", "catalog.write", "markdown.write",
-                       "config.write", "schedule.write", "tasks.run",
+                       "config.write", "sites.write", "schedule.write", "files.import.server", "tasks.run",
                        "tasks.stop", "logs.system.read", "export.read",
                        "tokens.manage", "users.manage"]
         for perm in write_perms:
@@ -80,7 +82,7 @@ class TestPermissionGroups:
     def test_premium_cannot_write(self):
         """Premium should not have write permissions."""
         write_perms = ["files.delete", "catalog.write", "markdown.write",
-                       "config.write", "schedule.write", "tasks.run",
+                       "config.write", "sites.write", "schedule.write", "files.import.server", "tasks.run",
                        "tasks.stop", "logs.system.read", "export.read",
                        "tokens.manage", "users.manage"]
         for perm in write_perms:


### PR DESCRIPTION
## Summary
- Adds `sites.write` and `files.import.server` to the canonical permission model.
- Moves monitored-site and site-backup write endpoints from `schedule.write` to `sites.write` so operators can maintain monitored sites without global config power.
- Gates legacy server filesystem browse/import paths behind admin-only `files.import.server`, while preserving safe browser upload-batch imports.
- Hides the site configuration task card unless the user has `sites.write`.

## Test Plan
- `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/unit/test_permissions.py tests/test_fastapi_ops_write_endpoints.py tests/test_tasks_react_source.py -q && git diff --check`
- `npm run build`
- `codex -c 'model="gpt-5.5"' review --uncommitted`

## Notes
- Local Codex review initially found that valid upload-batch imports with a stale `directory_path` could be rejected; fixed by requiring `files.import.server` only when a server path is present without `upload_batch_id`.
