### PR TITLE
feat: PR3 Agentic ready data summary and title search

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -4,14 +4,15 @@
 - Branch: `feat/agentic-rag-summary-title-tools`
 - Baseline: `origin/main` at `15edb62` (`Merge pull request #136 from ferryhe/feat/agentic-rag-manifest-registry-kb-ui`).
 - Scope: PR3 — L0 ready_data summary/title search tools and basic question classifier.
-- PR: pending creation for PR3.
+- PR: [#137](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/137) — open; post-review source-label follow-up fixes prepared.
 - Previous PRs: [#136](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/136) — merged; [#135](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/135) — merged; [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged; [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
 
 ### Current State
 
 - Local `main` was fast-forwarded to `origin/main` at `15edb62` after merging #136, then PR3 branch `feat/agentic-rag-summary-title-tools` was created from that baseline.
-- Current plan position: PR0, PR1, the roadmap reconciliation PR, and PR2 are merged; PR3 implements L0 summary/title search tooling and FastAPI endpoints and is ready for pre-PR review/PR creation.
+- Current plan position: PR0, PR1, the roadmap reconciliation PR, and PR2 are merged; PR3 is open as #137 with L0 summary/title search tooling and FastAPI endpoints.
 - Added ready-data search functions that read `ready_data_manifest.json`, `doc_catalog.jsonl`, optional `doc_summaries.jsonl`, and `sections.jsonl`; missing `doc_summaries.jsonl` falls back to catalog summaries, while missing/invalid ready-data files return empty tool results or API errors.
+- PR3 remote review follow-up: Copilot correctly identified that partial `doc_summaries.jsonl` rows could mislabel catalog-only fallback hits as `source="doc_summaries"`. The search merge now tracks catalog and summary provenance per document and the partial-summary regression test asserts `source="doc_catalog"`.
 - Review follow-up tightened ready-data file access: manifest artifact paths are contained under the ready_data output directory; explicit and registry-resolved `output_dir` values must stay under the DB-adjacent `agentic_ready_data` directory; `output_dir` cannot be mixed with `kb_id` registry lookup.
 - Added basic question classification for `catalog`, `locate`, `summary`, and `document_qa`; this intentionally does not implement PR4 alias-first rule/document-number lookup.
 - Added `/api/agentic-rag/search/summaries` and `/api/agentic-rag/search/titles`; requests can pass explicit `output_dir` for tests or `kb_id`/`profile` to resolve a ready PR2 registry manifest.
@@ -70,6 +71,13 @@
   - `python -m pytest tests/test_fastapi_entrypoint.py -q` without a session secret returns 503 for health/migration endpoints because current local runtime has CSRF enabled and no default FastAPI session secret; this is an environment precondition, not a PR3 router regression.
   - `git diff --check` (pass; Git emitted LF/CRLF working-copy warnings only)
   - Mandatory `codex review --uncommitted` could not run because WindowsApps `codex.exe` returned `Access is denied`; worker self-check plus independent spec and code-quality reviewers were used as the available pre-PR review gate.
+- PR3 #137 post-review follow-up verification:
+  - GitHub remote gate before follow-up: `python-smoke` passed; Copilot PR reviewer passed and left 2 valid inline comments about partial `doc_summaries.jsonl` source-label behavior and missing source assertion.
+  - `python -m py_compile ai_actuarial\agentic_rag\ready_data_tools.py ai_actuarial\agentic_rag\tools.py ai_actuarial\api\services\agentic_rag.py ai_actuarial\api\routers\agentic_rag.py ai_actuarial\api\app.py` (pass)
+  - `python -m pytest tests\agentic_rag\test_ready_data_tools.py tests\test_fastapi_agentic_rag_endpoints.py -q` (16 passed)
+  - `python -m pytest tests\agentic_rag\ tests\test_fastapi_agentic_rag_endpoints.py -q` (44 passed)
+  - `git diff --check` (pass; Git emitted LF/CRLF working-copy warnings only)
+  - Mandatory `codex review --uncommitted` still cannot run because WindowsApps `codex.exe` returned `Access is denied`; the blocker remains recorded for the PR gate.
 - PR3 worker verification:
   - `python -m pytest tests\agentic_rag\test_ready_data_tools.py tests\test_fastapi_agentic_rag_endpoints.py -q` (10 passed)
   - `python -m py_compile ai_actuarial\agentic_rag\ready_data_tools.py ai_actuarial\agentic_rag\tools.py ai_actuarial\api\services\agentic_rag.py ai_actuarial\api\routers\agentic_rag.py ai_actuarial\api\app.py` (pass)
@@ -109,7 +117,7 @@
 - Retriever protocol allows swapping in vector/ready_data/agentic retrievers later
 
 ### Next PRs
-- PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier — pending PR creation
+- PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier — open as #137; post-review source-label follow-up pending push/remote checks/merge
 - PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations`
 - PR5a: backend Agentic loop core (`planner.py`, `agentic_loop.py`, `/api/agentic-rag/chat`, metadata trace)
 - PR5b: Chat integration and frontend trace display with `rag_mode=agentic`

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,17 +1,21 @@
 # Project Status
 
 - Date: 2026-06-14
-- Branch: `feat/agentic-rag-manifest-registry-kb-ui`
-- Baseline: `origin/main` at `1f3f234` (`Merge pull request #135 from ferryhe/chore/agentic-rag-roadmap-reconciliation`).
-- Scope: PR2 — Manifest Registry + DB + KB UI.
-- PR: [#136](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/136) — open; post-review feedback fixes validated locally and ready to push.
-- Previous PRs: [#135](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/135) — merged; [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged; [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
+- Branch: `feat/agentic-rag-summary-title-tools`
+- Baseline: `origin/main` at `15edb62` (`Merge pull request #136 from ferryhe/feat/agentic-rag-manifest-registry-kb-ui`).
+- Scope: PR3 — L0 ready_data summary/title search tools and basic question classifier.
+- PR: pending creation for PR3.
+- Previous PRs: [#136](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/136) — merged; [#135](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/135) — merged; [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged; [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
 
 ### Current State
 
-- Local `main` was fast-forwarded to `origin/main` at `1f3f234` after merging #135.
-- Current branch `feat/agentic-rag-manifest-registry-kb-ui` is the PR2 implementation branch.
-- Current plan position: PR0, PR1, and the roadmap reconciliation PR are complete and merged; PR2 is open as #136 and is in the remote feedback gate.
+- Local `main` was fast-forwarded to `origin/main` at `15edb62` after merging #136, then PR3 branch `feat/agentic-rag-summary-title-tools` was created from that baseline.
+- Current plan position: PR0, PR1, the roadmap reconciliation PR, and PR2 are merged; PR3 implements L0 summary/title search tooling and FastAPI endpoints and is ready for pre-PR review/PR creation.
+- Added ready-data search functions that read `ready_data_manifest.json`, `doc_catalog.jsonl`, optional `doc_summaries.jsonl`, and `sections.jsonl`; missing `doc_summaries.jsonl` falls back to catalog summaries, while missing/invalid ready-data files return empty tool results or API errors.
+- Review follow-up tightened ready-data file access: manifest artifact paths are contained under the ready_data output directory; explicit and registry-resolved `output_dir` values must stay under the DB-adjacent `agentic_ready_data` directory; `output_dir` cannot be mixed with `kb_id` registry lookup.
+- Added basic question classification for `catalog`, `locate`, `summary`, and `document_qa`; this intentionally does not implement PR4 alias-first rule/document-number lookup.
+- Added `/api/agentic-rag/search/summaries` and `/api/agentic-rag/search/titles`; requests can pass explicit `output_dir` for tests or `kb_id`/`profile` to resolve a ready PR2 registry manifest.
+- PR2 was merged as #136 at merge commit `15edb6252cd199776906924a9220cfec1c0d9034` after `python-smoke` passed and all 5 Copilot comments were addressed.
 - PR2 remote gate after the wait window: GitHub `python-smoke` passed; Copilot left 5 inline comments. Four frontend comments requested i18n for Agentic manifest UI text, and one backend comment identified a valid `output_dir` rejection path that could leave/overwrite manifest state as `building`.
 - Follow-up fixes address all 5 comments: frontend Agentic manifest labels, messages, buttons, and metadata now use existing `t(...)` translations; invalid `output_dir` requests are rejected before writing `building` registry state and are covered by a regression test that preserves an existing ready manifest.
 - `gh pr view` GraphQL calls still return 401 in this environment; PR/check/review state was read with `gh pr checks` and REST `gh api`.
@@ -46,7 +50,31 @@
 - `client/src/pages/KBDetail.tsx`: shows manifest profile/status/count/output metadata and build/rebuild action on the KB detail page.
 - Tests cover KB-scoped builder output, same-file multi-profile chunk leakage prevention, registry build/status/stale/failed paths, output directory traversal rejection, and frontend source contracts.
 
+### PR3 Delivery
+
+- `ai_actuarial/agentic_rag/ready_data_tools.py`: added `search_summaries` and `search_titles` over L0 ready-data files, stable result fields, ranking/limit behavior, missing-file tolerance, and catalog-summary fallback when `doc_summaries.jsonl` is absent.
+- `ai_actuarial/agentic_rag/tools.py`: added basic `classify_question` with categories limited to `catalog`, `locate`, `summary`, and `document_qa`.
+- `ai_actuarial/api/services/agentic_rag.py` and `ai_actuarial/api/routers/agentic_rag.py`: added read-side Agentic RAG summary/title search endpoints with explicit output-dir and PR2 manifest-registry resolution.
+- `ai_actuarial/api/app.py`: includes the new Agentic RAG router before the retired `/api` fallback.
+- Tests added in `tests/agentic_rag/test_ready_data_tools.py` and `tests/test_fastapi_agentic_rag_endpoints.py`, including artifact path containment, partial `doc_summaries.jsonl`, explicit output_dir containment, mixed `output_dir`/`kb_id` rejection, and not-ready registry status handling.
+
 ### Verification
+- PR3 controller verification:
+  - Worker implementation used TDD; initial red state was missing `ready_data_tools` module.
+  - Spec-compliance reviewer found no PR3 scope gaps.
+  - Code-quality reviewer found one critical path-containment issue and two important edge cases; all were fixed with regression tests.
+  - `python -m py_compile ai_actuarial/agentic_rag/ready_data_tools.py ai_actuarial/agentic_rag/tools.py ai_actuarial/api/services/agentic_rag.py ai_actuarial/api/routers/agentic_rag.py ai_actuarial/api/app.py` (pass)
+  - `python -m pytest tests/agentic_rag/test_ready_data_tools.py tests/test_fastapi_agentic_rag_endpoints.py -q` (16 passed)
+  - `python -m pytest tests/agentic_rag/ tests/test_fastapi_agentic_rag_endpoints.py -q` (44 passed)
+  - `FASTAPI_SESSION_SECRET=fastapi-entrypoint-temp-secret python -m pytest tests/test_fastapi_entrypoint.py -q` (7 passed)
+  - `python -m pytest tests/test_fastapi_entrypoint.py -q` without a session secret returns 503 for health/migration endpoints because current local runtime has CSRF enabled and no default FastAPI session secret; this is an environment precondition, not a PR3 router regression.
+  - `git diff --check` (pass; Git emitted LF/CRLF working-copy warnings only)
+  - Mandatory `codex review --uncommitted` could not run because WindowsApps `codex.exe` returned `Access is denied`; worker self-check plus independent spec and code-quality reviewers were used as the available pre-PR review gate.
+- PR3 worker verification:
+  - `python -m pytest tests\agentic_rag\test_ready_data_tools.py tests\test_fastapi_agentic_rag_endpoints.py -q` (10 passed)
+  - `python -m py_compile ai_actuarial\agentic_rag\ready_data_tools.py ai_actuarial\agentic_rag\tools.py ai_actuarial\api\services\agentic_rag.py ai_actuarial\api\routers\agentic_rag.py ai_actuarial\api\app.py` (pass)
+  - `python -m pytest tests\agentic_rag\ tests\test_fastapi_agentic_rag_endpoints.py -q` (38 passed)
+  - `git diff --check` (pass; Git emitted LF/CRLF working-copy warning for `ai_actuarial/api/app.py` only)
 - PR2 local verification:
   - `python -m py_compile ai_actuarial/storage.py ai_actuarial/rag/knowledge_base.py ai_actuarial/agentic_rag/ready_data_builder.py ai_actuarial/api/services/rag_admin.py ai_actuarial/api/routers/rag_admin.py` (pass)
   - `python -m pytest tests/agentic_rag/test_ready_data_builder.py tests/test_fastapi_rag_admin_endpoints.py tests/test_knowledge_react_source.py -q` (38 passed)
@@ -81,8 +109,7 @@
 - Retriever protocol allows swapping in vector/ready_data/agentic retrievers later
 
 ### Next PRs
-- PR2: Manifest Registry + DB + KB UI
-- PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier
+- PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier — pending PR creation
 - PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations`
 - PR5a: backend Agentic loop core (`planner.py`, `agentic_loop.py`, `/api/agentic-rag/chat`, metadata trace)
 - PR5b: Chat integration and frontend trace display with `rag_mode=agentic`

--- a/ai_actuarial/agentic_rag/ready_data_tools.py
+++ b/ai_actuarial/agentic_rag/ready_data_tools.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+_WORD_RE = re.compile(r"[\w\u4e00-\u9fff]+", re.UNICODE)
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _tokens(query: str) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for token in _WORD_RE.findall(query.lower()):
+        if token and token not in seen:
+            seen.add(token)
+            out.append(token)
+    return out
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(item, dict):
+                    rows.append(item)
+    except OSError:
+        return []
+    return rows
+
+
+def _safe_child_path(root: Path, value: Any, default_name: str) -> Path:
+    root_resolved = root.resolve()
+    raw = str(value or default_name).strip()
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return root_resolved / default_name
+    resolved = (root_resolved / candidate).resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return root_resolved / default_name
+    return resolved
+
+
+def _artifact_path(output_dir: Path, manifest: dict[str, Any], default_name: str) -> Path:
+    artifact_files = manifest.get("artifact_files") or []
+    if isinstance(artifact_files, dict):
+        value = artifact_files.get(default_name) or artifact_files.get(default_name.replace(".jsonl", ""))
+        if value:
+            return _safe_child_path(output_dir, value, default_name)
+    if isinstance(artifact_files, list):
+        for item in artifact_files:
+            if isinstance(item, str) and Path(item).name == default_name:
+                return _safe_child_path(output_dir, item, default_name)
+    return _safe_child_path(output_dir, default_name, default_name)
+
+
+def _load_ready_data(output_dir: str | Path) -> dict[str, Any] | None:
+    root = Path(output_dir)
+    manifest = _read_json(root / "ready_data_manifest.json")
+    if not manifest:
+        return None
+    catalog = _read_jsonl(_artifact_path(root, manifest, "doc_catalog.jsonl"))
+    if not catalog:
+        return None
+    summaries_path = _artifact_path(root, manifest, "doc_summaries.jsonl")
+    summary_rows = _read_jsonl(summaries_path)
+    source = "doc_summaries" if summary_rows else "doc_catalog"
+    sections = _read_jsonl(_artifact_path(root, manifest, "sections.jsonl"))
+    return {
+        "manifest": manifest,
+        "catalog": catalog,
+        "summaries": summary_rows,
+        "summary_source": source,
+        "sections": sections,
+    }
+
+
+def _doc_key(row: dict[str, Any]) -> str:
+    return _norm(row.get("doc_id")) or _norm(row.get("file_url"))
+
+
+def _merge_summary_docs(catalog: list[dict[str, Any]], summaries: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str]:
+    by_key = {_doc_key(row): row for row in catalog if _doc_key(row)}
+    if not summaries:
+        return [dict(row) for row in catalog], "doc_catalog"
+
+    summary_by_key = {_doc_key(row): row for row in summaries if _doc_key(row)}
+    merged: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for key, catalog_row in by_key.items():
+        base = dict(catalog_row)
+        summary = summary_by_key.get(key)
+        if summary:
+            base.update({k: v for k, v in summary.items() if v not in (None, "")})
+        merged.append(base)
+        seen.add(key)
+
+    for summary in summaries:
+        key = _doc_key(summary)
+        if key and key not in seen:
+            merged.append({k: v for k, v in summary.items() if v not in (None, "")})
+            seen.add(key)
+    return merged, "doc_summaries"
+
+
+def _sections_by_doc(sections: list[dict[str, Any]]) -> dict[str, str]:
+    by_doc: dict[str, list[str]] = {}
+    for section in sections:
+        doc_id = _norm(section.get("doc_id"))
+        if not doc_id:
+            continue
+        heading_path = section.get("heading_path") or []
+        heading_text = " ".join(_norm(item) for item in heading_path) if isinstance(heading_path, list) else _norm(heading_path)
+        text = f"{heading_text} {_norm(section.get('text'))}".strip()
+        if text:
+            by_doc.setdefault(doc_id, []).append(text)
+    return {doc_id: " ".join(parts) for doc_id, parts in by_doc.items()}
+
+
+def _field_score(query_tokens: list[str], text: str, weight: float) -> float:
+    haystack = text.lower()
+    return sum(weight for token in query_tokens if token in haystack)
+
+
+def _format_result(row: dict[str, Any], *, score: float, source: str) -> dict[str, Any]:
+    file_url = _norm(row.get("file_url")) or _norm(row.get("doc_id"))
+    return {
+        "file_url": file_url,
+        "doc_id": _norm(row.get("doc_id")) or file_url,
+        "title": _norm(row.get("title")) or file_url,
+        "summary": _norm(row.get("summary")),
+        "category": _norm(row.get("category")),
+        "score": round(float(score), 4),
+        "source": source,
+    }
+
+
+def _limit(value: int | None) -> int:
+    try:
+        parsed = int(value if value is not None else 10)
+    except (TypeError, ValueError):
+        parsed = 10
+    return max(1, min(parsed, 100))
+
+
+def search_summaries(query: str, *, output_dir: str | Path, limit: int = 10) -> list[dict[str, Any]]:
+    """Search L0 ready-data summaries and return stable result dictionaries."""
+    query_text = _norm(query)
+    query_tokens = _tokens(query_text)
+    if not query_tokens:
+        return []
+    ready_data = _load_ready_data(output_dir)
+    if not ready_data:
+        return []
+
+    docs, default_source = _merge_summary_docs(ready_data["catalog"], ready_data["summaries"])
+    section_text = _sections_by_doc(ready_data["sections"])
+    scored: list[dict[str, Any]] = []
+    for row in docs:
+        doc_id = _doc_key(row)
+        headings = row.get("headings") or []
+        heading_text = " ".join(_norm(item) for item in headings) if isinstance(headings, list) else _norm(headings)
+        summary_score = _field_score(query_tokens, _norm(row.get("summary")), 4.0)
+        title_score = _field_score(query_tokens, _norm(row.get("title")), 2.0)
+        category_score = _field_score(query_tokens, _norm(row.get("category")), 1.0)
+        heading_score = _field_score(query_tokens, heading_text, 1.0)
+        section_score = _field_score(query_tokens, section_text.get(doc_id, ""), 0.75)
+        score = summary_score + title_score + category_score + heading_score + section_score
+        if query_text.lower() and query_text.lower() in _norm(row.get("summary")).lower():
+            score += 3.0
+        if score <= 0:
+            continue
+        source = default_source if summary_score > 0 or default_source == "doc_catalog" else "sections"
+        scored.append(_format_result(row, score=score, source=source))
+
+    scored.sort(key=lambda item: (-float(item["score"]), item["title"].lower(), item["file_url"]))
+    return scored[: _limit(limit)]
+
+
+def search_titles(query: str, *, output_dir: str | Path, limit: int = 10) -> list[dict[str, Any]]:
+    """Search L0 ready-data document titles with lightweight keyword scoring."""
+    query_text = _norm(query)
+    query_tokens = _tokens(query_text)
+    if not query_tokens:
+        return []
+    ready_data = _load_ready_data(output_dir)
+    if not ready_data:
+        return []
+
+    scored: list[dict[str, Any]] = []
+    for row in ready_data["catalog"]:
+        headings = row.get("headings") or []
+        heading_text = " ".join(_norm(item) for item in headings) if isinstance(headings, list) else _norm(headings)
+        title = _norm(row.get("title"))
+        score = (
+            _field_score(query_tokens, title, 5.0)
+            + _field_score(query_tokens, _norm(row.get("file_url")), 1.0)
+            + _field_score(query_tokens, _norm(row.get("category")), 0.5)
+            + _field_score(query_tokens, _norm(row.get("summary")), 0.5)
+            + _field_score(query_tokens, heading_text, 0.75)
+        )
+        if query_text.lower() and query_text.lower() in title.lower():
+            score += 4.0
+        if score <= 0:
+            continue
+        scored.append(_format_result(row, score=score, source="doc_catalog"))
+
+    scored.sort(key=lambda item: (-float(item["score"]), item["title"].lower(), item["file_url"]))
+    return scored[: _limit(limit)]

--- a/ai_actuarial/agentic_rag/ready_data_tools.py
+++ b/ai_actuarial/agentic_rag/ready_data_tools.py
@@ -103,19 +103,23 @@ def _doc_key(row: dict[str, Any]) -> str:
     return _norm(row.get("doc_id")) or _norm(row.get("file_url"))
 
 
-def _merge_summary_docs(catalog: list[dict[str, Any]], summaries: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str]:
+def _merge_summary_docs(
+    catalog: list[dict[str, Any]], summaries: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], set[str], set[str]]:
     by_key = {_doc_key(row): row for row in catalog if _doc_key(row)}
     if not summaries:
-        return [dict(row) for row in catalog], "doc_catalog"
+        return [dict(row) for row in catalog], set(by_key), set()
 
     summary_by_key = {_doc_key(row): row for row in summaries if _doc_key(row)}
     merged: list[dict[str, Any]] = []
     seen: set[str] = set()
+    summary_keys: set[str] = set()
     for key, catalog_row in by_key.items():
         base = dict(catalog_row)
         summary = summary_by_key.get(key)
         if summary:
             base.update({k: v for k, v in summary.items() if v not in (None, "")})
+            summary_keys.add(key)
         merged.append(base)
         seen.add(key)
 
@@ -124,7 +128,8 @@ def _merge_summary_docs(catalog: list[dict[str, Any]], summaries: list[dict[str,
         if key and key not in seen:
             merged.append({k: v for k, v in summary.items() if v not in (None, "")})
             seen.add(key)
-    return merged, "doc_summaries"
+            summary_keys.add(key)
+    return merged, set(by_key), summary_keys
 
 
 def _sections_by_doc(sections: list[dict[str, Any]]) -> dict[str, str]:
@@ -177,7 +182,7 @@ def search_summaries(query: str, *, output_dir: str | Path, limit: int = 10) -> 
     if not ready_data:
         return []
 
-    docs, default_source = _merge_summary_docs(ready_data["catalog"], ready_data["summaries"])
+    docs, catalog_keys, summary_keys = _merge_summary_docs(ready_data["catalog"], ready_data["summaries"])
     section_text = _sections_by_doc(ready_data["sections"])
     scored: list[dict[str, Any]] = []
     for row in docs:
@@ -194,7 +199,12 @@ def search_summaries(query: str, *, output_dir: str | Path, limit: int = 10) -> 
             score += 3.0
         if score <= 0:
             continue
-        source = default_source if summary_score > 0 or default_source == "doc_catalog" else "sections"
+        if doc_id in summary_keys and (summary_score > 0 or doc_id not in catalog_keys):
+            source = "doc_summaries"
+        elif summary_score > 0 or title_score > 0 or category_score > 0 or heading_score > 0:
+            source = "doc_catalog"
+        else:
+            source = "sections"
         scored.append(_format_result(row, score=score, source=source))
 
     scored.sort(key=lambda item: (-float(item["score"]), item["title"].lower(), item["file_url"]))

--- a/ai_actuarial/agentic_rag/tools.py
+++ b/ai_actuarial/agentic_rag/tools.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from .ready_data_tools import search_summaries, search_titles
+
+
+QuestionCategory = Literal["catalog", "locate", "summary", "document_qa"]
+
+
+def classify_question(question: str) -> QuestionCategory:
+    """Classify a user question into the PR3 L0 tool categories."""
+    text = str(question or "").strip().lower()
+    if not text:
+        return "document_qa"
+
+    summary_terms = ("summarize", "summary", "overview", "brief", "概述", "总结", "摘要")
+    locate_terms = ("find", "locate", "which document", "titled", "title", "url", "file", "where is", "查找", "定位", "标题")
+    catalog_terms = ("catalog", "list all", "all documents", "categories", "show documents", "目录", "清单", "全部文档")
+
+    if any(term in text for term in summary_terms):
+        return "summary"
+    if any(term in text for term in locate_terms):
+        return "locate"
+    if any(term in text for term in catalog_terms):
+        return "catalog"
+    return "document_qa"
+
+
+__all__ = ["QuestionCategory", "classify_question", "search_summaries", "search_titles"]

--- a/ai_actuarial/api/app.py
+++ b/ai_actuarial/api/app.py
@@ -14,6 +14,7 @@ from .route_inventory import (
     collect_fastapi_api_paths,
     collect_fastapi_route_signatures,
 )
+from .routers.agentic_rag import router as agentic_rag_router
 from .routers.auth import router as auth_router
 from .routers.chat import router as chat_router
 from .routers.files_write import router as files_write_router
@@ -232,6 +233,7 @@ def create_app() -> FastAPI:
     app.include_router(ops_write_router, prefix="/api", tags=["ops-write"])
     app.include_router(files_write_router, prefix="/api", tags=["files-write"])
     app.include_router(rag_admin_router, prefix="/api", tags=["rag-admin"])
+    app.include_router(agentic_rag_router, prefix="/api", tags=["agentic-rag"])
     app.include_router(chat_router, prefix="/api", tags=["chat"])
 
     app.state.fastapi_session_secret = os.getenv("FASTAPI_SESSION_SECRET", settings.FASTAPI_SESSION_SECRET)

--- a/ai_actuarial/api/routers/agentic_rag.py
+++ b/ai_actuarial/api/routers/agentic_rag.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from ..deps import AuthContext, require_permissions
+from ..services.agentic_rag import AgenticRagError, search_ready_summaries, search_ready_titles
+
+
+router = APIRouter()
+
+
+def _db_path(request: Request) -> str:
+    db_path = str(getattr(request.app.state, "db_path", "") or "")
+    if not db_path:
+        raise HTTPException(status_code=500, detail="Database path is unavailable")
+    return db_path
+
+
+def _error_response(exc: AgenticRagError) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content={"error": exc.message})
+
+
+@router.post("/agentic-rag/search/summaries")
+def api_search_agentic_summaries(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return search_ready_summaries(db_path=_db_path(request), payload=payload)
+    except AgenticRagError as exc:
+        return _error_response(exc)
+
+
+@router.post("/agentic-rag/search/titles")
+def api_search_agentic_titles(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return search_ready_titles(db_path=_db_path(request), payload=payload)
+    except AgenticRagError as exc:
+        return _error_response(exc)

--- a/ai_actuarial/api/services/agentic_rag.py
+++ b/ai_actuarial/api/services/agentic_rag.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from ai_actuarial.agentic_rag.ready_data_tools import search_summaries, search_titles
+from ai_actuarial.shared_runtime import parse_int_clamped
+from ai_actuarial.storage import Storage
+
+
+class AgenticRagError(Exception):
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _payload_value(payload: Mapping[str, Any], key: str, fallback: Any = None) -> Any:
+    value = payload.get(key)
+    return fallback if value in (None, "") else value
+
+
+def _validate_ready_output_dir(output_dir: str) -> str:
+    normalized = _norm(output_dir)
+    if not normalized:
+        raise AgenticRagError("output_dir or kb_id is required", status_code=400)
+    path = Path(normalized)
+    if not path.is_dir():
+        raise AgenticRagError("output_dir does not exist or is not a directory", status_code=400)
+    if not (path / "ready_data_manifest.json").is_file():
+        raise AgenticRagError("ready_data manifest not found in output_dir", status_code=400)
+    return str(path)
+
+
+def _validate_agentic_ready_output_dir(*, db_path: str, output_dir: str) -> str:
+    candidate = Path(_validate_ready_output_dir(output_dir)).resolve()
+    root = (Path(db_path).resolve().parent / "agentic_ready_data").resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise AgenticRagError(
+            "output_dir must stay under the database agentic_ready_data directory",
+            status_code=400,
+        ) from exc
+    return str(candidate)
+
+
+def _resolve_ready_output_dir(
+    *,
+    db_path: str,
+    payload: Mapping[str, Any],
+) -> tuple[str, str, str]:
+    explicit_output_dir = _norm(payload.get("output_dir"))
+    kb_id = _norm(payload.get("kb_id"))
+    profile = _norm(payload.get("profile") or payload.get("manifest_profile") or "general").lower() or "general"
+    if explicit_output_dir:
+        if kb_id:
+            raise AgenticRagError("output_dir cannot be combined with kb_id/profile registry lookup", status_code=400)
+        return _validate_agentic_ready_output_dir(db_path=db_path, output_dir=explicit_output_dir), "", profile
+    if not kb_id:
+        raise AgenticRagError("output_dir or kb_id is required", status_code=400)
+
+    storage = Storage(db_path)
+    try:
+        manifest = storage.get_agentic_ready_manifest(kb_id=kb_id, profile=profile)
+    finally:
+        storage.close()
+    if not manifest:
+        raise AgenticRagError("ready_data manifest not found for kb_id/profile", status_code=404)
+    status = _norm(manifest.get("status")).lower()
+    output_dir = _norm(manifest.get("output_dir"))
+    if status != "ready" or not output_dir:
+        raise AgenticRagError("ready_data manifest is not ready for kb_id/profile", status_code=409)
+    return _validate_agentic_ready_output_dir(db_path=db_path, output_dir=output_dir), kb_id, profile
+
+
+def _search_response(
+    *,
+    db_path: str,
+    payload: Mapping[str, Any],
+    search_fn: Callable[..., list[dict[str, Any]]],
+    search_type: str,
+) -> dict[str, Any]:
+    query = _norm(_payload_value(payload, "query", ""))
+    limit = parse_int_clamped(_payload_value(payload, "limit", 10), default=10, min_value=1, max_value=100)
+    output_dir, kb_id, profile = _resolve_ready_output_dir(db_path=db_path, payload=payload)
+    results = search_fn(query, output_dir=output_dir, limit=limit) if query else []
+    return {
+        "query": query,
+        "search_type": search_type,
+        "limit": limit,
+        "count": len(results),
+        "results": results,
+        "output_dir": output_dir,
+        "kb_id": kb_id or None,
+        "profile": profile,
+    }
+
+
+def search_ready_summaries(*, db_path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _search_response(
+        db_path=db_path,
+        payload=payload,
+        search_fn=search_summaries,
+        search_type="summaries",
+    )
+
+
+def search_ready_titles(*, db_path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _search_response(
+        db_path=db_path,
+        payload=payload,
+        search_fn=search_titles,
+        search_type="titles",
+    )

--- a/tests/agentic_rag/test_ready_data_tools.py
+++ b/tests/agentic_rag/test_ready_data_tools.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ai_actuarial.agentic_rag.ready_data_tools import search_summaries, search_titles
+from ai_actuarial.agentic_rag.tools import classify_question
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_ready_data(
+    output_dir: Path,
+    *,
+    include_summaries: bool = True,
+    summary_rows: list[dict[str, object]] | None = None,
+    artifact_files: list[str] | dict[str, str] | None = None,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    docs = [
+        {
+            "doc_id": "doc-capital",
+            "file_url": "https://example.test/capital.pdf",
+            "title": "Capital Adequacy Guideline",
+            "category": "regulation",
+            "summary": "Explains solvency capital requirements for insurers.",
+            "headings": ["Capital requirement", "Risk charge"],
+        },
+        {
+            "doc_id": "doc-reserve",
+            "file_url": "https://example.test/reserve.pdf",
+            "title": "Reserve Method Note",
+            "category": "method",
+            "summary": "Describes reserve calculation and liability assumptions.",
+            "headings": ["Reserve calculation"],
+        },
+    ]
+    _write_jsonl(output_dir / "doc_catalog.jsonl", docs)
+    if include_summaries:
+        _write_jsonl(
+            output_dir / "doc_summaries.jsonl",
+            summary_rows
+            if summary_rows is not None
+            else [
+                {
+                    "doc_id": "doc-capital",
+                    "file_url": "https://example.test/capital.pdf",
+                    "title": "Capital Adequacy Guideline",
+                    "category": "regulation",
+                    "summary": "Capital summary with solvency ratio and required capital.",
+                },
+                {
+                    "doc_id": "doc-reserve",
+                    "file_url": "https://example.test/reserve.pdf",
+                    "title": "Reserve Method Note",
+                    "category": "method",
+                    "summary": "Reserve summary for actuarial liabilities.",
+                },
+            ],
+        )
+    _write_jsonl(
+        output_dir / "sections.jsonl",
+        [
+            {
+                "section_id": "s-capital",
+                "doc_id": "doc-capital",
+                "heading_path": ["Capital requirement"],
+                "text": "Required capital is calibrated from risk charges.",
+                "token_count": 10,
+            },
+            {
+                "section_id": "s-reserve",
+                "doc_id": "doc-reserve",
+                "heading_path": ["Reserve calculation"],
+                "text": "Reserve assumptions include discount rates.",
+                "token_count": 9,
+            },
+        ],
+    )
+    (output_dir / "ready_data_manifest.json").write_text(
+        json.dumps(
+            {
+                "profile": "general",
+                "profile_version": "1",
+                "artifact_files": artifact_files
+                if artifact_files is not None
+                else [
+                    "doc_catalog.jsonl",
+                    "doc_summaries.jsonl",
+                    "sections.jsonl",
+                    "ready_data_manifest.json",
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_search_summaries_ranks_summary_hits_and_limits(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path)
+
+    results = search_summaries("solvency required capital", output_dir=str(tmp_path), limit=1)
+
+    assert len(results) == 1
+    assert results[0]["file_url"] == "https://example.test/capital.pdf"
+    assert results[0]["title"] == "Capital Adequacy Guideline"
+    assert results[0]["category"] == "regulation"
+    assert results[0]["summary"].startswith("Capital summary")
+    assert results[0]["score"] > 0
+    assert results[0]["source"] == "doc_summaries"
+
+
+def test_search_titles_scores_title_matches(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path)
+
+    results = search_titles("reserve method", output_dir=str(tmp_path), limit=5)
+
+    assert [item["file_url"] for item in results][:1] == ["https://example.test/reserve.pdf"]
+    assert results[0]["title"] == "Reserve Method Note"
+    assert results[0]["summary"]
+    assert results[0]["source"] == "doc_catalog"
+
+
+def test_search_summaries_falls_back_to_catalog_summary_when_doc_summaries_missing(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path, include_summaries=False)
+
+    results = search_summaries("liability assumptions", output_dir=str(tmp_path), limit=5)
+
+    assert results[0]["file_url"] == "https://example.test/reserve.pdf"
+    assert results[0]["summary"] == "Describes reserve calculation and liability assumptions."
+    assert results[0]["source"] == "doc_catalog"
+
+
+def test_search_summaries_keeps_catalog_docs_when_doc_summaries_are_partial(tmp_path: Path) -> None:
+    _write_ready_data(
+        tmp_path,
+        summary_rows=[
+            {
+                "doc_id": "doc-capital",
+                "file_url": "https://example.test/capital.pdf",
+                "title": "Capital Adequacy Guideline",
+                "category": "regulation",
+                "summary": "Capital summary with solvency ratio.",
+            }
+        ],
+    )
+
+    results = search_summaries("liability assumptions", output_dir=str(tmp_path), limit=5)
+
+    assert results[0]["file_url"] == "https://example.test/reserve.pdf"
+    assert results[0]["summary"] == "Describes reserve calculation and liability assumptions."
+
+
+def test_search_tools_do_not_read_manifest_artifacts_outside_ready_data_dir(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.jsonl"
+    _write_jsonl(
+        outside,
+        [
+            {
+                "doc_id": "outside",
+                "file_url": "https://example.test/outside.pdf",
+                "title": "Outside Secret",
+                "category": "secret",
+                "summary": "secret capital text",
+            }
+        ],
+    )
+    _write_ready_data(
+        tmp_path,
+        artifact_files={
+            "doc_catalog.jsonl": "../outside.jsonl",
+            "doc_summaries.jsonl": str(outside),
+            "sections.jsonl": "sections.jsonl",
+        },
+    )
+
+    title_results = search_titles("outside secret", output_dir=str(tmp_path), limit=5)
+    summary_results = search_summaries("secret capital", output_dir=str(tmp_path), limit=5)
+
+    assert all(item["file_url"] != "https://example.test/outside.pdf" for item in title_results)
+    assert all(item["file_url"] != "https://example.test/outside.pdf" for item in summary_results)
+
+
+def test_search_ready_data_missing_files_returns_empty_results(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    assert search_summaries("capital", output_dir=str(tmp_path)) == []
+    assert search_titles("capital", output_dir=str(tmp_path)) == []
+
+
+def test_classify_question_returns_l0_categories() -> None:
+    assert classify_question("List all documents in the catalog") == "catalog"
+    assert classify_question("Find the document titled Capital Adequacy Guideline") == "locate"
+    assert classify_question("Summarize the reserve method note") == "summary"
+    assert classify_question("How is required capital calculated?") == "document_qa"

--- a/tests/agentic_rag/test_ready_data_tools.py
+++ b/tests/agentic_rag/test_ready_data_tools.py
@@ -155,6 +155,7 @@ def test_search_summaries_keeps_catalog_docs_when_doc_summaries_are_partial(tmp_
 
     assert results[0]["file_url"] == "https://example.test/reserve.pdf"
     assert results[0]["summary"] == "Describes reserve calculation and liability assumptions."
+    assert results[0]["source"] == "doc_catalog"
 
 
 def test_search_tools_do_not_read_manifest_artifacts_outside_ready_data_dir(tmp_path: Path) -> None:

--- a/tests/test_fastapi_agentic_rag_endpoints.py
+++ b/tests/test_fastapi_agentic_rag_endpoints.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from ai_actuarial.api.app import create_app
+from ai_actuarial.rag.knowledge_base import KnowledgeBaseManager
+from ai_actuarial.storage import Storage
+
+
+def _write_config_files(base_dir: Path) -> Path:
+    db_path = base_dir / "index.db"
+    config_path = base_dir / "sites.yaml"
+    categories_path = base_dir / "categories.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "paths": {
+                    "db": str(db_path),
+                    "download_dir": str(base_dir / "files"),
+                    "updates_dir": str(base_dir / "updates"),
+                    "last_run_new": str(base_dir / "last_run_new.json"),
+                },
+                "defaults": {"user_agent": "test-agent/1.0", "max_pages": 10, "max_depth": 1},
+                "sites": [],
+                "scheduled_tasks": [],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    categories_path.write_text(yaml.safe_dump({"categories": {}}, sort_keys=False), encoding="utf-8")
+    return db_path
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_ready_data(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(
+        output_dir / "doc_catalog.jsonl",
+        [
+            {
+                "doc_id": "doc-a",
+                "file_url": "https://example.test/a.pdf",
+                "title": "Capital Adequacy Guideline",
+                "category": "regulation",
+                "summary": "Capital adequacy overview.",
+                "headings": ["Capital"],
+            },
+            {
+                "doc_id": "doc-b",
+                "file_url": "https://example.test/b.pdf",
+                "title": "Reserve Method Note",
+                "category": "method",
+                "summary": "Reserve method overview.",
+                "headings": ["Reserve"],
+            },
+        ],
+    )
+    _write_jsonl(
+        output_dir / "doc_summaries.jsonl",
+        [
+            {
+                "doc_id": "doc-a",
+                "file_url": "https://example.test/a.pdf",
+                "title": "Capital Adequacy Guideline",
+                "category": "regulation",
+                "summary": "Required capital and solvency ratio summary.",
+            },
+            {
+                "doc_id": "doc-b",
+                "file_url": "https://example.test/b.pdf",
+                "title": "Reserve Method Note",
+                "category": "method",
+                "summary": "Reserve assumptions summary.",
+            },
+        ],
+    )
+    _write_jsonl(
+        output_dir / "sections.jsonl",
+        [
+            {
+                "section_id": "doc-a#1",
+                "doc_id": "doc-a",
+                "heading_path": ["Capital"],
+                "text": "Required capital appears in the solvency section.",
+                "token_count": 8,
+            }
+        ],
+    )
+    (output_dir / "ready_data_manifest.json").write_text(
+        json.dumps(
+            {
+                "profile": "general",
+                "profile_version": "1",
+                "artifact_files": ["doc_catalog.jsonl", "doc_summaries.jsonl", "sections.jsonl"],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, Path]:
+    db_path = _write_config_files(tmp_path)
+    monkeypatch.setenv("CONFIG_PATH", str(tmp_path / "sites.yaml"))
+    monkeypatch.setenv("CATEGORIES_CONFIG_PATH", str(tmp_path / "categories.yaml"))
+    monkeypatch.setenv("FASTAPI_SESSION_SECRET", "agentic-rag-test-secret")
+    monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+    app = create_app()
+    return TestClient(app), db_path
+
+
+def test_fastapi_agentic_rag_summary_search_uses_explicit_output_dir(tmp_path: Path, monkeypatch) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "explicit"
+    _write_ready_data(ready_dir)
+
+    response = client.post(
+        "/api/agentic-rag/search/summaries",
+        json={"query": "required capital solvency", "limit": 1, "output_dir": str(ready_dir)},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["query"] == "required capital solvency"
+    assert body["limit"] == 1
+    assert body["count"] == 1
+    assert body["results"][0]["file_url"] == "https://example.test/a.pdf"
+    assert body["results"][0]["source"] == "doc_summaries"
+
+
+def test_fastapi_agentic_rag_title_search_resolves_registry_ready_manifest(tmp_path: Path, monkeypatch) -> None:
+    client, db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "kbs" / "kb-a" / "general" / "1"
+    _write_ready_data(ready_dir)
+    storage = Storage(str(db_path))
+    try:
+        manager = KnowledgeBaseManager(storage)
+        manager.create_kb(kb_id="kb-a", name="KB A", kb_mode="manual", manifest_profile="general")
+        storage.upsert_agentic_ready_manifest(
+            kb_id="kb-a",
+            profile="general",
+            profile_version="1",
+            status="ready",
+            output_dir=str(ready_dir),
+            artifact_files=["doc_catalog.jsonl", "doc_summaries.jsonl", "sections.jsonl"],
+            doc_count=2,
+            section_count=1,
+            built_at="2026-06-14T00:00:00+00:00",
+            source_db=str(db_path),
+        )
+    finally:
+        storage.close()
+
+    response = client.post(
+        "/api/agentic-rag/search/titles",
+        json={"query": "reserve method", "limit": 3, "kb_id": "kb-a", "profile": "general"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["kb_id"] == "kb-a"
+    assert body["profile"] == "general"
+    assert body["output_dir"] == str(ready_dir)
+    assert body["results"][0]["title"] == "Reserve Method Note"
+
+
+def test_fastapi_agentic_rag_search_returns_empty_results_for_no_match(tmp_path: Path, monkeypatch) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "explicit"
+    _write_ready_data(ready_dir)
+
+    response = client.post(
+        "/api/agentic-rag/search/summaries",
+        json={"query": "nonexistent phrase", "output_dir": str(ready_dir)},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["results"] == []
+    assert response.json()["count"] == 0
+
+
+def test_fastapi_agentic_rag_search_rejects_missing_output_dir(tmp_path: Path, monkeypatch) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/api/agentic-rag/search/summaries",
+        json={"query": "capital", "output_dir": str(tmp_path / "missing-ready")},
+    )
+
+    assert response.status_code == 400
+    assert "output_dir" in response.json()["error"]
+
+
+def test_fastapi_agentic_rag_search_rejects_explicit_output_dir_outside_ready_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "outside-ready"
+    _write_ready_data(ready_dir)
+
+    response = client.post(
+        "/api/agentic-rag/search/summaries",
+        json={"query": "capital", "output_dir": str(ready_dir)},
+    )
+
+    assert response.status_code == 400
+    assert "agentic_ready_data" in response.json()["error"]
+
+
+def test_fastapi_agentic_rag_search_rejects_output_dir_mixed_with_kb_registry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "explicit"
+    _write_ready_data(ready_dir)
+
+    response = client.post(
+        "/api/agentic-rag/search/titles",
+        json={"query": "capital", "output_dir": str(ready_dir), "kb_id": "kb-a", "profile": "general"},
+    )
+
+    assert response.status_code == 400
+    assert "cannot be combined" in response.json()["error"]
+
+
+def test_fastapi_agentic_rag_search_rejects_missing_ready_data_registry(tmp_path: Path, monkeypatch) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/api/agentic-rag/search/titles",
+        json={"query": "capital", "kb_id": "kb-missing", "profile": "general"},
+    )
+
+    assert response.status_code == 404
+    assert "ready_data" in response.json()["error"]
+
+
+def test_fastapi_agentic_rag_search_rejects_not_ready_registry_manifest(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "kbs" / "kb-building" / "general" / "1"
+    _write_ready_data(ready_dir)
+    storage = Storage(str(db_path))
+    try:
+        manager = KnowledgeBaseManager(storage)
+        manager.create_kb(kb_id="kb-building", name="Building KB", kb_mode="manual", manifest_profile="general")
+        storage.upsert_agentic_ready_manifest(
+            kb_id="kb-building",
+            profile="general",
+            profile_version="1",
+            status="building",
+            output_dir=str(ready_dir),
+        )
+    finally:
+        storage.close()
+
+    response = client.post(
+        "/api/agentic-rag/search/titles",
+        json={"query": "capital", "kb_id": "kb-building", "manifest_profile": "general"},
+    )
+
+    assert response.status_code == 409
+    assert "not ready" in response.json()["error"]
+
+
+def test_fastapi_agentic_rag_search_rejects_registry_output_dir_outside_ready_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "outside-ready"
+    _write_ready_data(ready_dir)
+    storage = Storage(str(db_path))
+    try:
+        manager = KnowledgeBaseManager(storage)
+        manager.create_kb(kb_id="kb-outside", name="Outside KB", kb_mode="manual", manifest_profile="general")
+        storage.upsert_agentic_ready_manifest(
+            kb_id="kb-outside",
+            profile="general",
+            profile_version="1",
+            status="ready",
+            output_dir=str(ready_dir),
+        )
+    finally:
+        storage.close()
+
+    response = client.post(
+        "/api/agentic-rag/search/titles",
+        json={"query": "capital", "kb_id": "kb-outside", "profile": "general"},
+    )
+
+    assert response.status_code == 400
+    assert "agentic_ready_data" in response.json()["error"]


### PR DESCRIPTION
## Summary
- add L0 ready_data search tools for summaries and document titles with stable result payloads
- add basic question classifier categories: catalog, locate, summary, document_qa
- add /api/agentic-rag/search/summaries and /api/agentic-rag/search/titles with PR2 manifest-registry resolution and output_dir guardrails

## Validation
- python -m py_compile ai_actuarial/agentic_rag/ready_data_tools.py ai_actuarial/agentic_rag/tools.py ai_actuarial/api/services/agentic_rag.py ai_actuarial/api/routers/agentic_rag.py ai_actuarial/api/app.py
- python -m pytest tests/agentic_rag/test_ready_data_tools.py tests/test_fastapi_agentic_rag_endpoints.py -q
- python -m pytest tests/agentic_rag/ tests/test_fastapi_agentic_rag_endpoints.py -q
- FASTAPI_SESSION_SECRET=fastapi-entrypoint-temp-secret python -m pytest tests/test_fastapi_entrypoint.py -q
- git diff --check

## Review gate
- Worker implementation used TDD; initial red state was missing ready_data_tools.
- Spec reviewer found no PR3 scope gaps.
- Code-quality reviewer found artifact/output_dir containment and partial doc_summaries edge cases; fixed with regression tests.
- Mandatory local codex review gate could not run because WindowsApps codex.exe returned Access is denied.

## Notes
- Plain tests/test_fastapi_entrypoint.py without FASTAPI_SESSION_SECRET returns 503 in this environment because CSRF is enabled without a default session secret; the same test passes with a temporary secret.