### PR TITLE
fix: tighten backend RBAC public payloads

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -4,10 +4,10 @@
 - Branch: `fix/backend-public-rbac-tightening`
 - Baseline: latest `origin/main` after PR A (`fix: gate frontend RBAC actions`) was merged.
 - Scope: Backend RBAC/payload tightening for public file read payloads, deleted-file access, RAG/KB admin read endpoints, and config backup permissions.
-- `/api/files` and `/api/files/detail` now project public responses through a public allowlist and only include sensitive fields (`sha256`, `local_path`, `etag`, `deleted_at`, `markdown_content`) for authenticated users with operational file/catalog permissions.
-- Anonymous or unauthorized `include_deleted=true` requests are rejected (`401` for anonymous, `403` for authenticated users without `files.delete`).
+- `/api/files` and `/api/files/detail` now project public responses through explicit public allowlists and only include sensitive fields (`sha256`, `local_path`, `etag`, `deleted_at`, `markdown_content`) for authenticated users with operational file/catalog permissions.
+- Anonymous or unauthorized `include_deleted=true` requests are rejected with standard auth messages (`401 Unauthorized` for anonymous, `403 Forbidden` for authenticated users without `files.delete`).
 - RAG/KB admin read endpoints are split by operational need: public KB browsing remains readable, pending-files and chunk profile reads are available to task runners, and category mapping/selectable/bindings admin surfaces require `config.write`.
 - Config backup list/create/restore/delete endpoints now require `config.write` instead of `sites.write`.
 - Tests updated for read payload filtering, include_deleted authorization, RAG admin endpoint permission split, config backup admin guard, and index dirty fixture consistency.
-- Local verification completed so far: 49 selected tests passed, `git diff --check` passed, Codex CLI review passed after addressing findings about operator chunk profile reads and markdown availability for authenticated callers.
-- Remaining before PR: service/browser smoke on current branch, commit/push, create PR, wait for remote comments/checks, then merge/delete branch if clean.
+- Local verification completed: 49 selected tests passed, focused 38-test backend suite passed after PR comments, `git diff --check` passed, Codex CLI review passed after addressing findings about operator chunk profile reads, markdown availability, public detail allowlist, auth messages, and test naming.
+- PR #126 created; CI python-smoke passed; Copilot comments addressed locally and ready to push follow-up commit.

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,18 +1,13 @@
 # Project Status
 
 - Date: 2026-05-26
-- Branch: `fix/frontend-rbac-action-gates`
-- Latest baseline: `origin/main` before this branch was created.
-- Scope: Frontend RBAC action gates for Knowledge, KB detail, Database, Chat, and File Detail.
-- Permission changes are UI-only in this PR: public/guest users keep read-only browsing/chat surfaces but no longer see or can use KB admin, persistent conversation management, export/download/delete/include-deleted, or task/chunk-generation controls without the matching permission.
-- Knowledge/KB controls now distinguish `catalog.read` browsing, `tasks.run` indexing/pending task actions, and `config.write` management/configuration actions.
-- Database controls now gate include-deleted and selection/delete behind `files.delete`, downloads behind `files.download`, and CSV export behind `export.read`; auth-loading is handled before URL rewrite/request generation so direct admin links preserve `include_deleted` until permissions are known.
-- Chat now gates history/new/delete conversation UI and list API calls behind `chat.conversations`, while still preserving query-returned `conversation_id` for guest multi-turn context when only `chat.query` is available.
-- FileDetail no longer checks nonexistent `rag.write`; task/chunk-generation controls use the actual backend `tasks.run` boundary while edit/download/delete controls continue to follow their specific permissions.
-- Tests updated: added `tests/test_frontend_rbac_action_gates.py` and updated FileDetail source test to reject `rag.write`.
-- Verification passed: `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_frontend_rbac_action_gates.py tests/test_auth_react_source.py tests/test_chat_react_source.py tests/test_file_detail_react_source.py -q` (19 passed).
-- Verification passed: `npm run build`.
-- Verification passed: `git diff --check`.
-- Browser smoke passed with local FastAPI + Vite under auth-required guest mode: `/database` has no export/download/delete/include-deleted controls, `/knowledge` and KB detail show read-only browsing without create/delete/index/bind controls, `/chat` hides conversation history/new/delete while leaving document/chat UI, file detail shows write/download/delete/chunk controls disabled, and browser console has no JavaScript errors.
-- Local Codex review gate: multiple rounds found auth-loading and permission-boundary issues; all accepted findings were fixed. Final Codex review found no discrete regressions.
-- Next step: commit, push, create PR, then follow up on GitHub checks/review comments after the standard wait window.
+- Branch: `fix/backend-public-rbac-tightening`
+- Baseline: latest `origin/main` after PR A (`fix: gate frontend RBAC actions`) was merged.
+- Scope: Backend RBAC/payload tightening for public file read payloads, deleted-file access, RAG/KB admin read endpoints, and config backup permissions.
+- `/api/files` and `/api/files/detail` now project public responses through a public allowlist and only include sensitive fields (`sha256`, `local_path`, `etag`, `deleted_at`, `markdown_content`) for authenticated users with operational file/catalog permissions.
+- Anonymous or unauthorized `include_deleted=true` requests are rejected (`401` for anonymous, `403` for authenticated users without `files.delete`).
+- RAG/KB admin read endpoints are split by operational need: public KB browsing remains readable, pending-files and chunk profile reads are available to task runners, and category mapping/selectable/bindings admin surfaces require `config.write`.
+- Config backup list/create/restore/delete endpoints now require `config.write` instead of `sites.write`.
+- Tests updated for read payload filtering, include_deleted authorization, RAG admin endpoint permission split, config backup admin guard, and index dirty fixture consistency.
+- Local verification completed so far: 49 selected tests passed, `git diff --check` passed, Codex CLI review passed after addressing findings about operator chunk profile reads and markdown availability for authenticated callers.
+- Remaining before PR: service/browser smoke on current branch, commit/push, create PR, wait for remote comments/checks, then merge/delete branch if clean.

--- a/ai_actuarial/api/routers/ops_write.py
+++ b/ai_actuarial/api/routers/ops_write.py
@@ -163,7 +163,7 @@ def api_config_sites_sample(
 @router.get("/config/backups")
 def api_config_backups(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("sites.write")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return list_backups()
@@ -175,7 +175,7 @@ def api_config_backups(
 def api_config_backups_create(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("sites.write")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         label = str(payload.get("label", "manual") or "manual")
@@ -189,7 +189,7 @@ def api_config_backups_create(
 def api_config_backups_restore(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("sites.write")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return restore_backup(str(payload.get("filename") or ""), bridge=_bridge(request))
@@ -201,7 +201,7 @@ def api_config_backups_restore(
 def api_config_backups_delete(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("sites.write")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return delete_backup(str(payload.get("filename") or ""))

--- a/ai_actuarial/api/routers/rag_admin.py
+++ b/ai_actuarial/api/routers/rag_admin.py
@@ -53,7 +53,7 @@ def _error_response(exc: RagAdminError) -> JSONResponse:
 @router.get("/chunk/profiles")
 def api_chunk_profiles(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+    _auth: AuthContext = Depends(require_permissions("tasks.run")),
 ):
     try:
         return list_chunk_profiles(db_path=_db_path(request))
@@ -225,7 +225,7 @@ def api_remove_knowledge_base_file(
 @router.get("/rag/categories/unmapped")
 def api_unmapped_categories(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return get_unmapped_categories(db_path=_db_path(request))
@@ -236,7 +236,7 @@ def api_unmapped_categories(
 @router.get("/rag/categories/mapping")
 def api_categories_mapping(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return get_categories_mapping(db_path=_db_path(request))
@@ -248,7 +248,7 @@ def api_categories_mapping(
 def api_category_stats(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return get_category_stats(db_path=_db_path(request), payload=payload)
@@ -259,7 +259,7 @@ def api_category_stats(
 @router.get("/rag/files/selectable")
 def api_selectable_files(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return list_selectable_files(db_path=_db_path(request), query=request.query_params)
@@ -296,7 +296,7 @@ def api_set_kb_categories(
 def api_pending_files(
     kb_id: str,
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+    _auth: AuthContext = Depends(require_permissions("tasks.run")),
 ):
     try:
         return get_pending_files(db_path=_db_path(request), kb_id=kb_id)
@@ -321,7 +321,7 @@ def api_bind_chunk_sets(
 def api_get_kb_bindings(
     kb_id: str,
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+    _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
         return get_kb_bindings(db_path=_db_path(request), kb_id=kb_id)

--- a/ai_actuarial/api/routers/read.py
+++ b/ai_actuarial/api/routers/read.py
@@ -67,6 +67,14 @@ def _decode_file_url_path(request: Request, file_url: str, *, suffix: str) -> st
         return file_url
 
 
+def _can_view_sensitive_file_fields(auth: AuthContext) -> bool:
+    return bool(auth.token) and (
+        "files.download" in auth.permissions
+        or "files.delete" in auth.permissions
+        or "catalog.write" in auth.permissions
+    )
+
+
 @router.get("/stats")
 def api_stats(
     request: Request,
@@ -98,22 +106,33 @@ def api_categories(
 @router.get("/files")
 def api_files(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("files.read")),
+    auth: AuthContext = Depends(require_permissions("files.read")),
 ) -> dict[str, object]:
     query = parse_file_list_query(request.query_params)
-    return list_files(db_path=_get_db_path(request), query=query)
+    if query.include_deleted and "files.delete" not in auth.permissions:
+        status_code = 401 if not auth.token else 403
+        raise HTTPException(status_code=status_code, detail="include_deleted requires files.delete")
+    return list_files(
+        db_path=_get_db_path(request),
+        query=query,
+        include_sensitive=_can_view_sensitive_file_fields(auth),
+    )
 
 
 @router.get("/files/detail")
 def api_file_detail(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("files.read")),
+    auth: AuthContext = Depends(require_permissions("files.read")),
 ) -> dict[str, object]:
     url = str(request.query_params.get("url", "") or "").strip()
     if not url:
         return JSONResponse(status_code=400, content={"error": "url parameter is required"})
 
-    file_data = get_file_detail(db_path=_get_db_path(request), url=url)
+    file_data = get_file_detail(
+        db_path=_get_db_path(request),
+        url=url,
+        include_sensitive=_can_view_sensitive_file_fields(auth),
+    )
     if not file_data:
         return JSONResponse(status_code=404, content={"error": "File not found"})
 

--- a/ai_actuarial/api/routers/read.py
+++ b/ai_actuarial/api/routers/read.py
@@ -110,8 +110,9 @@ def api_files(
 ) -> dict[str, object]:
     query = parse_file_list_query(request.query_params)
     if query.include_deleted and "files.delete" not in auth.permissions:
+        detail = "Unauthorized" if not auth.token else "Forbidden"
         status_code = 401 if not auth.token else 403
-        raise HTTPException(status_code=status_code, detail="include_deleted requires files.delete")
+        raise HTTPException(status_code=status_code, detail=detail)
     return list_files(
         db_path=_get_db_path(request),
         query=query,

--- a/ai_actuarial/api/services/read.py
+++ b/ai_actuarial/api/services/read.py
@@ -39,6 +39,14 @@ SENSITIVE_FILE_FIELDS: tuple[str, ...] = (
 
 FILE_LIST_FIELDS: tuple[str, ...] = PUBLIC_FILE_LIST_FIELDS + SENSITIVE_FILE_FIELDS
 
+PUBLIC_FILE_DETAIL_FIELDS: tuple[str, ...] = PUBLIC_FILE_LIST_FIELDS + (
+    "catalog_status",
+    "catalog_version",
+    "catalog_processed_at",
+    "catalog_updated_at",
+    "rag_kb_entries",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class FileListQuery:
@@ -136,7 +144,7 @@ def get_file_detail(*, db_path: str, url: str, include_sensitive: bool = False) 
         return None
     if include_sensitive:
         return file_data
-    return {key: value for key, value in file_data.items() if key not in SENSITIVE_FILE_FIELDS}
+    return {field: file_data.get(field) for field in PUBLIC_FILE_DETAIL_FIELDS}
 
 
 def get_file_markdown(*, db_path: str, url: str) -> dict[str, Any]:

--- a/ai_actuarial/api/services/read.py
+++ b/ai_actuarial/api/services/read.py
@@ -7,32 +7,37 @@ from typing import Any, Mapping
 from ai_actuarial.shared_runtime import get_categories_config_path, load_yaml, parse_int_clamped
 from ai_actuarial.storage import Storage
 
-FILE_LIST_FIELDS: tuple[str, ...] = (
+PUBLIC_FILE_LIST_FIELDS: tuple[str, ...] = (
     "url",
-    "sha256",
     "title",
     "source_site",
     "source_page_url",
     "original_filename",
-    "local_path",
     "bytes",
     "content_type",
     "last_modified",
-    "etag",
     "published_time",
     "first_seen",
     "last_seen",
     "crawl_time",
-    "deleted_at",
     "category",
     "summary",
     "keywords",
-    "markdown_content",
     "markdown_source",
     "markdown_updated_at",
     "rag_chunk_count",
     "rag_indexed_at",
 )
+
+SENSITIVE_FILE_FIELDS: tuple[str, ...] = (
+    "sha256",
+    "local_path",
+    "etag",
+    "deleted_at",
+    "markdown_content",
+)
+
+FILE_LIST_FIELDS: tuple[str, ...] = PUBLIC_FILE_LIST_FIELDS + SENSITIVE_FILE_FIELDS
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,8 +65,9 @@ def parse_file_list_query(raw_query: Mapping[str, str | None]) -> FileListQuery:
     )
 
 
-def _project_file_row(file_row: dict[str, Any]) -> dict[str, Any]:
-    return {field: file_row.get(field) for field in FILE_LIST_FIELDS}
+def _project_file_row(file_row: dict[str, Any], *, include_sensitive: bool = False) -> dict[str, Any]:
+    fields = FILE_LIST_FIELDS if include_sensitive else PUBLIC_FILE_LIST_FIELDS
+    return {field: file_row.get(field) for field in fields}
 
 
 def project_recent_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -69,8 +75,8 @@ def project_recent_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [{field: item.get(field) for field in fields} for item in files]
 
 
-def project_database_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [_project_file_row(item) for item in files]
+def project_database_files(files: list[dict[str, Any]], *, include_sensitive: bool = False) -> list[dict[str, Any]]:
+    return [_project_file_row(item, include_sensitive=include_sensitive) for item in files]
 
 
 def get_dashboard_stats(*, db_path: str, active_tasks: int) -> dict[str, int]:
@@ -120,12 +126,17 @@ def list_sources(*, db_path: str) -> dict[str, list[str]]:
     return {"sources": sources}
 
 
-def get_file_detail(*, db_path: str, url: str) -> dict[str, Any] | None:
+def get_file_detail(*, db_path: str, url: str, include_sensitive: bool = False) -> dict[str, Any] | None:
     storage = Storage(db_path)
     try:
-        return storage.get_file_with_catalog(url)
+        file_data = storage.get_file_with_catalog(url)
     finally:
         storage.close()
+    if not file_data:
+        return None
+    if include_sensitive:
+        return file_data
+    return {key: value for key, value in file_data.items() if key not in SENSITIVE_FILE_FIELDS}
 
 
 def get_file_markdown(*, db_path: str, url: str) -> dict[str, Any]:
@@ -147,7 +158,7 @@ def get_file_markdown(*, db_path: str, url: str) -> dict[str, Any]:
     }
 
 
-def list_files(*, db_path: str, query: FileListQuery) -> dict[str, Any]:
+def list_files(*, db_path: str, query: FileListQuery, include_sensitive: bool = False) -> dict[str, Any]:
     storage = Storage(db_path)
     try:
         files, total = storage.query_files_with_catalog(
@@ -164,7 +175,7 @@ def list_files(*, db_path: str, query: FileListQuery) -> dict[str, Any]:
         storage.close()
 
     return {
-        "files": project_database_files(files),
+        "files": project_database_files(files, include_sensitive=include_sensitive),
         "total": total,
         "limit": query.limit,
         "offset": query.offset,

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -226,18 +226,22 @@ def test_config_sites_crud_import_export_and_backups_roundtrip(tmp_path: Path, m
     assert delete_site_response.status_code == 200, delete_site_response.text
     assert all(site["name"] != "Import Site" for site in _read_sites(config_path))
 
-    backups_response = client.get("/api/config/backups", headers=headers)
+    operator_backups_response = client.get("/api/config/backups", headers=headers)
+    assert operator_backups_response.status_code == 403
+
+    admin_headers = {"X-Auth-Token": seed["admin_token"]}
+    backups_response = client.get("/api/config/backups", headers=admin_headers)
     assert backups_response.status_code == 200
     backups = backups_response.json()["backups"]
     assert backups, backups_response.text
     backup_filename = backups[0]["filename"]
 
-    delete_backup_response = client.post("/api/config/backups/delete", json={"filename": backup_filename}, headers=headers)
+    delete_backup_response = client.post("/api/config/backups/delete", json={"filename": backup_filename}, headers=admin_headers)
     assert delete_backup_response.status_code == 200, delete_backup_response.text
 
-    restore_source = client.get("/api/config/backups", headers=headers)
+    restore_source = client.get("/api/config/backups", headers=admin_headers)
     restore_filename = restore_source.json()["backups"][0]["filename"]
-    restore_response = client.post("/api/config/backups/restore", json={"filename": restore_filename}, headers=headers)
+    restore_response = client.post("/api/config/backups/restore", json={"filename": restore_filename}, headers=admin_headers)
     assert restore_response.status_code == 200, restore_response.text
 
 

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -188,6 +188,37 @@ def test_fastapi_rag_admin_routes_are_listed_in_native_inventory(tmp_path: Path,
     assert "/api/chunk-sets/cleanup" in body["native_paths"]
 
 
+def test_fastapi_rag_admin_read_routes_require_task_or_config_permissions(tmp_path: Path, monkeypatch) -> None:
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch)
+    client.headers.clear()
+
+    public_kbs = client.get("/api/rag/knowledge-bases")
+    assert public_kbs.status_code == 200, public_kbs.text
+
+    for path in (
+        "/api/chunk/profiles",
+        "/api/rag/categories/unmapped",
+        "/api/rag/categories/mapping",
+        "/api/rag/files/selectable",
+        "/api/rag/knowledge-bases/kb-missing/bindings",
+    ):
+        response = client.get(path)
+        assert response.status_code == 401, path
+
+    category_stats = client.post("/api/rag/categories/stats", json={"categories": ["AI"]})
+    assert category_stats.status_code == 401
+
+    pending = client.get("/api/rag/knowledge-bases/kb-missing/files/pending")
+    assert pending.status_code == 401
+
+    operator_headers = {"X-Auth-Token": seed["operator_token"]}
+    assert client.get("/api/rag/knowledge-bases/kb-missing/files/pending", headers=operator_headers).status_code in {200, 404}
+    assert client.get("/api/chunk/profiles", headers=operator_headers).status_code == 200
+
+    admin_headers = {"X-Auth-Token": seed["admin_token"]}
+    assert client.get("/api/chunk/profiles", headers=admin_headers).status_code == 200
+
+
 def test_fastapi_rag_admin_categories_mapping_uses_catalog_items_without_legacy_table(tmp_path: Path, monkeypatch) -> None:
     client, _app, seed = _build_test_client(tmp_path, monkeypatch)
     storage = Storage(str(tmp_path / "index.db"))
@@ -343,11 +374,19 @@ def test_fastapi_rag_admin_kb_add_marks_dirty_and_delete_soft_applies(tmp_path: 
             (indexed_at, 1, "kb-index-dirty", alpha_url),
         )
         storage._conn.execute(
+            "UPDATE catalog_items SET markdown_updated_at = ? WHERE file_url = ?",
+            (indexed_at, alpha_url),
+        )
+        storage._conn.execute(
             """
             INSERT INTO rag_chunks (chunk_id, kb_id, file_url, chunk_index, content, token_count, section_hierarchy, embedding_hash, created_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             ("kb-index-dirty:alpha:0", "kb-index-dirty", alpha_url, 0, "Alpha indexed chunk", 3, "Alpha", "hash-alpha", indexed_at),
+        )
+        storage._conn.execute(
+            "UPDATE kb_chunk_bindings SET bound_at = ? WHERE kb_id = ? AND file_url = ?",
+            (indexed_at, "kb-index-dirty", alpha_url),
         )
         storage._conn.execute(
             "UPDATE rag_knowledge_bases SET chunk_count = ?, updated_at = ? WHERE kb_id = ?",
@@ -396,6 +435,10 @@ def test_fastapi_rag_admin_kb_add_marks_dirty_and_delete_soft_applies(tmp_path: 
         storage._conn.execute(
             "UPDATE rag_kb_files SET indexed_at = ?, chunk_count = ? WHERE kb_id = ? AND file_url = ?",
             (beta_indexed_at, 1, "kb-index-dirty", beta_url),
+        )
+        storage._conn.execute(
+            "UPDATE catalog_items SET markdown_updated_at = ? WHERE file_url = ?",
+            (beta_indexed_at, beta_url),
         )
         storage._conn.commit()
         storage.create_kb_index_version(

--- a/tests/test_fastapi_read_endpoints.py
+++ b/tests/test_fastapi_read_endpoints.py
@@ -139,6 +139,13 @@ def _seed_storage(db_path: Path) -> dict[str, object]:
             token_hash=hashlib.sha256(token_plain.encode("utf-8")).hexdigest(),
             is_active=True,
         )
+        operator_token_plain = "operator-token"
+        storage.upsert_auth_token_by_hash(
+            subject="operator-token",
+            group_name="operator",
+            token_hash=hashlib.sha256(operator_token_plain.encode("utf-8")).hexdigest(),
+            is_active=True,
+        )
 
         storage._conn.execute(
             "UPDATE files SET last_seen = ? WHERE url = ?",
@@ -156,7 +163,7 @@ def _seed_storage(db_path: Path) -> dict[str, object]:
     finally:
         storage.close()
 
-    return {"user_id": user_id, "token_plain": token_plain}
+    return {"user_id": user_id, "token_plain": token_plain, "operator_token_plain": operator_token_plain}
 
 
 def _build_test_client(tmp_path: Path, monkeypatch, *, require_auth: bool) -> tuple[TestClient, object, dict[str, object]]:
@@ -230,7 +237,10 @@ def test_fastapi_files_supports_filters_sorting_and_deleted(tmp_path: Path, monk
     assert filtered_body["files"][0]["title"] == "Alpha Document"
     assert filtered_body["files"][0]["category"] == "AI; Risk"
 
-    deleted = client.get("/api/files?include_deleted=true&order_by=title&order_dir=asc")
+    deleted = client.get(
+        "/api/files?include_deleted=true&order_by=title&order_dir=asc",
+        headers={"Authorization": f"Bearer {_seed['operator_token_plain']}"},
+    )
     assert deleted.status_code == 200
     deleted_body = deleted.json()
     assert deleted_body["total"] == 3
@@ -245,18 +255,29 @@ def test_fastapi_native_read_routes_keep_public_reads_available_under_require_au
     client, _app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
 
     public_stats = client.get("/api/stats")
-    assert public_stats.status_code == 401
+    assert public_stats.status_code == 200
 
     public_files = client.get("/api/files")
     assert public_files.status_code == 200
-    assert public_files.json()["total"] == 2
+    public_files_body = public_files.json()
+    assert public_files_body["total"] == 2
+    assert "local_path" not in public_files_body["files"][0]
+    assert "sha256" not in public_files_body["files"][0]
+    assert "markdown_content" not in public_files_body["files"][0]
+
+    public_deleted = client.get("/api/files?include_deleted=true")
+    assert public_deleted.status_code == 401
 
     authorized = client.get(
         "/api/files",
         headers={"Authorization": f"Bearer {seed['token_plain']}"},
     )
     assert authorized.status_code == 200
-    assert authorized.json()["total"] == 2
+    authorized_body = authorized.json()
+    assert authorized_body["total"] == 2
+    assert "local_path" in authorized_body["files"][0]
+    assert "sha256" in authorized_body["files"][0]
+    assert "markdown_content" in authorized_body["files"][0]
 
 
 def test_fastapi_sources_file_detail_and_markdown_match_legacy_contract(tmp_path: Path, monkeypatch) -> None:
@@ -274,6 +295,9 @@ def test_fastapi_sources_file_detail_and_markdown_match_legacy_contract(tmp_path
     assert detail_body["file"]["url"] == "https://alpha.example/doc-a.pdf"
     assert detail_body["file"]["title"] == "Alpha Document"
     assert detail_body["file"]["markdown_source"] == "manual"
+    assert "local_path" not in detail_body["file"]
+    assert "sha256" not in detail_body["file"]
+    assert "markdown_content" not in detail_body["file"]
 
     missing_param = client.get("/api/files/detail")
     assert missing_param.status_code == 400

--- a/tests/test_fastapi_read_endpoints.py
+++ b/tests/test_fastapi_read_endpoints.py
@@ -220,7 +220,7 @@ def test_fastapi_stats_and_categories_are_native(tmp_path: Path, monkeypatch) ->
 
 
 def test_fastapi_files_supports_filters_sorting_and_deleted(tmp_path: Path, monkeypatch) -> None:
-    client, _app, _seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
 
     response = client.get("/api/files?limit=10&order_by=title&order_dir=asc")
     assert response.status_code == 200
@@ -239,7 +239,7 @@ def test_fastapi_files_supports_filters_sorting_and_deleted(tmp_path: Path, monk
 
     deleted = client.get(
         "/api/files?include_deleted=true&order_by=title&order_dir=asc",
-        headers={"Authorization": f"Bearer {_seed['operator_token_plain']}"},
+        headers={"Authorization": f"Bearer {seed['operator_token_plain']}"},
     )
     assert deleted.status_code == 200
     deleted_body = deleted.json()


### PR DESCRIPTION
## Summary
- Trim public `/api/files` and `/api/files/detail` responses through explicit allowlists, while preserving operational fields only for authenticated users with file/catalog permissions.
- Reject unauthorized `include_deleted=true` file-list requests and split RAG/KB admin read endpoints by task-runner vs config-admin permissions.
- Move config backup list/create/restore/delete behind `config.write` and add focused FastAPI coverage for the new guards.

## Validation
- `/home/ec2-user/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_fastapi_read_endpoints.py tests/test_fastapi_rag_admin_endpoints.py tests/test_fastapi_ops_write_endpoints.py tests/test_auth_react_source.py tests/test_frontend_rbac_action_gates.py tests/test_file_detail_react_source.py -q`
- `git diff --check`
- `codex -c 'model="gpt-5.5"' review --uncommitted`
- Local service smoke with uvicorn + Vite:
  - public `/api/files` returns 200 with no `sha256`, `local_path`, `etag`, `deleted_at`, or `markdown_content`
  - public `/api/files?include_deleted=true` returns 401
  - public `/api/chunk/profiles` returns 401
  - public `/api/rag/knowledge-bases` returns 200
  - Browser smoke for `/database` and `/knowledge` detail, console clean
