### PR TITLE
fix: allow admin sessions to manage RAG KBs

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -9,3 +9,4 @@
 - Focused tests added for anonymous 401, registered 403, operator/admin session success, legacy RAG token success, and unrelated config write denial with the legacy token.
 - Verification completed locally: `git diff --check`; `python -m pytest tests/test_fastapi_rag_admin_endpoints.py -q` (16 passed); `python -m pytest tests/test_fastapi_auth_endpoints.py tests/test_fastapi_ops_write_endpoints.py -q` (37 passed).
 - Independent review gate completed: delegate review PASS, delegate focused verification PASS, Codex CLI pre-PR review PASS. Codex read-only pytest attempt could not start due sandbox temp-dir limitation, but local pytest runs above passed.
+- PR #128 follow-up on 2026-05-29: addressed Copilot's note by preserving `tasks.run` for `create_index_task` while keeping the scoped legacy RAG token fallback; focused auth/RAG tests pass locally.

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,16 +1,11 @@
 # Project Status
 
 - Date: 2026-05-29
-- Branch: `chore/slim-runtime-requirements`
+- Branch: `fix/kb-admin-session`
 - Baseline: latest `origin/main`.
-- Scope: Slim standard runtime dependencies, remove local embedding/GPU-heavy optional packages from the default install path, document Java as an OS prerequisite for OpenDataLoader, and remove the private host path from `AGENTS.md`.
-- `requirements.txt` is grouped by runtime area and no longer directly includes `keybert`, `sentence-transformers`, `marker-pdf`, or explicit GPU-heavy packages. It keeps OpenAI/ChatGPT-compatible, Mistral, OpenDataLoader, MarkItDown, Docling Slim plus CPU PDF backend pieces, and core FastAPI/RAG/vector-search dependencies.
-- Java is documented as a system prerequisite for OpenDataLoader in `requirements.txt` comments and README quick-start requirements; Docker installs `default-jre-headless` because pip cannot install a JVM.
-- Docker no longer installs explicit torch/torchvision/easyocr/onnxruntime side packages or the old `mistralai==1.0.0` override.
-- Catalog keyword extraction now always uses the lightweight deterministic path after removing KeyBERT, filters common English stop words, and the catalog version was bumped to `v3-light-keywords` so existing catalog rows can be reprocessed instead of sharing the old `v2-keybert` version.
-- `AGENTS.md` now identifies the repo as the current checkout root instead of exposing a host-specific absolute checkout path.
-- `DoclingEngine` keeps the `docling` engine usable in the slim runtime by using a CPU text fallback for PDF files when the optional full Docling model stack is not installed; full `DocumentConverter` remains available when those optional dependencies are installed separately.
-- Focused verification completed locally: `python -m pip install --dry-run --no-deps -r requirements.txt`, full dependency dry-run with a forbidden GPU/package parse, 13 focused pytest tests, `git diff --check`, dependency/path searches.
-- Local Codex review gate found and prompted fixes for the KeyBERT determinism/version issue, Java package availability, the plain `docling` heavy transitive dependency path, the Docling Slim PDF backend gap, and lightweight keyword stop-word filtering; fixes implemented.
-- Final local Codex review gate reruns timed out twice after 15 minutes each: `codex review --uncommitted` and `codex review --base origin/main`. This is recorded as a tooling blocker before PR publication.
-- PR #127 created from `chore/slim-runtime-requirements`; GitHub `python-smoke` passed and Copilot PR review produced no actionable comments.
+- Scope: Fix RAG knowledge-base write endpoints so logged-in admin/operator browser sessions can create, update, delete, categorize, bind files/chunks, and start KB indexing without being blocked by the legacy `CONFIG_WRITE_AUTH_TOKEN` service-layer check.
+- RAG write routes now pass the resolved auth context into the service layer; the service trusts already-authorized session/API-token contexts and only falls back to `CONFIG_WRITE_AUTH_TOKEN` when no route auth was provided.
+- Legacy `CONFIG_WRITE_AUTH_TOKEN` compatibility is scoped to RAG write routing through `require_rag_write`; it is not promoted globally in shared auth dependencies and does not authorize unrelated config/task endpoints.
+- Focused tests added for anonymous 401, registered 403, operator/admin session success, legacy RAG token success, and unrelated config write denial with the legacy token.
+- Verification completed locally: `git diff --check`; `python -m pytest tests/test_fastapi_rag_admin_endpoints.py -q` (16 passed); `python -m pytest tests/test_fastapi_auth_endpoints.py tests/test_fastapi_ops_write_endpoints.py -q` (37 passed).
+- Independent review gate completed: delegate review PASS, delegate focused verification PASS, Codex CLI pre-PR review PASS. Codex read-only pytest attempt could not start due sandbox temp-dir limitation, but local pytest runs above passed.

--- a/ai_actuarial/api/routers/rag_admin.py
+++ b/ai_actuarial/api/routers/rag_admin.py
@@ -65,9 +65,9 @@ def _legacy_rag_write_context(request: Request) -> AuthContext | None:
     )
 
 
-def require_rag_write(request: Request) -> AuthContext:
+def _require_permission_or_legacy_rag_write(request: Request, permission: str) -> AuthContext:
     context = get_auth_context(request)
-    if context.token and "catalog.write" in context.permissions:
+    if context.token and permission in context.permissions:
         return context
     legacy_context = _legacy_rag_write_context(request)
     if legacy_context:
@@ -75,6 +75,14 @@ def require_rag_write(request: Request) -> AuthContext:
     if not context.token:
         raise HTTPException(status_code=401, detail="Unauthorized")
     raise HTTPException(status_code=403, detail="Forbidden")
+
+
+def require_rag_write(request: Request) -> AuthContext:
+    return _require_permission_or_legacy_rag_write(request, "catalog.write")
+
+
+def require_rag_task_run(request: Request) -> AuthContext:
+    return _require_permission_or_legacy_rag_write(request, "tasks.run")
 
 
 def _db_path(request: Request) -> str:
@@ -376,7 +384,7 @@ def api_create_index_task(
     kb_id: str,
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_rag_write),
+    _auth: AuthContext = Depends(require_rag_task_run),
 ):
     try:
         result, status_code = create_index_task(

--- a/ai_actuarial/api/routers/rag_admin.py
+++ b/ai_actuarial/api/routers/rag_admin.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import os
+import secrets
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from ..deps import AuthContext, require_permissions
+from ai_actuarial.config import settings
+
+from ..deps import AuthContext, get_auth_context, require_permissions
 from ..services.rag_admin import (
     RagAdminError,
     add_knowledge_base_files,
@@ -33,6 +38,43 @@ from ..services.rag_admin import (
 )
 
 router = APIRouter()
+
+
+def _presented_token(request: Request) -> str | None:
+    auth = request.headers.get("Authorization", "") or ""
+    parts = auth.strip().split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip()
+    token = request.headers.get("X-API-Token") or request.headers.get("X-Auth-Token")
+    return token.strip() if token else None
+
+
+def _legacy_rag_write_context(request: Request) -> AuthContext | None:
+    expected = os.getenv("CONFIG_WRITE_AUTH_TOKEN") or settings.CONFIG_WRITE_AUTH_TOKEN
+    presented = _presented_token(request)
+    if not expected or not presented or not secrets.compare_digest(presented, expected):
+        return None
+    return AuthContext(
+        token={
+            "id": None,
+            "subject": "legacy-config-write-token",
+            "group_name": "legacy_config_write",
+            "is_active": True,
+        },
+        permissions=frozenset({"catalog.write", "config.write", "tasks.run", "tasks.view"}),
+    )
+
+
+def require_rag_write(request: Request) -> AuthContext:
+    context = get_auth_context(request)
+    if context.token and "catalog.write" in context.permissions:
+        return context
+    legacy_context = _legacy_rag_write_context(request)
+    if legacy_context:
+        return legacy_context
+    if not context.token:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    raise HTTPException(status_code=403, detail="Forbidden")
 
 
 def _db_path(request: Request) -> str:
@@ -68,7 +110,7 @@ def api_create_chunk_profile(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        result = create_chunk_profile(db_path=_db_path(request), payload=payload, headers=dict(request.headers))
+        result = create_chunk_profile(db_path=_db_path(request), payload=payload, headers=dict(request.headers), auth=_auth)
         return JSONResponse(status_code=201, content=result)
     except RagAdminError as exc:
         return _error_response(exc)
@@ -82,7 +124,7 @@ def api_update_chunk_profile(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        return update_chunk_profile(db_path=_db_path(request), profile_id=profile_id, payload=payload, headers=dict(request.headers))
+        return update_chunk_profile(db_path=_db_path(request), profile_id=profile_id, payload=payload, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -94,7 +136,7 @@ def api_delete_chunk_profile(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        return delete_chunk_profile(db_path=_db_path(request), profile_id=profile_id, headers=dict(request.headers))
+        return delete_chunk_profile(db_path=_db_path(request), profile_id=profile_id, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -106,7 +148,7 @@ def api_chunk_sets_cleanup(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        return cleanup_chunk_sets(db_path=_db_path(request), payload=payload, headers=dict(request.headers))
+        return cleanup_chunk_sets(db_path=_db_path(request), payload=payload, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -126,10 +168,10 @@ def api_list_knowledge_bases(
 def api_create_knowledge_base(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
-        result = create_knowledge_base(db_path=_db_path(request), payload=payload, headers=dict(request.headers))
+        result = create_knowledge_base(db_path=_db_path(request), payload=payload, headers=dict(request.headers), auth=_auth)
         return JSONResponse(status_code=201, content=result)
     except RagAdminError as exc:
         return _error_response(exc)
@@ -152,10 +194,10 @@ def api_update_knowledge_base(
     kb_id: str,
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
-        return update_knowledge_base(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+        return update_knowledge_base(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -164,10 +206,10 @@ def api_update_knowledge_base(
 def api_delete_knowledge_base(
     kb_id: str,
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
-        return delete_knowledge_base(db_path=_db_path(request), kb_id=kb_id, headers=dict(request.headers))
+        return delete_knowledge_base(db_path=_db_path(request), kb_id=kb_id, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -201,10 +243,10 @@ def api_add_knowledge_base_files(
     kb_id: str,
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
-        return add_knowledge_base_files(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+        return add_knowledge_base_files(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -214,10 +256,10 @@ def api_remove_knowledge_base_file(
     kb_id: str,
     file_url: str,
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
-        return remove_knowledge_base_file(db_path=_db_path(request), kb_id=kb_id, file_url=file_url, headers=dict(request.headers))
+        return remove_knowledge_base_file(db_path=_db_path(request), kb_id=kb_id, file_url=file_url, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -225,7 +267,7 @@ def api_remove_knowledge_base_file(
 @router.get("/rag/categories/unmapped")
 def api_unmapped_categories(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
         return get_unmapped_categories(db_path=_db_path(request))
@@ -236,7 +278,7 @@ def api_unmapped_categories(
 @router.get("/rag/categories/mapping")
 def api_categories_mapping(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
         return get_categories_mapping(db_path=_db_path(request))
@@ -248,7 +290,7 @@ def api_categories_mapping(
 def api_category_stats(
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
         return get_category_stats(db_path=_db_path(request), payload=payload)
@@ -259,7 +301,7 @@ def api_category_stats(
 @router.get("/rag/files/selectable")
 def api_selectable_files(
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
         return list_selectable_files(db_path=_db_path(request), query=request.query_params)
@@ -284,10 +326,10 @@ def api_set_kb_categories(
     kb_id: str,
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
-        return set_knowledge_base_categories(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+        return set_knowledge_base_categories(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -309,10 +351,10 @@ def api_bind_chunk_sets(
     kb_id: str,
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
-        return bind_chunk_sets(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers))
+        return bind_chunk_sets(db_path=_db_path(request), kb_id=kb_id, payload=payload, headers=dict(request.headers), auth=_auth)
     except RagAdminError as exc:
         return _error_response(exc)
 
@@ -321,7 +363,7 @@ def api_bind_chunk_sets(
 def api_get_kb_bindings(
     kb_id: str,
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("config.write")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
         return get_kb_bindings(db_path=_db_path(request), kb_id=kb_id)
@@ -334,7 +376,7 @@ def api_create_index_task(
     kb_id: str,
     payload: dict[str, object],
     request: Request,
-    _auth: AuthContext = Depends(require_permissions("tasks.run")),
+    _auth: AuthContext = Depends(require_rag_write),
 ):
     try:
         result, status_code = create_index_task(
@@ -343,6 +385,7 @@ def api_create_index_task(
             payload=payload,
             headers=dict(request.headers),
             bridge_state=_bridge_state(request),
+            auth=_auth,
         )
         return JSONResponse(status_code=status_code, content=result)
     except RagAdminError as exc:

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -399,7 +399,16 @@ def _build_kb_embedding_status(
 
 
 
-def _require_config_write_token(headers: Mapping[str, str]) -> None:
+def _request_already_authorized(auth: Any | None) -> bool:
+    if auth is None or not getattr(auth, "token", None):
+        return False
+    permissions = getattr(auth, "permissions", frozenset())
+    return bool({"catalog.write", "config.write", "tasks.run"} & set(permissions))
+
+
+def _require_config_write_token(headers: Mapping[str, str], auth: Any | None = None) -> None:
+    if _request_already_authorized(auth):
+        return
     expected_token = os.getenv("CONFIG_WRITE_AUTH_TOKEN") or settings.CONFIG_WRITE_AUTH_TOKEN
     if not expected_token:
         return
@@ -418,8 +427,8 @@ def list_chunk_profiles(*, db_path: str) -> dict[str, Any]:
 
 
 
-def create_chunk_profile(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def create_chunk_profile(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
     name = _norm(payload.get("name"))
@@ -450,8 +459,8 @@ def create_chunk_profile(*, db_path: str, payload: dict[str, Any], headers: Mapp
 
 
 
-def delete_chunk_profile(*, db_path: str, profile_id: str, headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def delete_chunk_profile(*, db_path: str, profile_id: str, headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     normalized_profile_id = _norm(profile_id)
     if not normalized_profile_id:
         raise RagAdminError("profile_id is required")
@@ -465,8 +474,8 @@ def delete_chunk_profile(*, db_path: str, profile_id: str, headers: Mapping[str,
         storage.close()
 
 
-def update_chunk_profile(*, db_path: str, profile_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def update_chunk_profile(*, db_path: str, profile_id: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     normalized_profile_id = _norm(profile_id)
     if not normalized_profile_id:
         raise RagAdminError("profile_id is required")
@@ -679,8 +688,8 @@ def list_knowledge_bases(*, db_path: str, query: Mapping[str, Any]) -> dict[str,
 
 
 
-def create_knowledge_base(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def create_knowledge_base(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
     kb_id = _kb_id(payload.get("kb_id"))
@@ -795,8 +804,8 @@ def get_knowledge_base(*, db_path: str, kb_id: str) -> dict[str, Any]:
 
 
 
-def update_knowledge_base(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def update_knowledge_base(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     kid = _kb_id(kb_id)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
@@ -816,8 +825,8 @@ def update_knowledge_base(*, db_path: str, kb_id: str, payload: dict[str, Any], 
 
 
 
-def delete_knowledge_base(*, db_path: str, kb_id: str, headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def delete_knowledge_base(*, db_path: str, kb_id: str, headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     kid = _kb_id(kb_id)
     _KnowledgeBase, manager, storage = _manager_and_storage(db_path)
     try:
@@ -921,8 +930,8 @@ def list_knowledge_base_files(*, db_path: str, kb_id: str, query: Mapping[str, A
 
 
 
-def add_knowledge_base_files(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def add_knowledge_base_files(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     kid = _kb_id(kb_id)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
@@ -966,8 +975,8 @@ def add_knowledge_base_files(*, db_path: str, kb_id: str, payload: dict[str, Any
 
 
 
-def remove_knowledge_base_file(*, db_path: str, kb_id: str, file_url: str, headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def remove_knowledge_base_file(*, db_path: str, kb_id: str, file_url: str, headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     kid = _kb_id(kb_id)
     normalized_file_url = _norm(file_url)
     if not normalized_file_url:
@@ -1152,8 +1161,8 @@ def get_knowledge_base_categories(*, db_path: str, kb_id: str) -> dict[str, Any]
 
 
 
-def set_knowledge_base_categories(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def set_knowledge_base_categories(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     kid = _kb_id(kb_id)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
@@ -1265,8 +1274,8 @@ def get_pending_files(*, db_path: str, kb_id: str) -> dict[str, Any]:
 
 
 
-def bind_chunk_sets(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def bind_chunk_sets(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     kid = _kb_id(kb_id)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
@@ -1333,8 +1342,8 @@ def bind_chunk_sets(*, db_path: str, kb_id: str, payload: dict[str, Any], header
 
 
 
-def create_index_task(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str], bridge_state: Any) -> tuple[dict[str, Any], int]:
-    _require_config_write_token(headers)
+def create_index_task(*, db_path: str, kb_id: str, payload: dict[str, Any], headers: Mapping[str, str], bridge_state: Any, auth: Any | None = None) -> tuple[dict[str, Any], int]:
+    _require_config_write_token(headers, auth)
     kid = _kb_id(kb_id)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
@@ -1454,8 +1463,8 @@ def create_index_task(*, db_path: str, kb_id: str, payload: dict[str, Any], head
 
 
 
-def cleanup_chunk_sets(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str]) -> dict[str, Any]:
-    _require_config_write_token(headers)
+def cleanup_chunk_sets(*, db_path: str, payload: dict[str, Any], headers: Mapping[str, str], auth: Any | None = None) -> dict[str, Any]:
+    _require_config_write_token(headers, auth)
     if not isinstance(payload, dict):
         raise RagAdminError("Invalid JSON body")
     older_than_days = parse_int_clamped(payload.get("older_than_days") or 30, default=30, min_value=1, max_value=3650)

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import yaml
 from fastapi.testclient import TestClient
+from itsdangerous import URLSafeSerializer
 
 from ai_actuarial.api.app import create_app
 from ai_actuarial.storage import Storage
@@ -42,7 +43,7 @@ def _write_config_files(base_dir: Path) -> tuple[Path, Path, Path, Path]:
 
 
 
-def _seed_storage(db_path: Path, files_dir: Path) -> dict[str, str]:
+def _seed_storage(db_path: Path, files_dir: Path) -> dict[str, object]:
     alpha_path = files_dir / "alpha.pdf"
     alpha_path.write_bytes(PDF_BYTES)
     beta_path = files_dir / "beta.pdf"
@@ -116,14 +117,40 @@ def _seed_storage(db_path: Path, files_dir: Path) -> dict[str, str]:
             token_hash=hashlib.sha256(admin_token.encode("utf-8")).hexdigest(),
             is_active=True,
         )
+        registered_user_id = storage.create_user(
+            "registered@example.com",
+            "registered-password-hash",
+            role="registered",
+            display_name="Registered",
+        )
+        operator_user_id = storage.create_user(
+            "operator@example.com",
+            "operator-password-hash",
+            role="operator",
+            display_name="Operator",
+        )
+        admin_user_id = storage.create_user(
+            "admin@example.com",
+            "admin-password-hash",
+            role="admin",
+            display_name="Admin",
+        )
     finally:
         storage.close()
 
-    return {"alpha_url": alpha_url, "beta_url": beta_url, "operator_token": operator_token, "admin_token": admin_token}
+    return {
+        "alpha_url": alpha_url,
+        "beta_url": beta_url,
+        "operator_token": operator_token,
+        "admin_token": admin_token,
+        "registered_user_id": registered_user_id,
+        "operator_user_id": operator_user_id,
+        "admin_user_id": admin_user_id,
+    }
 
 
 
-def _build_test_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, object, dict[str, str]]:
+def _build_test_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, object, dict[str, object]]:
     db_path, config_path, categories_path, files_dir = _write_config_files(tmp_path)
     seed = _seed_storage(db_path, files_dir)
     monkeypatch.setenv("CONFIG_PATH", str(config_path))
@@ -135,6 +162,11 @@ def _build_test_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, object,
     client = TestClient(app)
     client.headers.update({"X-Auth-Token": seed["admin_token"]})
     return client, app, seed
+
+
+def _make_session_cookie(app, payload: dict[str, object]) -> str:
+    serializer = URLSafeSerializer(app.state.fastapi_session_secret, salt="fastapi-session")
+    return serializer.dumps(payload)
 
 
 
@@ -217,6 +249,97 @@ def test_fastapi_rag_admin_read_routes_require_task_or_config_permissions(tmp_pa
 
     admin_headers = {"X-Auth-Token": seed["admin_token"]}
     assert client.get("/api/chunk/profiles", headers=admin_headers).status_code == 200
+
+
+def test_fastapi_rag_admin_kb_writes_accept_admin_operator_sessions_with_legacy_token_configured(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("CONFIG_WRITE_AUTH_TOKEN", "legacy-config-token")
+    client, app, seed = _build_test_client(tmp_path, monkeypatch)
+    client.headers.clear()
+    app.state.start_background_task = lambda *args, **kwargs: "task-session-rag-index"
+
+    anonymous = client.post(
+        "/api/rag/knowledge-bases",
+        json={"kb_id": "kb-anonymous-denied", "name": "Anonymous Denied", "kb_mode": "manual"},
+    )
+    assert anonymous.status_code == 401
+
+    cookie_name = app.state.fastapi_session_cookie_name
+    client.cookies.set(
+        cookie_name,
+        _make_session_cookie(app, {"email_user_id": seed["registered_user_id"]}),
+    )
+    registered = client.post(
+        "/api/rag/knowledge-bases",
+        json={"kb_id": "kb-registered-denied", "name": "Registered Denied", "kb_mode": "manual"},
+    )
+    assert registered.status_code == 403
+
+    client.cookies.clear()
+    client.cookies.set(
+        cookie_name,
+        _make_session_cookie(app, {"email_user_id": seed["operator_user_id"]}),
+    )
+    operator_create = client.post(
+        "/api/rag/knowledge-bases",
+        json={"kb_id": "kb-session-operator", "name": "Operator Session KB", "kb_mode": "manual"},
+    )
+    assert operator_create.status_code == 201, operator_create.text
+
+    operator_add_file = client.post(
+        "/api/rag/knowledge-bases/kb-session-operator/files",
+        json={"file_urls": [seed["alpha_url"]]},
+    )
+    assert operator_add_file.status_code == 200, operator_add_file.text
+
+    operator_categories = client.post(
+        "/api/rag/knowledge-bases/kb-session-operator/categories",
+        json={"categories": ["AI"], "action": "replace"},
+    )
+    assert operator_categories.status_code == 200, operator_categories.text
+
+    operator_index = client.post(
+        "/api/rag/knowledge-bases/kb-session-operator/index",
+        json={"file_urls": [seed["alpha_url"]]},
+    )
+    assert operator_index.status_code == 202, operator_index.text
+
+    client.cookies.clear()
+    client.cookies.set(
+        cookie_name,
+        _make_session_cookie(app, {"email_user_id": seed["admin_user_id"]}),
+    )
+    admin_update = client.put(
+        "/api/rag/knowledge-bases/kb-session-operator",
+        json={"name": "Admin Updated KB"},
+    )
+    assert admin_update.status_code == 200, admin_update.text
+
+    admin_delete = client.delete("/api/rag/knowledge-bases/kb-session-operator")
+    assert admin_delete.status_code == 200, admin_delete.text
+
+
+def test_fastapi_rag_admin_kb_writes_preserve_legacy_config_token_access(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CONFIG_WRITE_AUTH_TOKEN", "legacy-config-token")
+    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+    client.headers.clear()
+
+    legacy = client.post(
+        "/api/rag/knowledge-bases",
+        json={"kb_id": "kb-legacy-token", "name": "Legacy Token KB", "kb_mode": "manual"},
+        headers={"X-Auth-Token": "legacy-config-token"},
+    )
+
+    assert legacy.status_code == 201, legacy.text
+
+    unrelated_config_write = client.post(
+        "/api/config/backend-settings",
+        json={"defaults": {"max_pages": 12}},
+        headers={"X-Auth-Token": "legacy-config-token"},
+    )
+    assert unrelated_config_write.status_code == 401
 
 
 def test_fastapi_rag_admin_categories_mapping_uses_catalog_items_without_legacy_table(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 import yaml
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from itsdangerous import URLSafeSerializer
 
 from ai_actuarial.api.app import create_app
+from ai_actuarial.api.routers import rag_admin as rag_admin_router
 from ai_actuarial.storage import Storage
 
 PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
@@ -167,6 +171,39 @@ def _build_test_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, object,
 def _make_session_cookie(app, payload: dict[str, object]) -> str:
     serializer = URLSafeSerializer(app.state.fastapi_session_secret, salt="fastapi-session")
     return serializer.dumps(payload)
+
+
+def test_rag_index_auth_preserves_tasks_run_permission_boundary(monkeypatch) -> None:
+    request = SimpleNamespace(headers={})
+
+    monkeypatch.setattr(
+        rag_admin_router,
+        "get_auth_context",
+        lambda _request: rag_admin_router.AuthContext(
+            token={"subject": "catalog-only"},
+            permissions=frozenset({"catalog.write"}),
+        ),
+    )
+
+    assert rag_admin_router.require_rag_write(request).token["subject"] == "catalog-only"
+    with pytest.raises(HTTPException) as exc_info:
+        rag_admin_router.require_rag_task_run(request)
+    assert exc_info.value.status_code == 403
+
+
+def test_rag_task_auth_preserves_legacy_config_token_fallback(monkeypatch) -> None:
+    request = SimpleNamespace(headers={"X-Auth-Token": "legacy-config-token"})
+    monkeypatch.setenv("CONFIG_WRITE_AUTH_TOKEN", "legacy-config-token")
+    monkeypatch.setattr(
+        rag_admin_router,
+        "get_auth_context",
+        lambda _request: rag_admin_router.AuthContext(token=None, permissions=frozenset()),
+    )
+
+    auth = rag_admin_router.require_rag_task_run(request)
+
+    assert auth.token["subject"] == "legacy-config-write-token"
+    assert "tasks.run" in auth.permissions
 
 
 


### PR DESCRIPTION
## Summary
- Fix RAG knowledge-base write endpoints so logged-in admin/operator sessions can manage KBs when `CONFIG_WRITE_AUTH_TOKEN` is configured.
- Keep legacy `X-Auth-Token` compatibility scoped to RAG write endpoints instead of promoting it into global auth.
- Add focused tests for admin/operator success, registered/anonymous denial, legacy RAG token access, and unrelated config-write denial.

## Verification
- `git diff --check`
- `python -m pytest tests/test_fastapi_rag_admin_endpoints.py -q` — 16 passed
- `python -m pytest tests/test_fastapi_auth_endpoints.py tests/test_fastapi_ops_write_endpoints.py -q` — 37 passed
- Independent delegate review: PASS
- Codex CLI pre-PR review: PASS
