### PR TITLE
chore: reconcile Agentic RAG roadmap status

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,11 +1,30 @@
 # Project Status
 
 - Date: 2026-06-14
-- Branch: `feat/agentic-rag-eval-scaffolding`
-- Baseline: `origin/main` at `3a0d5bd`.
-- Scope: PR0 — Agentic RAG eval scaffolding + 20 baseline retrieval cases (per 飞书方案文档 PR0 路线).
-- PR: https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134
+- Branch: `main`
+- Baseline: `origin/main` at `c9dea4b`.
+- Scope: Post-PR0/PR1 roadmap reconciliation; next implementation scope is PR2 — Manifest Registry + DB + KB UI.
+- PR: [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged 2026-06-14 12:27 UTC.
 - Previous PR: [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
+
+### Current State
+
+- Local `main` matches `origin/main` at merge commit `c9dea4b` (`Merge pull request #134 from ferryhe/feat/agentic-rag-eval-scaffolding`).
+- GitHub open PR list is empty; no PR2/PR3 branch or open PR was found.
+- Current plan position: PR0 is complete and merged; next implementation step is PR2.
+- Remote PR0 feature branch was not returned by `git ls-remote`, so it appears to have been removed after merge.
+
+### External Plan Reconciliation
+
+- Original Feishu source `https://my.feishu.cn/docx/EceldD7lIojOyaxzqjkczbo7neh` is still blocked by Lark CLI app/auth configuration, but the same plan was supplied as a local DOCX attachment and read successfully on 2026-06-14.
+- Plan title: `ai_actuarial_inforsearch 现有信息转成 Agentic RAG 独立项目方案（修订版）`; parsed content had 205 paragraphs and 16 tables.
+- Plan PR0 expectation: eval scaffolding, 20 retrieval cases, top-k/doc/category hit reporting, no ready_data dependency. Current #134 satisfies this and is merged.
+- Plan PR1 expectation: L0 ready_data builder MVP with basic validate, headings-only extraction, `doc_catalog.jsonl`, `doc_summaries.jsonl`, `sections.jsonl`, and `ready_data_manifest.json`; plan text also names `store.py` and `extractors.py`.
+- Current #133 PR1 reality: merged L0 MVP delivered `ready_data_builder.py`, `manifest_profiles.py`, `doc_catalog.jsonl`, `sections.jsonl`, `ready_data_manifest.json`, validation, and tests. It does not currently have separate `store.py` / `extractors.py` modules or `doc_summaries.jsonl`; decide whether to fold those into PR2/PR3 or explicitly keep PR1 as the narrower MVP.
+- Plan PR2 is still next: `agentic_ready_manifests` table, KB `manifest_profile` field, Knowledge UI manifest status/build button, KB mode selection rules, fallback behavior for KBs without ready_data, and stale/failed manifest messaging.
+- Plan PR3 follows PR2: `ready_data_tools.py`, `tools.py`, `search_summaries`, basic `search_titles`, `/api/agentic-rag/search/summaries`, `/api/agentic-rag/search/titles`, and basic question classifier (`catalog`, `locate`, `summary`, `document_qa`).
+- Plan acceptance table omitted a PR2 row. Local PR2 acceptance baseline should be: registry schema/migration works, KB manifest profile/status persists, Knowledge UI shows manifest status, build button triggers/records manifest build outcome, Standard/Agentic/Professional/Hybrid KB selection and no-ready_data fallback rules are implemented, and stale/failed manifest states have tests or smoke coverage.
+- Plan decision: PR3 remains L0 summary/title search only. Do not promise rule-number/document-number/attachment alias-first locate top-3 >= 90% until PR4.
 
 ### PR0 Delivery
 
@@ -25,7 +44,8 @@
 - `git diff --check` (pass; Git emitted LF/CRLF working-copy warnings only)
 - CLI JSON contract/idempotency verified with a temporary SQLite fixture: two `python -m ai_actuarial.agentic_rag.eval --db <fixture> --cases <fixture> --json` runs both returned 0 and parsed as JSON with 2/2 cases passing, `doc_hit_rate=1.0`, and `category_hit_rate=1.0`.
 - Local default `python -m ai_actuarial.agentic_rag.eval --json` returned 1 in this checkout because `data/index.db` is a stale local DB with 0 rows in `files`, `catalog_items`, and `rag_chunks`; this is a local data fixture limitation, not a code regression.
-- Remote CI before follow-up fixes: python-smoke ✅
+- Remote CI after follow-up fixes: `python-smoke` passed.
+- GitHub review threads on #134 still show unresolved Copilot housekeeping in the UI; most are outdated after follow-up commits. The remaining non-outdated details fallback comment was checked against current code and the retrieved-items case is handled by the `retrieved:` fallback.
 - Mandatory local `codex review --uncommitted` gate could not run because WindowsApps `codex.exe` returned `Access is denied`; independent multi-agent review was used as the available pre-merge review path.
 
 ### Design Notes
@@ -35,4 +55,9 @@
 
 ### Next PRs
 - PR2: Manifest Registry + DB + KB UI
-- PR3: search_titles / search_summaries API + question classifier
+- PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier
+- PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations`
+- PR5a: backend Agentic loop core (`planner.py`, `agentic_loop.py`, `/api/agentic-rag/chat`, metadata trace)
+- PR5b: Chat integration and frontend trace display with `rag_mode=agentic`
+- PR6: L2 formula/actuarial manifest (`formula_cards`, structured tables, calculation terms, formula tools)
+- PR7: eval loop and CI integration for retrieval/answer eval, citation coverage, hallucination checks, no-evidence refusal tests

--- a/ai_actuarial/api/route_inventory.py
+++ b/ai_actuarial/api/route_inventory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from typing import Any
 
 
@@ -9,6 +10,31 @@ _IGNORED_METHODS = {"HEAD", "OPTIONS"}
 
 def _signature(path: str, method: str) -> str:
     return f"{method} {path}"
+
+
+def _join_paths(prefix: str, path: str) -> str:
+    if not prefix:
+        return path
+    if not path:
+        return prefix
+    return f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _iter_routes(routes: Iterable[Any], prefix: str = "", parent_include_in_schema: bool = True) -> Iterable[tuple[Any, str | None, bool]]:
+    for route in routes:
+        include_in_schema = parent_include_in_schema and bool(getattr(route, "include_in_schema", True))
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            yield route, _join_paths(prefix, path), include_in_schema
+
+        original_router = getattr(route, "original_router", None)
+        if original_router is None:
+            continue
+
+        include_context = getattr(route, "include_context", None)
+        nested_prefix = _join_paths(prefix, str(getattr(include_context, "prefix", "") or ""))
+        nested_include = include_in_schema and bool(getattr(include_context, "include_in_schema", True))
+        yield from _iter_routes(getattr(original_router, "routes", []), nested_prefix, nested_include)
 
 
 def normalize_route_signature(signature: str) -> str:
@@ -20,9 +46,8 @@ def normalize_route_signature(signature: str) -> str:
 
 def collect_fastapi_api_paths(app: Any) -> list[str]:
     paths: set[str] = set()
-    for route in app.router.routes:
-        path = getattr(route, "path", None)
-        if getattr(route, "include_in_schema", True) is False:
+    for _route, path, include_in_schema in _iter_routes(app.router.routes):
+        if not include_in_schema:
             continue
         if isinstance(path, str) and path.startswith("/api"):
             paths.add(path)
@@ -31,10 +56,9 @@ def collect_fastapi_api_paths(app: Any) -> list[str]:
 
 def collect_fastapi_route_signatures(app: Any) -> list[str]:
     signatures: set[str] = set()
-    for route in app.router.routes:
-        path = getattr(route, "path", None)
+    for route, path, include_in_schema in _iter_routes(app.router.routes):
         methods = getattr(route, "methods", None)
-        if getattr(route, "include_in_schema", True) is False:
+        if not include_in_schema:
             continue
         if not isinstance(path, str) or not path.startswith("/api") or not methods:
             continue


### PR DESCRIPTION
## Summary
- Record local DOCX roadmap reconciliation after Feishu fetch was blocked
- Mark PR0/#134 and PR1/#133 as merged, with PR2 as next scope
- Capture PR1 scope delta and PR2 acceptance baseline from the revised plan
- Expand follow-on roadmap through PR7 and clarify PR3 vs PR4 expectations

## Verification
- Parsed supplied DOCX with python-docx: 205 paragraphs, 16 tables
- gh pr list --state open returned no open PRs before this PR
- git diff --check passed (LF/CRLF warning only)
- codex review --uncommitted could not run: WindowsApps codex.exe returned Access is denied