### PR TITLE
fix: chat retrieval returns zero results due to broken similarity score

### DIFF
--- a/ai_actuarial/chatbot/retrieval.py
+++ b/ai_actuarial/chatbot/retrieval.py
@@ -182,7 +182,7 @@ class RAGRetriever:
             formatted_results.append({
                 'content': metadata.get('content', ''),
                 'metadata': {
-                    'filename': metadata.get('filename', 'unknown'),
+                    'filename': metadata.get('filename') or metadata.get('title') or 'unknown',
                     'kb_id': kb_id,
                     'kb_name': kb.name,
                     'similarity_score': result['score'],

--- a/ai_actuarial/rag/vector_store.py
+++ b/ai_actuarial/rag/vector_store.py
@@ -261,11 +261,10 @@ class VectorStore:
             # neighbors just below deleted hits can still be returned.
             distances, indices = self.index.search(query_vector, search_k)
             
-            # Convert distances to similarity scores (L2 distance to cosine-like score)
-            # Lower distance = higher similarity
-            # Normalize to 0-1 range approximately
-            max_distance = np.max(distances) if np.max(distances) > 0 else 1.0
-            similarities = 1.0 - (distances / (max_distance + 1e-8))
+            # Convert L2 distances to cosine similarity (unit-normalized vectors).
+            # For unit vectors: cos(u,v) = 1 - ||u-v||^2 / 2
+            # OpenAI / text-embedding-* outputs are L2-normalized.
+            similarities = 1.0 - (distances ** 2 / 2.0)
             
             # Build results
             results = []


### PR DESCRIPTION
## Summary

Two bugfixes that were preventing chat retrieval from working at all:

### 1. Fix similarity score: L2-distance normalization → cosine similarity

**Root cause:** `VectorStore.search()` used `1.0 - (distances / max_distance)` to convert FAISS L2 distances to 0-1 similarity scores. With unit-normalized OpenAI embeddings, L2 distances are small (~0.7), the max-distance normalization compresses all scores to ~0.0-0.08 — well below the default 0.4 threshold. **Every query returned zero results.**

**Fix:** Use the correct cosine similarity conversion for unit vectors: `1 - d²/2`. Scores now correctly reflect semantic closeness (0.68-0.78 for top matches).

### 2. Fix citation filename: fallback to `title` field

**Root cause:** FAISS metadata stores document names in a `title` field, but `RAGRetriever._retrieve_from_kb()` only looked for `filename`. All citations showed "unknown".

**Fix:** Use `metadata.get('filename') or metadata.get('title')` as fallback.

## Test Plan

- [x] Chat query returns chunks (was 0 before fix)
- [x] Citations show document titles (was "unknown")
- [x] Verified with KB "all" (13978 chunks) and "AI" (4325 chunks)
