### PR TITLE
fix: gate frontend RBAC actions

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,15 +1,18 @@
 # Project Status
 
-- Date: 2026-05-25
-- Branch: `fix/public-stats-read`
-- Latest baseline: `origin/main` at `16f44c0` (`docs: refresh security rollout documentation (#123)`).
-- Scope: Open anonymous/public `stats.read` so the dashboard home route can render without redirecting to login while preserving read-only public browsing of database and file detail.
-- Permission change: `PUBLIC_PERMISSIONS_WHEN_AUTH_DISABLED` / guest permissions now include `stats.read` alongside `files.read`, `catalog.read`, `markdown.read`, `chat.view`, and `chat.query`.
-- Metrics safety: added `require_authenticated_permissions(...)` for endpoints that should ignore public permissions; `/api/metrics` now requires authenticated `stats.read`, so raw uptime/request/rate-limit metrics remain login-gated even though dashboard `/api/stats` is public.
-- Tests updated: auth endpoint coverage asserts anonymous `/api/auth/me` includes `stats.read`, `/api/stats` returns 200, `/api/metrics` remains 401, `/api/files` remains 200, and conversation creation remains 401. Permission unit test now expects guest `stats.read`.
-- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_fastapi_auth_endpoints.py tests/unit/test_permissions.py -q` (39 passed).
+- Date: 2026-05-26
+- Branch: `fix/frontend-rbac-action-gates`
+- Latest baseline: `origin/main` before this branch was created.
+- Scope: PR A frontend RBAC action gates for Knowledge, KB detail, Database, Chat, and File Detail.
+- Permission changes are UI-only in this PR: public/guest users keep read-only browsing/chat surfaces but no longer see or can use KB admin, persistent conversation management, export/download/delete/include-deleted, or task/chunk-generation controls without the matching permission.
+- Knowledge/KB controls now distinguish `catalog.read` browsing, `tasks.run` indexing/pending task actions, and `config.write` management/configuration actions.
+- Database controls now gate include-deleted and selection/delete behind `files.delete`, downloads behind `files.download`, and CSV export behind `export.read`; auth-loading is handled before URL rewrite/request generation so direct admin links preserve `include_deleted` until permissions are known.
+- Chat now gates history/new/delete conversation UI and list API calls behind `chat.conversations`, while still preserving query-returned `conversation_id` for guest multi-turn context when only `chat.query` is available.
+- FileDetail no longer checks nonexistent `rag.write`; task/chunk-generation controls use the actual backend `tasks.run` boundary while edit/download/delete controls continue to follow their specific permissions.
+- Tests updated: added `tests/test_frontend_rbac_action_gates.py` and updated FileDetail source test to reject `rag.write`.
+- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_frontend_rbac_action_gates.py tests/test_auth_react_source.py tests/test_chat_react_source.py tests/test_file_detail_react_source.py -q` (19 passed).
 - Verification passed: `npm run build`.
 - Verification passed: `git diff --check`.
-- Browser/API smoke passed with local FastAPI + Vite under auth-required mode: anonymous `/` renders dashboard instead of login, `/database` renders, clicking a file opens file detail, browser console has no JS errors, `/api/auth/me` includes `stats.read`, `/api/stats` returns 200, and `/api/metrics` returns 401.
-- Local Codex review gate: first pass flagged global `stats.read` could expose `/api/metrics`; fixed by adding authenticated-only dependency and moving `/api/metrics` to it. Second pass found no discrete actionable regressions.
+- Browser smoke passed with local FastAPI + Vite under auth-required guest mode: `/database` has no export/download/delete/include-deleted controls, `/knowledge` and KB detail show read-only browsing without create/delete/index/bind controls, `/chat` hides conversation history/new/delete while leaving document/chat UI, file detail shows write/download/delete/chunk controls disabled, and browser console has no JavaScript errors.
+- Local Codex review gate: multiple rounds found auth-loading and permission-boundary issues; all accepted findings were fixed. Final Codex review found no discrete regressions.
 - Next step: commit, push, create PR, then follow up on GitHub checks/review comments after the standard wait window.

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -3,7 +3,7 @@
 - Date: 2026-05-26
 - Branch: `fix/frontend-rbac-action-gates`
 - Latest baseline: `origin/main` before this branch was created.
-- Scope: PR A frontend RBAC action gates for Knowledge, KB detail, Database, Chat, and File Detail.
+- Scope: Frontend RBAC action gates for Knowledge, KB detail, Database, Chat, and File Detail.
 - Permission changes are UI-only in this PR: public/guest users keep read-only browsing/chat surfaces but no longer see or can use KB admin, persistent conversation management, export/download/delete/include-deleted, or task/chunk-generation controls without the matching permission.
 - Knowledge/KB controls now distinguish `catalog.read` browsing, `tasks.run` indexing/pending task actions, and `config.write` management/configuration actions.
 - Database controls now gate include-deleted and selection/delete behind `files.delete`, downloads behind `files.download`, and CSV export behind `export.read`; auth-loading is handled before URL rewrite/request generation so direct admin links preserve `include_deleted` until permissions are known.

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -386,7 +386,8 @@ export default function Chat() {
   const { t } = useTranslation();
   const [location, navigate] = useLocation();
   const routeState = useHistoryState<ChatRouteState | null>();
-  const { user, isLoggedIn } = useAuth();
+  const { user, isLoggedIn, permissions, isLoading: authLoading } = useAuth();
+  const canUseConversations = permissions.includes("chat.conversations");
   const isGuest = !isLoggedIn || user?.role === "guest";
   const GUEST_CHAT_QUOTA = 5;
   const [conversations, setConversations] = useState<Conversation[]>([]);
@@ -423,11 +424,23 @@ export default function Chat() {
   }, [messages, sending, scrollToBottom]);
 
   useEffect(() => {
-    loadConversations();
+    if (authLoading) return;
+    if (canUseConversations) {
+      setSidebarTab("conversations");
+      loadConversations();
+    } else {
+      setLoadingConvs(false);
+      setConversations([]);
+      setActiveConvId(null);
+      if (sidebarTab === "conversations") {
+        setSidebarTab("documents");
+      }
+    }
     loadKnowledgeBases();
-  }, []);
+  }, [authLoading, canUseConversations]);
 
   async function loadConversations() {
+    if (!canUseConversations) return;
     setLoadingConvs(true);
     try {
       const res = await apiGet<{ success?: boolean; data?: { conversations?: Conversation[] }; conversations?: Conversation[] }>("/api/chat/conversations");
@@ -514,6 +527,7 @@ export default function Chat() {
   }
 
   async function loadConversation(id: string) {
+    if (!canUseConversations) return;
     setActiveConvId(id);
     setErrorMsg(null);
     try {
@@ -527,6 +541,7 @@ export default function Chat() {
   }
 
   async function createConversation() {
+    if (!canUseConversations) return;
     setErrorMsg(null);
     try {
       const res = await apiPost<{ success?: boolean; data?: { conversation_id?: string; conversation?: Conversation }; conversation?: Conversation }>("/api/chat/conversations", {
@@ -551,6 +566,7 @@ export default function Chat() {
   }
 
   async function deleteConversation(id: string) {
+    if (!canUseConversations) return;
     try {
       await apiDelete(`/api/chat/conversations/${id}`);
       setConversations((prev) => prev.filter((c) => c.id !== id));
@@ -563,7 +579,7 @@ export default function Chat() {
 
   async function askAboutDocument(doc: AvailableDocument) {
     const questionText = `${t("chat.explain_document")}: "${doc.filename || doc.title}"`;
-    setSidebarTab("conversations");
+    if (canUseConversations) setSidebarTab("conversations");
     await sendMessage({ text: questionText, document: doc });
   }
 
@@ -718,7 +734,7 @@ export default function Chat() {
 
       if (res.data?.conversation_id && !activeConvId) {
         setActiveConvId(res.data.conversation_id);
-        loadConversations();
+        if (canUseConversations) loadConversations();
       }
 
       const assistantMsg: Message = {
@@ -778,14 +794,16 @@ export default function Chat() {
           >
             <div className="p-3 border-b border-border space-y-2">
               <div className="flex items-center gap-2">
-                <button
-                  onClick={createConversation}
-                  className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
-                  data-testid="button-new-conversation"
-                >
-                  <Plus className="w-4 h-4" />
-                  {t("chat.new_conversation")}
-                </button>
+                {canUseConversations && (
+                  <button
+                    onClick={createConversation}
+                    className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+                    data-testid="button-new-conversation"
+                  >
+                    <Plus className="w-4 h-4" />
+                    {t("chat.new_conversation")}
+                  </button>
+                )}
                 <button
                   onClick={() => setSidebarOpen(false)}
                   className="p-2 rounded-lg hover:bg-muted text-muted-foreground"
@@ -796,19 +814,21 @@ export default function Chat() {
               </div>
 
               <div className="flex rounded-lg bg-muted p-0.5">
-                <button
-                  onClick={() => setSidebarTab("conversations")}
-                  className={cn(
-                    "flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium transition-colors",
-                    sidebarTab === "conversations"
-                      ? "bg-card text-foreground shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  )}
-                  data-testid="tab-conversations"
-                >
-                  <MessageSquare className="w-3.5 h-3.5" />
-                  {t("chat.tab_history")}
-                </button>
+                {canUseConversations && (
+                  <button
+                    onClick={() => setSidebarTab("conversations")}
+                    className={cn(
+                      "flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium transition-colors",
+                      sidebarTab === "conversations"
+                        ? "bg-card text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    )}
+                    data-testid="tab-conversations"
+                  >
+                    <MessageSquare className="w-3.5 h-3.5" />
+                    {t("chat.tab_history")}
+                  </button>
+                )}
                 <button
                   onClick={() => setSidebarTab("documents")}
                   className={cn(
@@ -825,7 +845,7 @@ export default function Chat() {
               </div>
             </div>
 
-            {sidebarTab === "conversations" ? (
+            {sidebarTab === "conversations" && canUseConversations ? (
               <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
                 {loadingConvs ? (
                   <div className="flex justify-center py-8">
@@ -859,16 +879,18 @@ export default function Chat() {
                           </span>
                         )}
                       </div>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          deleteConversation(conv.id);
-                        }}
-                        className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-destructive/10 hover:text-destructive transition-all"
-                        data-testid={`button-delete-conversation-${conv.id}`}
-                      >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </button>
+                      {canUseConversations && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            deleteConversation(conv.id);
+                          }}
+                          className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-destructive/10 hover:text-destructive transition-all"
+                          data-testid={`button-delete-conversation-${conv.id}`}
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      )}
                     </div>
                   ))
                 )}

--- a/client/src/pages/Database.tsx
+++ b/client/src/pages/Database.tsx
@@ -25,6 +25,7 @@ import ConfirmDeleteModal from "@/components/ConfirmDeleteModal";
 import { buildFileDetailPath, buildFilePreviewPath } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "@/components/Layout";
+import { useAuth } from "@/context/AuthContext";
 import { apiGet, apiPost } from "@/lib/api";
 
 interface FileItem {
@@ -288,6 +289,10 @@ function normalizeCategories(items: Array<string | CategoryOption> | undefined):
 
 export default function DatabasePage() {
   const { t } = useTranslation();
+  const { permissions, isLoading: authLoading } = useAuth();
+  const canDeleteFiles = permissions.includes("files.delete");
+  const canDownloadFiles = permissions.includes("files.download");
+  const canExportFiles = permissions.includes("export.read");
   const [, navigate] = useLocation();
   const searchStr = useSearch();
 
@@ -365,7 +370,7 @@ export default function DatabasePage() {
     query: debouncedQuery,
     source,
     category,
-    includeDeleted,
+    includeDeleted: !authLoading && canDeleteFiles && includeDeleted,
     orderBy,
     orderDir,
   };
@@ -374,8 +379,9 @@ export default function DatabasePage() {
 
   // Persist current state to URL so back-navigation restores filters/page
   useEffect(() => {
+    if (authLoading) return;
     window.history.replaceState(null, "", locationKey);
-  }, [locationKey]);
+  }, [authLoading, locationKey]);
 
   useEffect(() => {
     const cachedMeta = getCachedMeta();
@@ -416,7 +422,7 @@ export default function DatabasePage() {
         query: debouncedQuery,
         source,
         category,
-        includeDeleted,
+        includeDeleted: !authLoading && canDeleteFiles && includeDeleted,
         orderBy,
         orderDir,
       };
@@ -460,15 +466,16 @@ export default function DatabasePage() {
         }
       }
     },
-    [offset, debouncedQuery, source, category, includeDeleted, orderBy, orderDir]
+    [offset, debouncedQuery, source, category, authLoading, canDeleteFiles, includeDeleted, orderBy, orderDir]
   );
 
   useEffect(() => {
+    if (authLoading) return;
     void fetchFiles();
-  }, [fetchFiles, requestKey]);
+  }, [authLoading, fetchFiles, requestKey]);
 
   useEffect(() => {
-    if (loading || total <= 0) return;
+    if (authLoading || loading || total <= 0) return;
     const prevOffset = offset - PAGE_SIZE;
     const nextOffset = offset + PAGE_SIZE;
     if (prevOffset >= 0) {
@@ -477,7 +484,7 @@ export default function DatabasePage() {
     if (nextOffset < total) {
       void fetchFiles({ targetOffset: nextOffset });
     }
-  }, [fetchFiles, loading, offset, total]);
+  }, [authLoading, fetchFiles, loading, offset, total]);
 
   useEffect(() => {
     return () => {
@@ -626,8 +633,8 @@ export default function DatabasePage() {
     }
   }
 
-  const activeFilterCount = [source, category, includeDeleted ? "y" : ""].filter(Boolean).length;
-  const selectableVisibleUrls = files.filter((file) => !file.deleted_at).map((file) => file.url);
+  const activeFilterCount = [source, category, canDeleteFiles && includeDeleted ? "y" : ""].filter(Boolean).length;
+  const selectableVisibleUrls = canDeleteFiles ? files.filter((file) => !file.deleted_at).map((file) => file.url) : [];
   const allVisibleSelected = selectableVisibleUrls.length > 0 && selectableVisibleUrls.every((url) => selectedUrls.includes(url));
 
   return (
@@ -641,18 +648,20 @@ export default function DatabasePage() {
           <p className="text-muted-foreground mt-1 text-sm">{t("db.subtitle")}</p>
         </div>
         <div className="flex items-center gap-2 flex-wrap justify-end">
-          <button
-            onClick={exportCsv}
-            className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-xs font-medium text-foreground hover:bg-muted transition-colors"
-            data-testid="button-export-csv"
-          >
-            <FileSpreadsheet className="w-3.5 h-3.5" />
-            {t("db.export_csv")}
-          </button>
+          {canExportFiles && (
+            <button
+              onClick={exportCsv}
+              className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-xs font-medium text-foreground hover:bg-muted transition-colors"
+              data-testid="button-export-csv"
+            >
+              <FileSpreadsheet className="w-3.5 h-3.5" />
+              {t("db.export_csv")}
+            </button>
+          )}
         </div>
       </motion.div>
 
-      {(files.length > 0 || selectedUrls.length > 0) && (
+      {canDeleteFiles && (files.length > 0 || selectedUrls.length > 0) && (
         <div className="flex flex-col gap-3 rounded-xl border border-border bg-card px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
           <button
             type="button"
@@ -781,16 +790,18 @@ export default function DatabasePage() {
             </select>
           </div>
           <div className="flex items-end gap-3">
-            <label className="flex items-center gap-2 cursor-pointer px-3 py-2 rounded-lg border border-border bg-card text-sm" data-testid="checkbox-include-deleted">
-              <input
-                type="checkbox"
-                checked={includeDeleted}
-                onChange={(e) => setIncludeDeleted(e.target.checked)}
-                className="rounded border-border"
-              />
-              <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
-              {t("db.include_deleted")}
-            </label>
+            {canDeleteFiles && (
+              <label className="flex items-center gap-2 cursor-pointer px-3 py-2 rounded-lg border border-border bg-card text-sm" data-testid="checkbox-include-deleted">
+                <input
+                  type="checkbox"
+                  checked={includeDeleted}
+                  onChange={(e) => setIncludeDeleted(e.target.checked)}
+                  className="rounded border-border"
+                />
+                <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
+                {t("db.include_deleted")}
+              </label>
+            )}
             {activeFilterCount > 0 && (
               <button
                 onClick={() => { setSource(""); setCategory(""); setIncludeDeleted(false); }}
@@ -827,15 +838,17 @@ export default function DatabasePage() {
         </motion.div>
       ) : (
         <div className="rounded-xl border border-border bg-card overflow-hidden">
-          <div className="hidden lg:grid grid-cols-[36px_1fr_110px_120px_50px_70px_90px_176px] gap-3 px-4 py-2.5 bg-muted/50 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            <button
-              type="button"
-              onClick={toggleSelectAllVisible}
-              className="flex items-center justify-center hover:text-foreground transition-colors"
-              data-testid="checkbox-select-all-header"
-            >
-              {allVisibleSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4 opacity-70" />}
-            </button>
+          <div className={cn("hidden lg:grid gap-3 px-4 py-2.5 bg-muted/50 text-xs font-medium text-muted-foreground uppercase tracking-wider", canDeleteFiles ? "grid-cols-[36px_1fr_110px_120px_50px_70px_90px_176px]" : "grid-cols-[1fr_110px_120px_50px_70px_90px_136px]")}>
+            {canDeleteFiles && (
+              <button
+                type="button"
+                onClick={toggleSelectAllVisible}
+                className="flex items-center justify-center hover:text-foreground transition-colors"
+                data-testid="checkbox-select-all-header"
+              >
+                {allVisibleSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4 opacity-70" />}
+              </button>
+            )}
             <button onClick={() => handleSort("title")} className="flex items-center gap-1 hover:text-foreground transition-colors text-left" data-testid="sort-title">
               {t("table.title")} <SortIcon field="title" />
             </button>
@@ -866,27 +879,30 @@ export default function DatabasePage() {
                 initial="hidden"
                 animate="visible"
                 className={cn(
-                  "grid lg:grid-cols-[36px_1fr_110px_120px_50px_70px_90px_176px] gap-1 lg:gap-3 px-4 py-3 border-t border-border hover:bg-muted/30 transition-colors cursor-pointer",
+                  "grid gap-1 lg:gap-3 px-4 py-3 border-t border-border hover:bg-muted/30 transition-colors cursor-pointer",
+                  canDeleteFiles ? "lg:grid-cols-[36px_1fr_110px_120px_50px_70px_90px_176px]" : "lg:grid-cols-[1fr_110px_120px_50px_70px_90px_136px]",
                   isDeleted && "opacity-50"
                 )}
                 onClick={() => navigateToFile(file)}
                 data-testid={`file-row-${i}`}
               >
-                <div className="hidden lg:flex items-center justify-center">
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (isDeleted) return;
-                      toggleSelected(file.url);
-                    }}
-                    disabled={isDeleted}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
-                    data-testid={`checkbox-select-${i}`}
-                  >
-                    {isSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
-                  </button>
-                </div>
+                {canDeleteFiles && (
+                  <div className="hidden lg:flex items-center justify-center">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (isDeleted) return;
+                        toggleSelected(file.url);
+                      }}
+                      disabled={isDeleted}
+                      className="text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+                      data-testid={`checkbox-select-${i}`}
+                    >
+                      {isSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
+                    </button>
+                  </div>
+                )}
 
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 min-w-0">
@@ -968,34 +984,38 @@ export default function DatabasePage() {
                   >
                     <Eye className="w-4 h-4" />
                   </button>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      downloadFile(file);
-                    }}
-                    className="inline-flex items-center justify-center rounded-md border border-border p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                    data-testid={`button-download-${i}`}
-                    title={t("db.download")}
-                  >
-                    <Download className="w-4 h-4" />
-                  </button>
+                  {canDownloadFiles && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        downloadFile(file);
+                      }}
+                      className="inline-flex items-center justify-center rounded-md border border-border p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                      data-testid={`button-download-${i}`}
+                      title={t("db.download")}
+                    >
+                      <Download className="w-4 h-4" />
+                    </button>
+                  )}
                 </div>
 
                 <div className="flex items-center gap-2 sm:hidden mt-1">
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (isDeleted) return;
-                      toggleSelected(file.url);
-                    }}
-                    disabled={isDeleted}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
-                    data-testid={`checkbox-select-mobile-${i}`}
-                  >
-                    {isSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
-                  </button>
+                  {canDeleteFiles && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (isDeleted) return;
+                        toggleSelected(file.url);
+                      }}
+                      disabled={isDeleted}
+                      className="text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+                      data-testid={`checkbox-select-mobile-${i}`}
+                    >
+                      {isSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
+                    </button>
+                  )}
                   <span className={cn("text-[10px] font-semibold px-2 py-0.5 rounded-full", contentTypeBadgeColor(file.content_type))}>
                     {contentTypeLabel(file.content_type)}
                   </span>
@@ -1029,18 +1049,20 @@ export default function DatabasePage() {
                     <Eye className="w-3.5 h-3.5" />
                     {t("db.preview")}
                   </button>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      downloadFile(file);
-                    }}
-                    className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                    data-testid={`button-download-mobile-${i}`}
-                  >
-                    <Download className="w-3.5 h-3.5" />
-                    {t("db.download")}
-                  </button>
+                  {canDownloadFiles && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        downloadFile(file);
+                      }}
+                      className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                      data-testid={`button-download-mobile-${i}`}
+                    >
+                      <Download className="w-3.5 h-3.5" />
+                      {t("db.download")}
+                    </button>
+                  )}
                 </div>
               </motion.div>
             );

--- a/client/src/pages/FileDetail.tsx
+++ b/client/src/pages/FileDetail.tsx
@@ -763,7 +763,7 @@ export default function FileDetail() {
   const canDeleteFile = permissions.includes("files.delete");
   const canCatalogWrite = permissions.includes("catalog.write");
   const canMarkdownWrite = permissions.includes("markdown.write");
-  const canRagWrite = permissions.includes("rag.write");
+  const canRunTasks = permissions.includes("tasks.run");
 
   const canEdit = canCatalogWrite && !anyTaskRunning && !mdEditMode;
   const canCatalog = canCatalogWrite && !isDeleted && !anyTaskRunning && !editing && !mdEditMode;
@@ -771,7 +771,8 @@ export default function FileDetail() {
   const canDownload = hasLocalFile && canDownloadFile;
   const canPreview = hasLocalFile;
   const canDelete = canDeleteFile && !isDeleted && !anyTaskRunning;
-  const canModifyChunk = canRagWrite && hasMarkdown && !isDeleted && !anyTaskRunning && !editing && !mdEditMode;
+  const canModifyMarkdown = canMarkdownWrite && hasMarkdown && !isDeleted && !anyTaskRunning && !editing;
+  const canModifyChunk = canRunTasks && hasMarkdown && !isDeleted && !anyTaskRunning && !editing && !mdEditMode;
   const canSwitchMdEdit = canMarkdownWrite && !editing && !anyTaskRunning;
   const canConvert = canMarkdownWrite && hasLocalFile && !editing && !anyTaskRunning;
 

--- a/client/src/pages/FileDetail.tsx
+++ b/client/src/pages/FileDetail.tsx
@@ -771,7 +771,6 @@ export default function FileDetail() {
   const canDownload = hasLocalFile && canDownloadFile;
   const canPreview = hasLocalFile;
   const canDelete = canDeleteFile && !isDeleted && !anyTaskRunning;
-  const canModifyMarkdown = canMarkdownWrite && hasMarkdown && !isDeleted && !anyTaskRunning && !editing;
   const canModifyChunk = canRunTasks && hasMarkdown && !isDeleted && !anyTaskRunning && !editing && !mdEditMode;
   const canSwitchMdEdit = canMarkdownWrite && !editing && !anyTaskRunning;
   const canConvert = canMarkdownWrite && hasLocalFile && !editing && !anyTaskRunning;

--- a/client/src/pages/KBDetail.tsx
+++ b/client/src/pages/KBDetail.tsx
@@ -26,6 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useTranslation } from "@/components/Layout";
 import { apiGet, apiPost, apiPut, apiDelete, formatApiErrorDetail } from "@/lib/api";
+import { useAuth } from "@/context/AuthContext";
 
 interface KBMeta {
   kb_id: string;
@@ -114,12 +115,15 @@ function StatusDot({ status }: { status?: string }) {
 
 export default function KBDetail() {
   const { t } = useTranslation();
+  const { permissions } = useAuth();
+  const canManageKnowledge = permissions.includes("config.write");
+  const canRunKnowledgeTasks = permissions.includes("tasks.run");
   const [, navigate] = useLocation();
   const [match, params] = useRoute("/knowledge/:kbId");
   const kbId = params?.kbId ? decodeURIComponent(params.kbId) : "";
 
   const [meta, setMeta] = useState<KBMeta | null>(null);
-  const canBindFiles = Boolean(meta?.chunk_profile_id);
+  const canBindFiles = canManageKnowledge && Boolean(meta?.chunk_profile_id);
   const [stats, setStats] = useState<KBStats | null>(null);
   const [files, setFiles] = useState<KBFile[]>([]);
   const [categories, setCategories] = useState<KBCategory[]>([]);
@@ -488,29 +492,41 @@ export default function KBDetail() {
               <BookOpen className="w-6 h-6" strokeWidth={1.8} />
             </div>
             <div className="flex-1 min-w-0">
-              <input
-                value={editName}
-                onChange={(e) => {
-                  setEditName(e.target.value);
-                  setHasEdits(true);
-                }}
-                className="text-xl font-serif font-bold tracking-tight bg-transparent border-none outline-none w-full focus:ring-0 p-0"
-                data-testid="input-kb-edit-name"
-              />
-              <textarea
-                value={editDesc}
-                onChange={(e) => {
-                  setEditDesc(e.target.value);
-                  setHasEdits(true);
-                }}
-                placeholder={t("kb.desc_placeholder")}
-                className="mt-2 w-full text-sm text-muted-foreground bg-transparent border-none outline-none resize-none focus:ring-0 p-0 leading-relaxed"
-                rows={2}
-                data-testid="input-kb-edit-desc"
-              />
-              <p className="text-[10px] text-muted-foreground/60 mt-1">{t("kb.desc_guidance")}</p>
+              {canManageKnowledge && (
+                <>
+                  <input
+                    value={editName}
+                    onChange={(e) => {
+                      setEditName(e.target.value);
+                      setHasEdits(true);
+                    }}
+                    className="text-xl font-serif font-bold tracking-tight bg-transparent border-none outline-none w-full focus:ring-0 p-0"
+                    data-testid="input-kb-edit-name"
+                  />
+                  <textarea
+                    value={editDesc}
+                    onChange={(e) => {
+                      setEditDesc(e.target.value);
+                      setHasEdits(true);
+                    }}
+                    placeholder={t("kb.desc_placeholder")}
+                    className="mt-2 w-full text-sm text-muted-foreground bg-transparent border-none outline-none resize-none focus:ring-0 p-0 leading-relaxed"
+                    rows={2}
+                    data-testid="input-kb-edit-desc"
+                  />
+                  <p className="text-[10px] text-muted-foreground/60 mt-1">{t("kb.desc_guidance")}</p>
+                </>
+              )}
+              {!canManageKnowledge && (
+                <>
+                  <h1 className="text-xl font-serif font-bold tracking-tight" data-testid="text-kb-name-readonly">{meta.name}</h1>
+                  {meta.description && (
+                    <p className="mt-2 text-sm text-muted-foreground leading-relaxed" data-testid="text-kb-desc-readonly">{meta.description}</p>
+                  )}
+                </>
+              )}
             </div>
-            {hasEdits && (
+            {canManageKnowledge && hasEdits && (
               <button
                 onClick={handleSave}
                 disabled={saving}
@@ -562,7 +578,7 @@ export default function KBDetail() {
         </div>
       )}
 
-      {needsEmbeddingRebuild && (
+      {canRunKnowledgeTasks && needsEmbeddingRebuild && (
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -598,7 +614,7 @@ export default function KBDetail() {
         </motion.div>
       )}
 
-      {isCategoryMode && pendingCount > 0 && !needsEmbeddingRebuild && (
+      {canRunKnowledgeTasks && isCategoryMode && pendingCount > 0 && !needsEmbeddingRebuild && (
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -653,12 +669,13 @@ export default function KBDetail() {
         ))}
       </motion.div>
 
-      <motion.div
-        initial={{ opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.15, duration: 0.4 }}
-        className="flex items-center gap-2"
-      >
+      {canRunKnowledgeTasks && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.15, duration: 0.4 }}
+          className="flex items-center gap-2"
+        >
         <button
           onClick={() => handleBuildIndex(false)}
           disabled={indexing || pendingCount === 0}
@@ -693,9 +710,10 @@ export default function KBDetail() {
             {t("kb.view_pending")} ({pendingCount})
           </button>
         )}
-      </motion.div>
+        </motion.div>
+      )}
 
-      {showPendingFiles && (
+      {canRunKnowledgeTasks && showPendingFiles && (
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -772,17 +790,19 @@ export default function KBDetail() {
               <span className="text-sm font-semibold">{t("kb.categories")}</span>
               <span className="text-xs text-muted-foreground">({categories.length})</span>
             </div>
-            <button
-              onClick={() => setShowAddCategory(!showAddCategory)}
-              className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium hover:bg-muted transition-colors"
-              data-testid="button-add-category"
-            >
-              <Plus className="w-3.5 h-3.5" />
-              {t("kb.add_category")}
-            </button>
+            {canManageKnowledge && (
+              <button
+                onClick={() => setShowAddCategory(!showAddCategory)}
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium hover:bg-muted transition-colors"
+                data-testid="button-add-category"
+              >
+                <Plus className="w-3.5 h-3.5" />
+                {t("kb.add_category")}
+              </button>
+            )}
           </div>
 
-          {showAddCategory && (
+          {canManageKnowledge && showAddCategory && (
             <div className="px-4 py-3 border-b border-border bg-muted/10 flex items-center gap-2">
               <input
                 value={newCategory}
@@ -829,13 +849,15 @@ export default function KBDetail() {
                   {cat.file_count != null && (
                     <span className="text-[10px] text-primary/60">({cat.file_count})</span>
                   )}
-                  <button
-                    onClick={() => handleRemoveCategory(cat.name)}
-                    className="ml-0.5 opacity-0 group-hover:opacity-100 hover:text-red-500 transition-all"
-                    data-testid={`button-remove-category-${cat.name}`}
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
+                  {canManageKnowledge && (
+                    <button
+                      onClick={() => handleRemoveCategory(cat.name)}
+                      className="ml-0.5 opacity-0 group-hover:opacity-100 hover:text-red-500 transition-all"
+                      data-testid={`button-remove-category-${cat.name}`}
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  )}
                 </span>
               ))
             )}
@@ -863,16 +885,18 @@ export default function KBDetail() {
               className="w-48 px-3 py-1.5 text-xs rounded-lg border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30"
               data-testid="input-search-kb-files"
             />
-            <button
-              onClick={handleOpenBindDialog}
-              disabled={!canBindFiles}
-              title={!canBindFiles ? t("knowledge.select_chunk_profile_first") : undefined}
-              className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              data-testid="button-bind-files"
-            >
-              <LinkIcon className="w-3.5 h-3.5" />
-              {isManualMode ? t("kb.add_files") : t("kb.bind_file")}
-            </button>
+            {canManageKnowledge && (
+              <button
+                onClick={handleOpenBindDialog}
+                disabled={!canBindFiles}
+                title={!canBindFiles ? t("knowledge.select_chunk_profile_first") : undefined}
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                data-testid="button-bind-files"
+              >
+                <LinkIcon className="w-3.5 h-3.5" />
+                {isManualMode ? t("kb.add_files") : t("kb.bind_file")}
+              </button>
+            )}
           </div>
         </div>
 
@@ -927,14 +951,16 @@ export default function KBDetail() {
                       )}
                     </div>
                   </div>
-                  <button
-                    onClick={() => handleRemoveFile(file.file_url)}
-                    className="p-1.5 rounded hover:bg-red-500/10 text-muted-foreground hover:text-red-500 transition-colors shrink-0"
-                    title={t("kb.remove_file")}
-                    data-testid={`button-remove-file-${i}`}
-                  >
-                    <Unlink className="w-3.5 h-3.5" />
-                  </button>
+                  {canManageKnowledge && (
+                    <button
+                      onClick={() => handleRemoveFile(file.file_url)}
+                      className="p-1.5 rounded hover:bg-red-500/10 text-muted-foreground hover:text-red-500 transition-colors shrink-0"
+                      title={t("kb.remove_file")}
+                      data-testid={`button-remove-file-${i}`}
+                    >
+                      <Unlink className="w-3.5 h-3.5" />
+                    </button>
+                  )}
                 </div>
               );
             })}
@@ -942,7 +968,7 @@ export default function KBDetail() {
         )}
       </motion.div>
 
-      {showBindDialog && (
+      {canManageKnowledge && showBindDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" data-testid="dialog-bind-files">
           <motion.div
             initial={{ opacity: 0, scale: 0.95 }}

--- a/client/src/pages/Knowledge.tsx
+++ b/client/src/pages/Knowledge.tsx
@@ -22,6 +22,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useTranslation } from "@/components/Layout";
 import { apiGet, apiPost, apiDelete, formatApiErrorDetail } from "@/lib/api";
+import { useAuth } from "@/context/AuthContext";
 import ConfirmDeleteModal from "@/components/ConfirmDeleteModal";
 
 interface KnowledgeBase {
@@ -154,6 +155,9 @@ function normalizeCategoryNames(items: unknown): string[] {
 
 export default function Knowledge() {
   const { t } = useTranslation();
+  const { permissions } = useAuth();
+  const canManageKnowledge = permissions.includes("config.write");
+  const canRunKnowledgeTasks = permissions.includes("tasks.run");
   const [, navigate] = useLocation();
   const [kbs, setKbs] = useState<KnowledgeBase[]>([]);
   const [profiles, setProfiles] = useState<ChunkProfile[]>([]);
@@ -501,15 +505,17 @@ export default function Knowledge() {
             {t("knowledge.subtitle")}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={openCreateKB}
-          className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
-          data-testid="button-create-kb"
-        >
-          <Plus className="w-4 h-4" />
-          {t("knowledge.create")}
-        </button>
+        {canManageKnowledge && (
+          <button
+            type="button"
+            onClick={openCreateKB}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+            data-testid="button-create-kb"
+          >
+            <Plus className="w-4 h-4" />
+            {t("knowledge.create")}
+          </button>
+        )}
       </motion.div>
 
       {kbActionError && (
@@ -526,7 +532,7 @@ export default function Knowledge() {
       )}
 
       <AnimatePresence>
-        {showCreateKB && (
+        {canManageKnowledge && showCreateKB && (
           <motion.div
             initial={{ opacity: 0, y: -8, height: 0 }}
             animate={{ opacity: 1, y: 0, height: "auto" }}
@@ -891,7 +897,7 @@ export default function Knowledge() {
                       {kb.embedding_model}
                     </p>
                   )}
-                  {needsReembed && (
+                  {canRunKnowledgeTasks && needsReembed && (
                     <div
                       className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3"
                       data-testid={`banner-reembed-kb-${kbId}`}
@@ -956,24 +962,28 @@ export default function Knowledge() {
                     <Eye className="w-3.5 h-3.5" />
                     {t("knowledge.view_detail")}
                   </button>
-                  <div className="w-px bg-border" />
-                  <button
-                    onClick={() => setDeleteConfirm(kbId)}
-                    className="flex items-center justify-center gap-1.5 px-4 py-2.5 text-xs font-medium text-red-500 hover:bg-red-500/5 transition-colors rounded-br-xl"
-                    data-testid={`button-delete-kb-${kbId}`}
-                  >
-                    <Trash2 className="w-3.5 h-3.5" />
-                  </button>
+                  {canManageKnowledge && <div className="w-px bg-border" />}
+                  {canManageKnowledge && (
+                    <button
+                      onClick={() => setDeleteConfirm(kbId)}
+                      className="flex items-center justify-center gap-1.5 px-4 py-2.5 text-xs font-medium text-red-500 hover:bg-red-500/5 transition-colors rounded-br-xl"
+                      data-testid={`button-delete-kb-${kbId}`}
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  )}
                 </div>
 
-                <ConfirmDeleteModal
-                  open={deleteConfirm === kbId}
-                  onClose={() => setDeleteConfirm(null)}
-                  onConfirm={() => handleDeleteKB(kbId)}
-                  title={t("knowledge.delete_confirm")}
-                  message={t("knowledge.delete_warn")}
-                  loading={deleting}
-                />
+                {canManageKnowledge && (
+                  <ConfirmDeleteModal
+                    open={deleteConfirm === kbId}
+                    onClose={() => setDeleteConfirm(null)}
+                    onConfirm={() => handleDeleteKB(kbId)}
+                    title={t("knowledge.delete_confirm")}
+                    message={t("knowledge.delete_warn")}
+                    loading={deleting}
+                  />
+                )}
               </motion.div>
             );
           })}
@@ -986,18 +996,20 @@ export default function Knowledge() {
             <Settings2 className="w-5 h-5 text-muted-foreground" />
             <h2 className="text-lg font-semibold">{t("knowledge.chunk_profiles")}</h2>
           </div>
-          <button
-            onClick={openCreateProfile}
-            className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium hover:bg-muted transition-colors"
-            data-testid="button-create-profile"
-          >
-            <Plus className="w-4 h-4" />
-            {t("knowledge.create_profile")}
-          </button>
+          {canManageKnowledge && (
+            <button
+              onClick={openCreateProfile}
+              className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium hover:bg-muted transition-colors"
+              data-testid="button-create-profile"
+            >
+              <Plus className="w-4 h-4" />
+              {t("knowledge.create_profile")}
+            </button>
+          )}
         </div>
 
         <AnimatePresence>
-          {showCreateProfile && (
+          {canManageKnowledge && showCreateProfile && (
             <motion.div
               initial={{ opacity: 0, y: -8, height: 0 }}
               animate={{ opacity: 1, y: 0, height: "auto" }}
@@ -1131,7 +1143,7 @@ export default function Knowledge() {
                   <th className="text-right px-4 py-2.5 whitespace-nowrap">{t("knowledge.overlap")}</th>
                   <th className="text-left px-4 py-2.5 whitespace-nowrap">{t("knowledge.splitter")}</th>
                   <th className="text-left px-4 py-2.5 whitespace-nowrap">{t("knowledge.tokenizer")}</th>
-                  <th className="w-10 px-2 py-2.5" />
+                  {canManageKnowledge && <th className="w-10 px-2 py-2.5" />}
                 </tr>
               </thead>
               <tbody>
@@ -1146,16 +1158,18 @@ export default function Knowledge() {
                     <td className="px-4 py-3 text-right text-muted-foreground tabular-nums">{profile.chunk_overlap}</td>
                     <td className="px-4 py-3 text-muted-foreground whitespace-nowrap">{profile.splitter || "-"}</td>
                     <td className="px-4 py-3 text-muted-foreground font-mono whitespace-nowrap">{profile.tokenizer || "-"}</td>
-                    <td className="px-2 py-3 text-center">
-                      <button
-                        onClick={() => profile.profile_id && setDeleteProfileConfirm(profile.profile_id)}
-                        className="p-1 rounded hover:bg-red-500/10 text-muted-foreground hover:text-red-500 transition-colors"
-                        data-testid={`button-delete-profile-${i}`}
-                        title={t("knowledge.delete_profile")}
-                      >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </button>
-                    </td>
+                    {canManageKnowledge && (
+                      <td className="px-2 py-3 text-center">
+                        <button
+                          onClick={() => profile.profile_id && setDeleteProfileConfirm(profile.profile_id)}
+                          className="p-1 rounded hover:bg-red-500/10 text-muted-foreground hover:text-red-500 transition-colors"
+                          data-testid={`button-delete-profile-${i}`}
+                          title={t("knowledge.delete_profile")}
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>
@@ -1163,32 +1177,36 @@ export default function Knowledge() {
           </div>
         )}
 
-        <ConfirmDeleteModal
-          open={!!deleteProfileConfirm}
-          onClose={() => setDeleteProfileConfirm(null)}
-          onConfirm={() => {
-            if (deleteProfileConfirm) {
-              handleDeleteProfile(deleteProfileConfirm);
-              setDeleteProfileConfirm(null);
-            }
-          }}
-          title={t("knowledge.delete_profile")}
-          message={t("knowledge.confirm_delete_profile")}
-        />
+        {canManageKnowledge && (
+          <ConfirmDeleteModal
+            open={!!deleteProfileConfirm}
+            onClose={() => setDeleteProfileConfirm(null)}
+            onConfirm={() => {
+              if (deleteProfileConfirm) {
+                handleDeleteProfile(deleteProfileConfirm);
+                setDeleteProfileConfirm(null);
+              }
+            }}
+            title={t("knowledge.delete_profile")}
+            message={t("knowledge.confirm_delete_profile")}
+          />
+        )}
 
-        <div className="flex items-center gap-3 mt-4">
-          <button
-            onClick={() => { setShowCleanup(!showCleanup); setCleanupResult(null); }}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border text-xs font-medium text-muted-foreground hover:bg-muted/50 transition-colors"
-            data-testid="button-toggle-cleanup"
-          >
-            <Trash2 className="w-3.5 h-3.5" />
-            {t("knowledge.cleanup_orphan")}
-          </button>
-        </div>
+        {canManageKnowledge && (
+          <>
+            <div className="flex items-center gap-3 mt-4">
+              <button
+                onClick={() => { setShowCleanup(!showCleanup); setCleanupResult(null); }}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border text-xs font-medium text-muted-foreground hover:bg-muted/50 transition-colors"
+                data-testid="button-toggle-cleanup"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+                {t("knowledge.cleanup_orphan")}
+              </button>
+            </div>
 
-        <AnimatePresence>
-          {showCleanup && (
+            <AnimatePresence>
+              {showCleanup && (
             <motion.div
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
@@ -1244,7 +1262,9 @@ export default function Knowledge() {
               )}
             </motion.div>
           )}
-        </AnimatePresence>
+            </AnimatePresence>
+          </>
+        )}
       </div>
     </div>
   );

--- a/tests/test_file_detail_react_source.py
+++ b/tests/test_file_detail_react_source.py
@@ -37,7 +37,8 @@ def test_file_detail_uses_permission_gates_for_mutating_actions():
     assert 'permissions.includes("files.delete")' in src
     assert 'permissions.includes("catalog.write")' in src
     assert 'permissions.includes("markdown.write")' in src
-    assert 'permissions.includes("rag.write")' in src
+    assert 'permissions.includes("tasks.run")' in src
+    assert 'permissions.includes("rag.write")' not in src
 
 
 def test_file_detail_chunk_modal_can_bind_generated_chunks_to_kb():

--- a/tests/test_frontend_rbac_action_gates.py
+++ b/tests/test_frontend_rbac_action_gates.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "client" / "src"
+KNOWLEDGE_TSX = ROOT / "pages" / "Knowledge.tsx"
+KB_DETAIL_TSX = ROOT / "pages" / "KBDetail.tsx"
+DATABASE_TSX = ROOT / "pages" / "Database.tsx"
+CHAT_TSX = ROOT / "pages" / "Chat.tsx"
+FILE_DETAIL_TSX = ROOT / "pages" / "FileDetail.tsx"
+
+
+def test_knowledge_management_controls_are_permission_gated():
+    src = KNOWLEDGE_TSX.read_text(encoding="utf-8")
+
+    assert 'import { useAuth } from "@/context/AuthContext";' in src
+    assert 'const canManageKnowledge = permissions.includes("config.write");' in src
+    assert 'const canRunKnowledgeTasks = permissions.includes("tasks.run");' in src
+    assert '{canManageKnowledge && (' in src
+    assert '{canRunKnowledgeTasks && needsReembed && (' in src
+    assert '{canManageKnowledge && <div className="w-px bg-border" />}' in src
+    assert '{canManageKnowledge && (' in src and 'data-testid={`button-delete-kb-${kbId}`}' in src
+    assert '{canManageKnowledge && (' in src and 'data-testid="button-create-profile"' in src
+    assert '{canManageKnowledge && (' in src and 'data-testid="button-toggle-cleanup"' in src
+
+
+def test_kb_detail_admin_controls_are_permission_gated():
+    src = KB_DETAIL_TSX.read_text(encoding="utf-8")
+
+    assert 'import { useAuth } from "@/context/AuthContext";' in src
+    assert 'const canManageKnowledge = permissions.includes("config.write");' in src
+    assert 'const canRunKnowledgeTasks = permissions.includes("tasks.run");' in src
+    assert 'const canBindFiles = canManageKnowledge && Boolean(meta?.chunk_profile_id);' in src
+    assert '{canManageKnowledge && (' in src and 'data-testid="input-kb-edit-name"' in src
+    assert '{canManageKnowledge && (' in src and 'data-testid="button-add-category"' in src
+    assert '{canRunKnowledgeTasks && (' in src and 'data-testid="button-index-incremental"' in src
+    assert '{canRunKnowledgeTasks && (' in src and 'data-testid="button-index-rebuild"' in src
+    assert '{canManageKnowledge && (' in src and 'data-testid={`button-remove-file-${i}`}' in src
+    assert 'onClick={loadPendingFiles}' in src and 'canRunKnowledgeTasks' in src
+
+
+def test_database_sensitive_controls_are_permission_gated():
+    src = DATABASE_TSX.read_text(encoding="utf-8")
+
+    assert 'import { useAuth } from "@/context/AuthContext";' in src
+    assert 'const canDeleteFiles = permissions.includes("files.delete");' in src
+    assert 'const canDownloadFiles = permissions.includes("files.download");' in src
+    assert 'const canExportFiles = permissions.includes("export.read");' in src
+    assert '{canExportFiles && (' in src and 'data-testid="button-export-csv"' in src
+    assert '{canDeleteFiles && (' in src and 'data-testid="button-bulk-delete"' in src
+    assert '{canDeleteFiles && (' in src and 'data-testid="checkbox-include-deleted"' in src
+    assert '{canDownloadFiles && (' in src and 'data-testid={`button-download-${i}`}' in src
+    assert '{canDownloadFiles && (' in src and 'data-testid={`button-download-mobile-${i}`}' in src
+
+
+def test_chat_persistent_conversations_require_chat_conversations_permission():
+    src = CHAT_TSX.read_text(encoding="utf-8")
+
+    assert 'const canUseConversations = permissions.includes("chat.conversations");' in src
+    assert 'if (canUseConversations) {' in src and 'loadConversations();' in src
+    assert 'if (!canUseConversations) return;' in src
+    assert '{canUseConversations && (' in src and 'data-testid="button-new-conversation"' in src
+    assert '{canUseConversations && (' in src and 'data-testid="tab-conversations"' in src
+    assert 'sidebarTab === "conversations" && canUseConversations ? (' in src
+
+
+def test_file_detail_uses_real_task_permission_not_rag_write():
+    src = FILE_DETAIL_TSX.read_text(encoding="utf-8")
+
+    assert 'rag.write' not in src
+    assert 'const canRunTasks = permissions.includes("tasks.run");' in src
+    assert 'const canModifyChunk = canRunTasks && hasMarkdown' in src


### PR DESCRIPTION
## Summary
- Gate Knowledge and KB detail admin/task controls by explicit permissions so public/reader users only see read-only KB browsing.
- Gate Database export/download/delete/include-deleted and Chat conversation-management UI by their backend permissions while preserving guest chat multi-turn context.
- Replace the obsolete FileDetail `rag.write` check with the actual `tasks.run` boundary and add React source tests for the frontend RBAC action gates.

## Test Plan
- `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_frontend_rbac_action_gates.py tests/test_auth_react_source.py tests/test_chat_react_source.py tests/test_file_detail_react_source.py -q`
- `npm run build`
- `git diff --check`
- Browser smoke with local FastAPI + Vite under auth-required guest mode: `/database`, `/knowledge`, KB detail, `/chat`, and file detail verified for hidden/disabled write controls and no browser console errors.
- `codex -c 'model="gpt-5.5"' review --uncommitted` found no remaining discrete regressions after accepted fixes.
