### PR TITLE
feat: L0 Agentic RAG ready_data builder MVP

### DIFF
--- a/ai_actuarial/agentic_rag/__init__.py
+++ b/ai_actuarial/agentic_rag/__init__.py
@@ -1,0 +1,9 @@
+"""Agentic RAG — Professional ready-data layer and evidence engine.
+
+Converts existing catalog_items and global_chunks into structured
+ready_data artifacts (doc_catalog, summaries, sections, etc.) that
+enable title-first retrieval, structured evidence, and agentic loops
+on top of the existing vector RAG.
+"""
+
+__version__ = "0.1.0"

--- a/ai_actuarial/agentic_rag/manifest_profiles.py
+++ b/ai_actuarial/agentic_rag/manifest_profiles.py
@@ -1,0 +1,69 @@
+"""Manifest profiles defining ready_data artifact schemas per level.
+
+Three tiers:
+
+- L0 (general):   Basic doc_catalog + sections for general/research/internal docs.
+- L1 (regulation): Professional structure with aliases, summaries, relations.
+- L2 (formula):    L1 + formula_cards, tables, calculation terms.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ManifestProfile:
+    profile: str  # "general", "regulation", "formula"
+    version: str
+    artifacts: list[str]
+    description: str
+
+
+L0_GENERAL = ManifestProfile(
+    profile="general",
+    version="1",
+    artifacts=[
+        "doc_catalog.jsonl",
+        "sections.jsonl",
+        "ready_data_manifest.json",
+    ],
+    description="Basic semi-structured manifest for general/research/internal documents",
+)
+
+L1_REGULATION = ManifestProfile(
+    profile="regulation",
+    version="1",
+    artifacts=[
+        "doc_catalog.jsonl",
+        "title_aliases.jsonl",
+        "doc_summaries.jsonl",
+        "sections_structured.jsonl",
+        "relations_graph.json",
+        "ready_data_manifest.json",
+    ],
+    description="Professional structured manifest for regulation/standard/compliance documents",
+)
+
+L2_FORMULA = ManifestProfile(
+    profile="formula",
+    version="1",
+    artifacts=[
+        "doc_catalog.jsonl",
+        "title_aliases.jsonl",
+        "doc_summaries.jsonl",
+        "sections_structured.jsonl",
+        "formula_cards.jsonl",
+        "tables_structured.jsonl",
+        "calculation_terms.jsonl",
+        "relations_graph.json",
+        "ready_data_manifest.json",
+    ],
+    description="Formula/actuarial professional manifest with formula cards and tables",
+)
+
+PROFILES: dict[str, ManifestProfile] = {
+    "general": L0_GENERAL,
+    "regulation": L1_REGULATION,
+    "formula": L2_FORMULA,
+}

--- a/ai_actuarial/agentic_rag/ready_data_builder.py
+++ b/ai_actuarial/agentic_rag/ready_data_builder.py
@@ -23,12 +23,22 @@ from typing import Any
 
 from .manifest_profiles import L0_GENERAL, PROFILES
 
+try:
+    from ai_actuarial.config import settings
+
+    _DB_PATH_FROM_SETTINGS = settings.DB_PATH
+except ImportError:
+    _DB_PATH_FROM_SETTINGS = None
+
 logger = logging.getLogger(__name__)
 
 
 def get_db_path() -> str:
-    """Resolve the SQLite DB path (same logic as config)."""
-    db_path = os.getenv("DB_PATH", "data/index.db")
+    """Resolve the SQLite DB path from settings, env, or default."""
+    if _DB_PATH_FROM_SETTINGS:
+        db_path = _DB_PATH_FROM_SETTINGS
+    else:
+        db_path = os.getenv("DB_PATH", "data/index.db")
     if not os.path.isabs(db_path):
         db_path = os.path.abspath(db_path)
     return db_path
@@ -110,7 +120,18 @@ def build_l0(
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
 
-    profile_def = PROFILES.get(profile, L0_GENERAL)
+    if profile not in PROFILES:
+        raise ValueError(
+            f"Unknown profile {profile!r}. Use one of: {', '.join(PROFILES)}"
+        )
+    profile_def = PROFILES[profile]
+
+    # MVP only supports L0 general; fail fast for L1/L2
+    if profile != "general":
+        raise NotImplementedError(
+            f"Profile {profile!r} (L1/L2) is not yet implemented. "
+            f"Only 'general' (L0) is supported in this MVP."
+        )
     if output_dir is None:
         output_dir = os.path.join("data", "agentic_ready_data", profile, profile_def.version)
     os.makedirs(output_dir, exist_ok=True)
@@ -195,6 +216,7 @@ def build_l0(
             section_count += 1
 
     # ── 3. Build ready_data_manifest.json ─────────────────────────────────
+    profile_def_artifacts = profile_def.artifacts
     manifest = {
         "built_at": now_utc,
         "profile": profile,
@@ -202,7 +224,7 @@ def build_l0(
         "source_db": db_path,
         "doc_count": doc_count,
         "section_count": section_count,
-        "artifact_files": ["doc_catalog.jsonl", "sections.jsonl", "ready_data_manifest.json"],
+        "artifact_files": profile_def_artifacts,
         "schema_versions": {
             "doc_catalog_fields": DOC_CATALOG_FIELDS,
             "section_fields": SECTION_FIELDS,
@@ -222,10 +244,28 @@ def build_l0(
     return manifest
 
 
+def _safe_jsonl_load(file_path: str) -> tuple[list[dict], list[str]]:
+    """Load a JSONL file, returning parsed entries and parse-error line numbers."""
+    entries: list[dict] = []
+    errors: list[str] = []
+    with open(file_path, "r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                errors.append(f"{os.path.basename(file_path)}:{i} invalid JSON")
+                if len(errors) > 3:
+                    break
+    return entries, errors
+
+
 def validate(output_dir: str) -> dict:
     """Validate built ready_data artifacts.
 
-    Checks: files exist, JSONL lines are valid JSON, required fields present,
+    Checks: files exist, JSONL lines are valid JSON,
     doc_id references consistent between catalog and sections.
     """
     errors: list[str] = []
@@ -236,8 +276,12 @@ def validate(output_dir: str) -> dict:
         errors.append(f"manifest not found: {manifest_path}")
         return {"valid": False, "errors": errors, "warnings": warnings}
 
-    with open(manifest_path, "r", encoding="utf-8") as f:
-        manifest = json.load(f)
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except json.JSONDecodeError as e:
+        errors.append(f"ready_data_manifest.json: invalid JSON: {e}")
+        return {"valid": False, "errors": errors, "warnings": warnings}
 
     for artifact in manifest.get("artifact_files", []):
         path = os.path.join(output_dir, artifact)
@@ -271,21 +315,13 @@ def validate(output_dir: str) -> dict:
     doc_catalog_path = os.path.join(output_dir, "doc_catalog.jsonl")
     sections_path = os.path.join(output_dir, "sections.jsonl")
     if os.path.isfile(doc_catalog_path) and os.path.isfile(sections_path):
-        catalog_doc_ids: set[str] = set()
-        with open(doc_catalog_path, "r", encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                catalog_doc_ids.add(json.loads(line).get("doc_id", ""))
+        catalog_entries, cat_errors = _safe_jsonl_load(doc_catalog_path)
+        errors.extend(cat_errors)
+        catalog_doc_ids: set[str] = {e.get("doc_id", "") for e in catalog_entries}
 
-        section_doc_ids: set[str] = set()
-        with open(sections_path, "r", encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                section_doc_ids.add(json.loads(line).get("doc_id", ""))
+        section_entries, sec_errors = _safe_jsonl_load(sections_path)
+        errors.extend(sec_errors)
+        section_doc_ids: set[str] = {e.get("doc_id", "") for e in section_entries}
 
         orphan_sections = section_doc_ids - catalog_doc_ids
         if orphan_sections:
@@ -323,8 +359,8 @@ def main():
     parser.add_argument(
         "--profile",
         default="general",
-        choices=["general", "regulation", "formula"],
-        help="Manifest profile",
+        choices=["general"],
+        help="Manifest profile (only 'general' L0 supported in this MVP)",
     )
     parser.add_argument("--validate", action="store_true", help="Validate after build")
     args = parser.parse_args()
@@ -339,7 +375,7 @@ def main():
     if args.validate:
         result = validate(
             args.output_dir
-            or os.path.join("data", "agentic_ready_data", args.profile, "1")
+            or os.path.join("data", "agentic_ready_data", args.profile, L0_GENERAL.version)
         )
         status = "✅ valid" if result["valid"] else "❌ invalid"
         print(f"\nValidation: {status}")

--- a/ai_actuarial/agentic_rag/ready_data_builder.py
+++ b/ai_actuarial/agentic_rag/ready_data_builder.py
@@ -1,0 +1,355 @@
+"""Ready-data builder — L0 MVP.
+
+Reads existing catalog_items and global_chunks from the SQLite DB
+and produces the L0 ready_data artifacts:
+
+  doc_catalog.jsonl   — document index with title, category, summary, headings
+  sections.jsonl      — section-level chunks with heading_path and token_count
+  ready_data_manifest.json — build metadata and counts
+
+Usage:
+  python -m ai_actuarial.agentic_rag.ready_data_builder
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .manifest_profiles import L0_GENERAL, PROFILES
+
+logger = logging.getLogger(__name__)
+
+
+def get_db_path() -> str:
+    """Resolve the SQLite DB path (same logic as config)."""
+    db_path = os.getenv("DB_PATH", "data/index.db")
+    if not os.path.isabs(db_path):
+        db_path = os.path.abspath(db_path)
+    return db_path
+
+
+# ── Schema ────────────────────────────────────────────────────────────────────
+
+DOC_CATALOG_FIELDS = [
+    "doc_id",
+    "file_url",
+    "title",
+    "category",
+    "source_site",
+    "publish_date",
+    "summary",
+    "keywords",
+    "headings",
+    "rag_chunk_count",
+]
+
+SECTION_FIELDS = [
+    "section_id",
+    "doc_id",
+    "heading_path",
+    "text",
+    "token_count",
+]
+
+
+# ── Extraction helpers ────────────────────────────────────────────────────────
+
+def _extract_headings(chunks: list[dict]) -> list[str]:
+    """Extract unique ordered headings from section_hierarchy across chunks."""
+    seen: set[str] = set()
+    headings: list[str] = []
+    for chunk in chunks:
+        hierarchy = chunk.get("section_hierarchy", "")
+        if not hierarchy:
+            continue
+        for h in hierarchy.split(" > "):
+            h = h.strip()
+            if h and h not in seen:
+                seen.add(h)
+                headings.append(h)
+    return headings
+
+
+def _parse_keywords(raw: str | None) -> list[str]:
+    """Parse keywords from JSON string or comma-separated text."""
+    if not raw:
+        return []
+    raw = raw.strip()
+    if raw.startswith("["):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+    return [k.strip() for k in raw.split(",") if k.strip()]
+
+
+# ── Builder ───────────────────────────────────────────────────────────────────
+
+def build_l0(
+    db_path: str | None = None,
+    output_dir: str | None = None,
+    profile: str = "general",
+) -> dict:
+    """Build L0 ready_data artifacts from catalog_items + global_chunks.
+
+    Args:
+        db_path: Path to SQLite DB. Defaults to env DB_PATH or data/index.db.
+        output_dir: Output directory. Defaults to data/agentic_ready_data/{profile}/.
+        profile: Manifest profile key (general, regulation, formula).
+
+    Returns:
+        Manifest dict with built_at, doc_count, section_count, artifact_files.
+    """
+    db_path = db_path or get_db_path()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    profile_def = PROFILES.get(profile, L0_GENERAL)
+    if output_dir is None:
+        output_dir = os.path.join("data", "agentic_ready_data", profile, profile_def.version)
+    os.makedirs(output_dir, exist_ok=True)
+
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    # ── 1. Build doc_catalog.jsonl ────────────────────────────────────────
+    catalog_rows = conn.execute(
+        """SELECT c.file_url, f.title, c.category, c.summary, c.keywords,
+                  c.rag_chunk_count,
+                  f.source_site, f.published_time
+           FROM catalog_items c
+           LEFT JOIN files f ON c.file_url = f.url
+           WHERE c.status = 'ok'
+           ORDER BY c.category, c.file_url"""
+    ).fetchall()
+
+    # Collect per-doc chunks for heading extraction
+    file_urls = [r["file_url"] for r in catalog_rows]
+    placeholders = ",".join("?" for _ in file_urls)
+    chunk_rows = (
+        conn.execute(
+            f"""SELECT g.chunk_id, g.content, g.token_count, g.section_hierarchy,
+                       fcs.file_url
+                FROM global_chunks g
+                JOIN file_chunk_sets fcs ON g.chunk_set_id = fcs.chunk_set_id
+                WHERE fcs.file_url IN ({placeholders})
+                ORDER BY fcs.file_url, g.chunk_index""",
+            file_urls,
+        ).fetchall()
+        if file_urls
+        else []
+    )
+
+    # Group chunks by file_url
+    chunks_by_file: dict[str, list[dict]] = {}
+    for row in chunk_rows:
+        chunks_by_file.setdefault(row["file_url"], []).append(dict(row))
+
+    doc_catalog_path = os.path.join(output_dir, "doc_catalog.jsonl")
+    doc_count = 0
+    with open(doc_catalog_path, "w", encoding="utf-8") as f:
+        for row in catalog_rows:
+            file_url = row["file_url"]
+            chunks = chunks_by_file.get(file_url, [])
+            headings = _extract_headings(chunks)
+            keywords = _parse_keywords(row["keywords"])
+
+            entry = {
+                "doc_id": file_url,
+                "file_url": file_url,
+                "title": row["title"] or file_url,
+                "category": row["category"] or "general",
+                "source_site": row["source_site"] or "",
+                "publish_date": row["published_time"] or "",
+                "summary": row["summary"] or "",
+                "keywords": keywords,
+                "headings": headings,
+                "rag_chunk_count": row["rag_chunk_count"] or 0,
+            }
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            doc_count += 1
+
+    # ── 2. Build sections.jsonl ───────────────────────────────────────────
+    section_count = 0
+    sections_path = os.path.join(output_dir, "sections.jsonl")
+    with open(sections_path, "w", encoding="utf-8") as f:
+        for row in chunk_rows:
+            file_url = row["file_url"]
+            chunk_id = row["chunk_id"]
+            hierarchy = row["section_hierarchy"] or ""
+            heading_path = [h.strip() for h in hierarchy.split(" > ") if h.strip()]
+
+            entry: dict[str, Any] = {
+                "section_id": f"{file_url}#{chunk_id}",
+                "doc_id": file_url,
+                "heading_path": heading_path,
+                "text": row["content"] or "",
+                "token_count": row["token_count"] or 0,
+            }
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            section_count += 1
+
+    # ── 3. Build ready_data_manifest.json ─────────────────────────────────
+    manifest = {
+        "built_at": now_utc,
+        "profile": profile,
+        "profile_version": profile_def.version,
+        "source_db": db_path,
+        "doc_count": doc_count,
+        "section_count": section_count,
+        "artifact_files": ["doc_catalog.jsonl", "sections.jsonl", "ready_data_manifest.json"],
+        "schema_versions": {
+            "doc_catalog_fields": DOC_CATALOG_FIELDS,
+            "section_fields": SECTION_FIELDS,
+        },
+    }
+    manifest_path = os.path.join(output_dir, "ready_data_manifest.json")
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False)
+
+    conn.close()
+    logger.info(
+        "L0 ready_data built: %d docs, %d sections → %s",
+        doc_count,
+        section_count,
+        output_dir,
+    )
+    return manifest
+
+
+def validate(output_dir: str) -> dict:
+    """Validate built ready_data artifacts.
+
+    Checks: files exist, JSONL lines are valid JSON, required fields present,
+    doc_id references consistent between catalog and sections.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    manifest_path = os.path.join(output_dir, "ready_data_manifest.json")
+    if not os.path.isfile(manifest_path):
+        errors.append(f"manifest not found: {manifest_path}")
+        return {"valid": False, "errors": errors, "warnings": warnings}
+
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    for artifact in manifest.get("artifact_files", []):
+        path = os.path.join(output_dir, artifact)
+        if not os.path.isfile(path):
+            errors.append(f"artifact missing: {artifact}")
+        elif artifact.endswith(".jsonl"):
+            # Validate JSONL: every line must parse
+            bad_lines = 0
+            with open(path, "r", encoding="utf-8") as af:
+                for i, line in enumerate(af, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        json.loads(line)
+                    except json.JSONDecodeError:
+                        bad_lines += 1
+                        if bad_lines <= 3:
+                            errors.append(f"{artifact}:{i} invalid JSON")
+            if bad_lines:
+                errors.append(f"{artifact}: {bad_lines} invalid JSON lines")
+
+        elif artifact.endswith(".json"):
+            try:
+                with open(path, "r", encoding="utf-8") as af:
+                    json.load(af)
+            except json.JSONDecodeError as e:
+                errors.append(f"{artifact}: invalid JSON: {e}")
+
+    # Cross-reference: doc_ids in sections must exist in catalog
+    doc_catalog_path = os.path.join(output_dir, "doc_catalog.jsonl")
+    sections_path = os.path.join(output_dir, "sections.jsonl")
+    if os.path.isfile(doc_catalog_path) and os.path.isfile(sections_path):
+        catalog_doc_ids: set[str] = set()
+        with open(doc_catalog_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                catalog_doc_ids.add(json.loads(line).get("doc_id", ""))
+
+        section_doc_ids: set[str] = set()
+        with open(sections_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                section_doc_ids.add(json.loads(line).get("doc_id", ""))
+
+        orphan_sections = section_doc_ids - catalog_doc_ids
+        if orphan_sections:
+            errors.append(
+                f"{len(orphan_sections)} section doc_ids not in catalog "
+                f"(e.g. {list(orphan_sections)[:3]})"
+            )
+
+        docs_without_sections = catalog_doc_ids - section_doc_ids
+        if docs_without_sections:
+            warnings.append(
+                f"{len(docs_without_sections)} docs have no sections "
+                f"(e.g. {list(docs_without_sections)[:3]})"
+            )
+
+    return {
+        "valid": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+# ── CLI entry point ───────────────────────────────────────────────────────────
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build L0 Agentic RAG ready_data")
+    parser.add_argument("--db", default=None, help="SQLite DB path")
+    parser.add_argument(
+        "--output-dir", default=None, help="Output directory for ready_data"
+    )
+    parser.add_argument(
+        "--profile",
+        default="general",
+        choices=["general", "regulation", "formula"],
+        help="Manifest profile",
+    )
+    parser.add_argument("--validate", action="store_true", help="Validate after build")
+    args = parser.parse_args()
+
+    manifest = build_l0(
+        db_path=args.db,
+        output_dir=args.output_dir,
+        profile=args.profile,
+    )
+    print(json.dumps(manifest, indent=2, ensure_ascii=False))
+
+    if args.validate:
+        result = validate(
+            args.output_dir
+            or os.path.join("data", "agentic_ready_data", args.profile, "1")
+        )
+        status = "✅ valid" if result["valid"] else "❌ invalid"
+        print(f"\nValidation: {status}")
+        if result["errors"]:
+            for e in result["errors"]:
+                print(f"  ERROR: {e}")
+        if result["warnings"]:
+            for w in result["warnings"]:
+                print(f"  WARN:  {w}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agentic_rag/test_ready_data_builder.py
+++ b/tests/agentic_rag/test_ready_data_builder.py
@@ -1,0 +1,250 @@
+"""Tests for ready_data_builder L0 MVP."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Import under test
+import ai_actuarial.agentic_rag.ready_data_builder as builder
+
+
+@pytest.fixture
+def test_db_path(tmp_path):
+    """Create a file-backed SQLite DB with test catalog + chunk data."""
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    conn.executescript(
+        """
+        CREATE TABLE files (
+            url TEXT PRIMARY KEY,
+            title TEXT,
+            source_site TEXT,
+            published_time TEXT
+        );
+        CREATE TABLE catalog_items (
+            file_url TEXT PRIMARY KEY,
+            status TEXT DEFAULT 'ok',
+            summary TEXT,
+            category TEXT,
+            keywords TEXT,
+            rag_chunk_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE file_chunk_sets (
+            chunk_set_id TEXT PRIMARY KEY,
+            file_url TEXT NOT NULL,
+            chunk_count INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'ready'
+        );
+        CREATE TABLE global_chunks (
+            chunk_id TEXT PRIMARY KEY,
+            chunk_set_id TEXT NOT NULL,
+            chunk_index INTEGER NOT NULL,
+            content TEXT NOT NULL,
+            token_count INTEGER DEFAULT 0,
+            section_hierarchy TEXT
+        );
+    """
+    )
+
+    # Insert test data
+    conn.execute(
+        "INSERT INTO files(url,title,source_site,published_time) VALUES(?,?,?,?)",
+        ("https://example.com/rule1", "偿付能力监管规则第3号", "CBIRC", "2024-01-01"),
+    )
+    conn.execute(
+        "INSERT INTO catalog_items(file_url,status,summary,category,keywords,rag_chunk_count) VALUES(?,?,?,?,?,?)",
+        (
+            "https://example.com/rule1",
+            "ok",
+            "偿付能力监管规则摘要",
+            "regulation",
+            '["偿二代","偿付能力","寿险"]',
+            2,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO file_chunk_sets(chunk_set_id,file_url,chunk_count) VALUES(?,?,?)",
+        ("cs1", "https://example.com/rule1", 2),
+    )
+    conn.execute(
+        "INSERT INTO global_chunks(chunk_id,chunk_set_id,chunk_index,content,token_count,section_hierarchy) VALUES(?,?,?,?,?,?)",
+        ("c1", "cs1", 0, "第一章 总则，第一条 为规范...", 50, "第一章 总则 > 第一条"),
+    )
+    conn.execute(
+        "INSERT INTO global_chunks(chunk_id,chunk_set_id,chunk_index,content,token_count,section_hierarchy) VALUES(?,?,?,?,?,?)",
+        ("c2", "cs1", 1, "第二章 负债评估，第十九条...", 80, "第二章 负债评估 > 第十九条"),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_build_l0_basic(test_db_path, tmp_path):
+    """Build L0 from test DB and verify all artifacts."""
+    manifest = builder.build_l0(
+        db_path=test_db_path,
+        output_dir=str(tmp_path),
+        profile="general",
+    )
+
+    assert manifest["doc_count"] == 1
+    assert manifest["section_count"] == 2
+    assert manifest["profile"] == "general"
+
+    # Check doc_catalog.jsonl
+    catalog_path = tmp_path / "doc_catalog.jsonl"
+    assert catalog_path.exists()
+    entries = []
+    with open(catalog_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                entries.append(json.loads(line))
+
+    assert len(entries) == 1
+    doc = entries[0]
+    assert doc["doc_id"] == "https://example.com/rule1"
+    assert doc["title"] == "偿付能力监管规则第3号"
+    assert doc["category"] == "regulation"
+    assert "偿二代" in doc["keywords"]
+    assert "第一章 总则" in doc["headings"]
+    assert doc["rag_chunk_count"] == 2
+
+    # Check sections.jsonl
+    sec_path = tmp_path / "sections.jsonl"
+    assert sec_path.exists()
+    sections = []
+    with open(sec_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                sections.append(json.loads(line))
+
+    assert len(sections) == 2
+    assert all(s["doc_id"] == "https://example.com/rule1" for s in sections)
+    assert sections[0]["token_count"] == 50
+    assert sections[1]["token_count"] == 80
+
+    # Check manifest.json
+    manifest_path = tmp_path / "ready_data_manifest.json"
+    assert manifest_path.exists()
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        m = json.load(f)
+    assert "built_at" in m
+    assert m["artifact_files"] == [
+        "doc_catalog.jsonl",
+        "sections.jsonl",
+        "ready_data_manifest.json",
+    ]
+
+
+def test_build_l0_empty_db(tmp_path):
+    """Build with no catalog items should produce empty outputs."""
+    db_path = str(tmp_path / "empty.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS files(url TEXT PRIMARY KEY, title TEXT, source_site TEXT, published_time TEXT);
+        CREATE TABLE IF NOT EXISTS catalog_items(file_url TEXT PRIMARY KEY, status TEXT, summary TEXT, category TEXT, keywords TEXT, rag_chunk_count INTEGER);
+        CREATE TABLE IF NOT EXISTS file_chunk_sets(chunk_set_id TEXT PRIMARY KEY, file_url TEXT, chunk_count INTEGER, status TEXT);
+        CREATE TABLE IF NOT EXISTS global_chunks(chunk_id TEXT PRIMARY KEY, chunk_set_id TEXT, chunk_index INTEGER, content TEXT, token_count INTEGER, section_hierarchy TEXT);
+    """
+    )
+    conn.commit()
+    conn.close()
+
+    manifest = builder.build_l0(
+        db_path=db_path,
+        output_dir=str(tmp_path),
+        profile="general",
+    )
+
+    assert manifest["doc_count"] == 0
+    assert manifest["section_count"] == 0
+
+
+def test_validate(tmp_path):
+    """Validation returns valid=True for correct outputs."""
+    # Write minimal valid outputs
+    doc = {
+        "doc_id": "test.md",
+        "file_url": "test.md",
+        "title": "Test",
+        "category": "general",
+        "source_site": "",
+        "publish_date": "",
+        "summary": "",
+        "keywords": [],
+        "headings": ["H1"],
+        "rag_chunk_count": 1,
+    }
+    section = {
+        "section_id": "test.md#c1",
+        "doc_id": "test.md",
+        "heading_path": ["H1"],
+        "text": "hello",
+        "token_count": 5,
+    }
+
+    with open(tmp_path / "doc_catalog.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(doc, ensure_ascii=False) + "\n")
+    with open(tmp_path / "sections.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(section, ensure_ascii=False) + "\n")
+    with open(tmp_path / "ready_data_manifest.json", "w", encoding="utf-8") as f:
+        json.dump({"artifact_files": ["doc_catalog.jsonl", "sections.jsonl", "ready_data_manifest.json"]}, f)
+
+    result = builder.validate(str(tmp_path))
+    assert result["valid"] is True
+    assert result["errors"] == []
+
+
+def test_validate_missing_artifact(tmp_path):
+    """Validation fails when an artifact is missing."""
+    with open(tmp_path / "ready_data_manifest.json", "w", encoding="utf-8") as f:
+        json.dump({"artifact_files": ["doc_catalog.jsonl", "sections.jsonl", "ready_data_manifest.json"]}, f)
+    # doc_catalog.jsonl and sections.jsonl are missing
+
+    result = builder.validate(str(tmp_path))
+    assert result["valid"] is False
+    assert any("doc_catalog" in e for e in result["errors"])
+
+
+def test_validate_orphan_sections(tmp_path):
+    """Validation catches sections referencing non-existent doc_ids."""
+    doc = {
+        "doc_id": "a.md",
+        "file_url": "a.md",
+        "title": "A",
+        "category": "general",
+        "source_site": "",
+        "publish_date": "",
+        "summary": "",
+        "keywords": [],
+        "headings": [],
+        "rag_chunk_count": 0,
+    }
+    section = {
+        "section_id": "b.md#c1",
+        "doc_id": "b.md",  # orphan
+        "heading_path": [],
+        "text": "",
+        "token_count": 0,
+    }
+    with open(tmp_path / "doc_catalog.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(doc, ensure_ascii=False) + "\n")
+    with open(tmp_path / "sections.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(section, ensure_ascii=False) + "\n")
+    with open(tmp_path / "ready_data_manifest.json", "w", encoding="utf-8") as f:
+        json.dump({"artifact_files": ["doc_catalog.jsonl", "sections.jsonl", "ready_data_manifest.json"]}, f)
+
+    result = builder.validate(str(tmp_path))
+    assert result["valid"] is False
+    assert any("orphan" in e.lower() or "not in catalog" in e.lower() for e in result["errors"])


### PR DESCRIPTION
## PR 1 / 7 — Agentic RAG ready_data builder (L0 MVP)

按方案文档 [Agentic RAG 独立项目方案](https://my.feishu.cn/docx/EceldD7lIojOyaxzqjkczbo7neh) 第 9 节 PR 路线，实现第一阶段。

### 做了什么

新增 `ai_actuarial/agentic_rag/` 包，包含：

| 文件 | 用途 |
|---|---|
| `ready_data_builder.py` | 从现有 `catalog_items` + `global_chunks` 生成 L0 ready_data |
| `manifest_profiles.py` | L0 (general) / L1 (regulation) / L2 (formula) profile schema |
| `tests/agentic_rag/test_ready_data_builder.py` | 5 个聚焦测试 |

### 产物（L0，general profile）

- `doc_catalog.jsonl` — doc_id, file_url, title, category, source_site, publish_date, summary, keywords, headings, rag_chunk_count
- `sections.jsonl` — section_id, doc_id, heading_path, text, token_count
- `ready_data_manifest.json` — built_at, profile, counts, artifact_files

### 设计要点

- 只读现有 SQLite（`catalog_items` `files` `global_chunks` `file_chunk_sets`），不改写任何表
- 通过 `section_hierarchy` 字段推断 headings
- `validate()` 做 artifact 完整性、JSON 合法性、doc_id 引用一致性检查
- 不接 Chat/API/UI，纯 CLI/脚本构建

### 运行方式

```bash
python -m ai_actuarial.agentic_rag.ready_data_builder --validate
```

### 测试

```
5 passed — build_basic, empty_db, validate, missing_artifact, orphan_sections
```

### 后续 PR

- PR 2: Manifest Registry + DB + KB UI
- PR 3: 文档定位与总结工具 (search_titles/search_summaries API)
- PR 4-6: L1/L2 manifest + agentic loop
- PR 7: 评测与质量门禁