### PR TITLE
fix: allow public dashboard stats

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,17 +1,15 @@
 # Project Status
 
 - Date: 2026-05-25
-- Branch: `docs/security-rollout-completion`
-- Latest baseline: `origin/main` at merged PR #122 (`fix: rate limit auth submissions`).
-- Scope: documentation completion audit after security/RBAC rollout PRs #118-#122 were merged. Sibling repositories were not read or modified.
-- Repo/PR audit: `gh pr list --state open` returned no open PRs; recent merged rollout PRs #118, #119, #120, #121, #122 are present on `origin/main`.
-- README refresh: root English and Chinese READMEs now describe the current FastAPI + React stack, merged security rollout status, browser-upload file import contract, Chat/RAG source bounds, auth rate limiting, and current verification commands.
-- Security docs refresh: `SECURITY.md` now reflects maintained FastAPI + React posture, auth/RBAC, encrypted credentials, SSRF/file import/Chat-RAG boundaries, production checklist, and security-focused test commands.
-- Rate-limit docs refresh: `docs/rate-limit-config.md` now documents role/default endpoint limits plus separate login/register IP-scoped auth limits, `Retry-After`, CORS/preflight behavior, and `TRUST_PROXY` semantics.
-- Docs index refresh: `docs/README.md` now points to current references and explains archive areas.
-- Archive moves: stale Flask-era security review docs, stale quick-start/modular/chatbot roadmap guides, completed FastAPI migration plans, and the completed February hardening plan were moved under `docs/archive/` with archive notes.
-- Link cleanup: updated moved-document references in impacted implementation/API token docs.
-- Verification passed: repo-level markdown link checker over 143 Markdown files found 0 missing non-code internal links.
+- Branch: `fix/public-stats-read`
+- Latest baseline: `origin/main` at `16f44c0` (`docs: refresh security rollout documentation (#123)`).
+- Scope: Open anonymous/public `stats.read` so the dashboard home route can render without redirecting to login while preserving read-only public browsing of database and file detail.
+- Permission change: `PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED` / guest permissions now include `stats.read` alongside `files.read`, `catalog.read`, `markdown.read`, `chat.view`, and `chat.query`.
+- Metrics safety: added `require_authenticated_permissions(...)` for endpoints that should ignore public permissions; `/api/metrics` now requires authenticated `stats.read`, so raw uptime/request/rate-limit metrics remain login-gated even though dashboard `/api/stats` is public.
+- Tests updated: auth endpoint coverage asserts anonymous `/api/auth/me` includes `stats.read`, `/api/stats` returns 200, `/api/metrics` remains 401, `/api/files` remains 200, and conversation creation remains 401. Permission unit test now expects guest `stats.read`.
+- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_fastapi_auth_endpoints.py tests/unit/test_permissions.py -q` (39 passed).
+- Verification passed: `npm run build`.
 - Verification passed: `git diff --check`.
-- Local Codex review gate: first pass found two doc issues (server-path import wording and archived roadmap references); both were fixed. Second pass found no discrete actionable issues.
-- Next step: commit/push/create PR for documentation completion audit.
+- Browser/API smoke passed with local FastAPI + Vite under auth-required mode: anonymous `/` renders dashboard instead of login, `/database` renders, clicking a file opens file detail, browser console has no JS errors, `/api/auth/me` includes `stats.read`, `/api/stats` returns 200, and `/api/metrics` returns 401.
+- Local Codex review gate: first pass flagged global `stats.read` could expose `/api/metrics`; fixed by adding authenticated-only dependency and moving `/api/metrics` to it. Second pass found no discrete actionable regressions.
+- Next step: commit, push, create PR, then follow up on GitHub checks/review comments after the standard wait window.

--- a/ai_actuarial/api/deps.py
+++ b/ai_actuarial/api/deps.py
@@ -9,7 +9,7 @@ from itsdangerous import BadSignature, URLSafeSerializer
 
 from ai_actuarial.shared_auth import (
     PERMISSIONS,
-    PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED,
+    PUBLIC_BROWSE_PERMISSIONS,
     hash_token,
     permissions_for_group,
 )
@@ -134,13 +134,21 @@ def get_auth_context(request: Request) -> AuthContext:
 
 
 def public_permissions_for_request(request: Request) -> frozenset[str]:
-    return PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED
+    return PUBLIC_BROWSE_PERMISSIONS
 
 
 def _validate_required_permissions(required: tuple[str, ...]) -> None:
     for permission in required:
         if permission not in PERMISSIONS:
             raise ValueError(f"Unknown permission: {permission}")
+
+
+def _assert_context_has_permissions(context: AuthContext, required: tuple[str, ...]) -> None:
+    if not context.token:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    if any(permission not in context.permissions for permission in required):
+        raise HTTPException(status_code=403, detail="Forbidden")
 
 
 def require_permissions(*required: str):
@@ -156,12 +164,7 @@ def require_permissions(*required: str):
             return AuthContext(token=None, permissions=frozenset())
 
         context = _load_auth_context(request)
-        if not context.token:
-            raise HTTPException(status_code=401, detail="Unauthorized")
-
-        if any(permission not in context.permissions for permission in required):
-            raise HTTPException(status_code=403, detail="Forbidden")
-
+        _assert_context_has_permissions(context, required)
         return context
 
     return dependency
@@ -171,13 +174,11 @@ def require_authenticated_permissions(*required: str):
     _validate_required_permissions(required)
 
     def dependency(request: Request) -> AuthContext:
-        context = _load_auth_context(request)
-        if not context.token:
+        if not _has_presented_auth_material(request):
             raise HTTPException(status_code=401, detail="Unauthorized")
 
-        if any(permission not in context.permissions for permission in required):
-            raise HTTPException(status_code=403, detail="Forbidden")
-
+        context = _load_auth_context(request)
+        _assert_context_has_permissions(context, required)
         return context
 
     return dependency

--- a/ai_actuarial/api/deps.py
+++ b/ai_actuarial/api/deps.py
@@ -137,10 +137,14 @@ def public_permissions_for_request(request: Request) -> frozenset[str]:
     return PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED
 
 
-def require_permissions(*required: str):
+def _validate_required_permissions(required: tuple[str, ...]) -> None:
     for permission in required:
         if permission not in PERMISSIONS:
             raise ValueError(f"Unknown permission: {permission}")
+
+
+def require_permissions(*required: str):
+    _validate_required_permissions(required)
 
     def dependency(request: Request) -> AuthContext:
         public_permissions = public_permissions_for_request(request)
@@ -151,6 +155,22 @@ def require_permissions(*required: str):
                     return context
             return AuthContext(token=None, permissions=frozenset())
 
+        context = _load_auth_context(request)
+        if not context.token:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+        if any(permission not in context.permissions for permission in required):
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+        return context
+
+    return dependency
+
+
+def require_authenticated_permissions(*required: str):
+    _validate_required_permissions(required)
+
+    def dependency(request: Request) -> AuthContext:
         context = _load_auth_context(request)
         if not context.token:
             raise HTTPException(status_code=401, detail="Unauthorized")

--- a/ai_actuarial/api/routers/metrics.py
+++ b/ai_actuarial/api/routers/metrics.py
@@ -34,9 +34,9 @@ def get_uptime_seconds() -> float:
 @router.get("/metrics")
 async def get_metrics(
     request: Request,
-    _auth: AuthContext = Depends(require_authenticated_permissions("stats.read")),
+    _auth: AuthContext = Depends(require_authenticated_permissions("logs.system.read")),
 ) -> dict:
-    """Return system metrics in JSON format (authenticated stats permission required)."""
+    """Return system metrics in JSON format (authenticated system-log permission required)."""
     rate_limit_tiers = {}
     for role, limit in ROLE_RATE_LIMITS.items():
         rate_limit_tiers[role] = {"limit_per_minute": limit}

--- a/ai_actuarial/api/routers/metrics.py
+++ b/ai_actuarial/api/routers/metrics.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Request
 
-from ai_actuarial.api.deps import AuthContext, require_permissions
+from ai_actuarial.api.deps import AuthContext, require_authenticated_permissions
 from ai_actuarial.api.middleware.rate_limit import ROLE_RATE_LIMITS
 
 router = APIRouter()
@@ -34,9 +34,9 @@ def get_uptime_seconds() -> float:
 @router.get("/metrics")
 async def get_metrics(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("stats.read")),
+    _auth: AuthContext = Depends(require_authenticated_permissions("stats.read")),
 ) -> dict:
-    """Return system metrics in JSON format (auth required)."""
+    """Return system metrics in JSON format (authenticated stats permission required)."""
     rate_limit_tiers = {}
     for role, limit in ROLE_RATE_LIMITS.items():
         rate_limit_tiers[role] = {"limit_per_minute": limit}

--- a/ai_actuarial/shared_auth.py
+++ b/ai_actuarial/shared_auth.py
@@ -42,7 +42,7 @@ PERMISSIONS: frozenset[str] = frozenset(
 # Anonymous visitors may browse the database/file detail surfaces and use the
 # limited AI chat quota only; task, settings, logs, download, export, and any
 # mutating API remain authenticated role capabilities.
-PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED: frozenset[str] = frozenset(
+PUBLIC_BROWSE_PERMISSIONS: frozenset[str] = frozenset(
     {
         "stats.read",
         "files.read",
@@ -53,13 +53,16 @@ PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED: frozenset[str] = frozenset(
     }
 )
 
+# Backwards-compatible alias for older imports/config references.
+PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED: frozenset[str] = PUBLIC_BROWSE_PERMISSIONS
+
 # ============================================================
 # Group Permissions (new design)
 # ============================================================
 
 # Guest/anonymous: public browse + dashboard stats + 5 AI-chat messages. No task
 # visibility, downloads, exports, logs, settings, or mutations.
-GUEST_PERMISSIONS: frozenset[str] = frozenset(PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED)
+GUEST_PERMISSIONS: frozenset[str] = frozenset(PUBLIC_BROWSE_PERMISSIONS)
 
 # Registered: a signed-in reader. They may view read-only product surfaces,
 # including task status/history, but cannot run/stop/schedule tasks or change

--- a/ai_actuarial/shared_auth.py
+++ b/ai_actuarial/shared_auth.py
@@ -44,6 +44,7 @@ PERMISSIONS: frozenset[str] = frozenset(
 # mutating API remain authenticated role capabilities.
 PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED: frozenset[str] = frozenset(
     {
+        "stats.read",
         "files.read",
         "catalog.read",
         "markdown.read",
@@ -56,8 +57,8 @@ PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED: frozenset[str] = frozenset(
 # Group Permissions (new design)
 # ============================================================
 
-# Guest/anonymous: public browse + 5 AI-chat messages. No dashboard stats,
-# task visibility, downloads, exports, logs, settings, or mutations.
+# Guest/anonymous: public browse + dashboard stats + 5 AI-chat messages. No task
+# visibility, downloads, exports, logs, settings, or mutations.
 GUEST_PERMISSIONS: frozenset[str] = frozenset(PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED)
 
 # Registered: a signed-in reader. They may view read-only product surfaces,

--- a/tests/test_fastapi_auth_endpoints.py
+++ b/tests/test_fastapi_auth_endpoints.py
@@ -282,10 +282,17 @@ def test_auth_me_allows_anonymous_database_and_chat_browse_when_auth_required(tm
     body = auth_me.json()["data"]
     assert body["require_auth"] is True
     assert body["authenticated"] is False
+    assert "stats.read" in body["permissions"]
     assert "files.read" in body["permissions"]
     assert "chat.view" in body["permissions"]
     assert "chat.query" in body["permissions"]
     assert "chat.conversations" not in body["permissions"]
+
+    stats = client.get("/api/stats")
+    assert stats.status_code == 200, stats.text
+
+    metrics = client.get("/api/metrics")
+    assert metrics.status_code == 401, metrics.text
 
     files = client.get("/api/files")
     assert files.status_code == 200, files.text

--- a/tests/test_fastapi_auth_endpoints.py
+++ b/tests/test_fastapi_auth_endpoints.py
@@ -20,6 +20,7 @@ PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
 class SeedData(TypedDict):
     user_id: int
     admin_token: str
+    guest_token: str
 
 
 def _write_config_files(base_dir: Path) -> tuple[Path, Path, Path, Path]:
@@ -89,6 +90,13 @@ def _seed_storage(db_path: Path, files_dir: Path) -> SeedData:
             token_hash=hashlib.sha256(admin_token.encode("utf-8")).hexdigest(),
             is_active=True,
         )
+        guest_token = "guest-token-123"
+        storage.upsert_auth_token_by_hash(
+            subject="guest@example.com",
+            group_name="guest",
+            token_hash=hashlib.sha256(guest_token.encode("utf-8")).hexdigest(),
+            is_active=True,
+        )
         user_id = storage.create_user(
             "member@example.com",
             hash_password("password123"),
@@ -98,7 +106,7 @@ def _seed_storage(db_path: Path, files_dir: Path) -> SeedData:
     finally:
         storage.close()
 
-    return {"user_id": user_id, "admin_token": admin_token}
+    return {"user_id": user_id, "admin_token": admin_token, "guest_token": guest_token}
 
 
 def _build_test_client(tmp_path: Path, monkeypatch, *, require_auth: bool = True) -> tuple[TestClient, object, SeedData]:
@@ -275,7 +283,7 @@ def test_csrf_protection_exempts_api_token_mutations(tmp_path: Path, monkeypatch
 
 
 def test_auth_me_allows_anonymous_database_and_chat_browse_when_auth_required(tmp_path: Path, monkeypatch) -> None:
-    client, _app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
 
     auth_me = client.get("/api/auth/me")
     assert auth_me.status_code == 200, auth_me.text
@@ -293,6 +301,18 @@ def test_auth_me_allows_anonymous_database_and_chat_browse_when_auth_required(tm
 
     metrics = client.get("/api/metrics")
     assert metrics.status_code == 401, metrics.text
+
+    guest_metrics = client.get(
+        "/api/metrics",
+        headers={"X-Auth-Token": seed["guest_token"]},
+    )
+    assert guest_metrics.status_code == 403, guest_metrics.text
+
+    authorized_metrics = client.get(
+        "/api/metrics",
+        headers={"X-Auth-Token": seed["admin_token"]},
+    )
+    assert authorized_metrics.status_code == 200, authorized_metrics.text
 
     files = client.get("/api/files")
     assert files.status_code == 200, files.text

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -24,7 +24,7 @@ class TestPermissionGroups:
         assert "catalog.read" in GUEST_PERMISSIONS
         assert "markdown.read" in GUEST_PERMISSIONS
         assert "chat.query" in GUEST_PERMISSIONS
-        assert "stats.read" not in GUEST_PERMISSIONS
+        assert "stats.read" in GUEST_PERMISSIONS
         assert "tasks.view" not in GUEST_PERMISSIONS
         assert "files.download" not in GUEST_PERMISSIONS
         assert "tasks.run" not in GUEST_PERMISSIONS


### PR DESCRIPTION
## Summary
- Opens `stats.read` for anonymous/public-browse users so the dashboard home route can render without redirecting to login.
- Adds an authenticated-only permission dependency and moves `/api/metrics` onto it, keeping raw operational metrics login-gated even though dashboard `/api/stats` is public.
- Updates auth/permission tests for anonymous `/api/stats` access and `/api/metrics` protection.

## Verification
- `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_fastapi_auth_endpoints.py tests/unit/test_permissions.py -q`
- `npm run build`
- `git diff --check`
- Local FastAPI + Vite browser smoke: anonymous `/` renders dashboard, `/database` renders, file detail opens, console has no JS errors; curl confirms `/api/stats` = 200 and `/api/metrics` = 401 for anonymous.

## Review
- Local Codex review gate passed after addressing the first-pass concern about `/api/metrics` exposure.
