### PR TITLE
feat: PR4 L1 regulation ready data tools

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,16 +1,24 @@
 # Project Status
 
-- Date: 2026-06-14
-- Branch: `feat/agentic-rag-summary-title-tools`
-- Baseline: `origin/main` at `15edb62` (`Merge pull request #136 from ferryhe/feat/agentic-rag-manifest-registry-kb-ui`).
-- Scope: PR3 — L0 ready_data summary/title search tools and basic question classifier.
-- PR: [#137](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/137) — open; post-review source-label follow-up fixes prepared.
-- Previous PRs: [#136](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/136) — merged; [#135](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/135) — merged; [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged; [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
+- Date: 2026-06-15
+- Branch: `feat/agentic-rag-l1-regulation-tools`
+- Baseline: `origin/main` at `ac35a8a` (`Merge pull request #137 from ferryhe/feat/agentic-rag-summary-title-tools`).
+- Scope: PR4 — L1 regulation manifest, aliases, alias-first title search, section search, and relation tracing.
+- PR: pending creation for PR4.
+- Previous PRs: [#137](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/137) — merged; [#136](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/136) — merged; [#135](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/135) — merged; [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged; [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
 
 ### Current State
 
-- Local `main` was fast-forwarded to `origin/main` at `15edb62` after merging #136, then PR3 branch `feat/agentic-rag-summary-title-tools` was created from that baseline.
-- Current plan position: PR0, PR1, the roadmap reconciliation PR, and PR2 are merged; PR3 is open as #137 with L0 summary/title search tooling and FastAPI endpoints.
+- PR4 branch `feat/agentic-rag-l1-regulation-tools` was created from latest `main` after #137 merged, and now implements L1 regulation artifacts, read tools, read endpoints, and rag-admin regulation manifest build integration.
+- `ready_data_builder.build_l0(..., profile="regulation")` now emits the L1 profile artifacts declared in `manifest_profiles.py`: `doc_catalog.jsonl`, `title_aliases.jsonl`, `doc_summaries.jsonl`, `sections_structured.jsonl`, `relations_graph.json`, and `ready_data_manifest.json`. The existing L0 `general` manifest artifact list is unchanged.
+- `search_titles` now checks `title_aliases.jsonl` first for exact/near alias, identifier, document-number, or rule-number matches, returning `source="title_aliases"` and `matched_alias` for alias hits before fallback scoring.
+- Added `search_sections(query, output_dir, limit=...)` with stable document/section identity, heading, text snippet, score, and source fields. It prefers `sections_structured.jsonl` and falls back to L0 `sections.jsonl`.
+- Added `trace_relations(query_or_doc, output_dir, limit=...)` over `relations_graph.json`; missing or invalid optional L1 artifacts return empty relation results or safe section fallback in the existing ready-data-tool style.
+- Added `/api/agentic-rag/search/sections` and `/api/agentic-rag/trace/relations`, both using the existing Agentic RAG output-dir/KB registry resolution and `catalog.read` authorization dependency.
+- Updated the rag-admin manifest build path so KBs with `manifest_profile="regulation"` can build ready L1 manifests through `/api/rag/knowledge-bases/{kb_id}/agentic-ready-manifest/build`; `formula` remains a declared but not-yet-implemented profile and records a failed manifest.
+- Review follow-up tightened PR4 behavior: `kb_id`-only Agentic search now resolves the KB's stored `manifest_profile`, generated L1 aliases include explicit `document_numbers` and `rule_numbers`, numeric alias matching uses bounded rule/document-number checks to avoid `Rule 7` matching `Rule 70`, and builder validation rejects manifest artifact path escapes plus orphan L1 structured-section/relation references.
+- Local `main` was fast-forwarded to `origin/main` at `ac35a8a` after merging #137, then PR4 branch `feat/agentic-rag-l1-regulation-tools` was created from that baseline.
+- Current plan position: PR0, PR1, the roadmap reconciliation PR, PR2, and PR3 are merged; PR4 is in local implementation/review before PR creation.
 - Added ready-data search functions that read `ready_data_manifest.json`, `doc_catalog.jsonl`, optional `doc_summaries.jsonl`, and `sections.jsonl`; missing `doc_summaries.jsonl` falls back to catalog summaries, while missing/invalid ready-data files return empty tool results or API errors.
 - PR3 remote review follow-up: Copilot correctly identified that partial `doc_summaries.jsonl` rows could mislabel catalog-only fallback hits as `source="doc_summaries"`. The search merge now tracks catalog and summary provenance per document and the partial-summary regression test asserts `source="doc_catalog"`.
 - Review follow-up tightened ready-data file access: manifest artifact paths are contained under the ready_data output directory; explicit and registry-resolved `output_dir` values must stay under the DB-adjacent `agentic_ready_data` directory; `output_dir` cannot be mixed with `kb_id` registry lookup.
@@ -60,6 +68,22 @@
 - Tests added in `tests/agentic_rag/test_ready_data_tools.py` and `tests/test_fastapi_agentic_rag_endpoints.py`, including artifact path containment, partial `doc_summaries.jsonl`, explicit output_dir containment, mixed `output_dir`/`kb_id` rejection, and not-ready registry status handling.
 
 ### Verification
+- PR4 local verification:
+  - TDD red state: focused pytest initially failed during collection because `search_sections` was not exported from `ready_data_tools`.
+  - `python -m pytest tests\agentic_rag\test_ready_data_builder.py tests\agentic_rag\test_ready_data_tools.py tests\test_fastapi_agentic_rag_endpoints.py -q` (29 passed)
+  - `python -m py_compile ai_actuarial\agentic_rag\ready_data_builder.py ai_actuarial\agentic_rag\ready_data_tools.py ai_actuarial\agentic_rag\tools.py ai_actuarial\api\services\agentic_rag.py ai_actuarial\api\routers\agentic_rag.py` (pass)
+  - `python -m pytest tests\agentic_rag\ tests\test_fastapi_agentic_rag_endpoints.py -q` (51 passed)
+  - Controller follow-up added rag-admin build integration for `manifest_profile="regulation"` and preserved failed-manifest behavior for `formula`.
+  - `python -m py_compile ai_actuarial\agentic_rag\ready_data_builder.py ai_actuarial\agentic_rag\ready_data_tools.py ai_actuarial\agentic_rag\tools.py ai_actuarial\api\services\agentic_rag.py ai_actuarial\api\routers\agentic_rag.py ai_actuarial\api\services\rag_admin.py` (pass)
+  - `python -m pytest tests\agentic_rag\test_ready_data_builder.py tests\agentic_rag\test_ready_data_tools.py tests\test_fastapi_agentic_rag_endpoints.py tests\test_fastapi_rag_admin_endpoints.py -q` (52 passed)
+  - Independent spec/code-quality reviewers found registry profile resolution, typed alias-number fields, numeric alias false positives, validation path containment, and L1 referential validation gaps; all were fixed with regression tests.
+  - `python -m pytest tests\agentic_rag\test_ready_data_builder.py tests\agentic_rag\test_ready_data_tools.py tests\test_fastapi_agentic_rag_endpoints.py -q` (33 passed)
+  - `python -m pytest tests\test_fastapi_rag_admin_endpoints.py -q` (23 passed)
+  - `python -m pytest tests\agentic_rag\ tests\test_fastapi_agentic_rag_endpoints.py tests\test_fastapi_rag_admin_endpoints.py -q` (78 passed)
+  - `python -m ai_actuarial.agentic_rag.ready_data_builder --help` (pass; shows `--profile {general,regulation}`)
+  - `git diff --check` (pass; Git emitted LF/CRLF working-copy warnings only)
+  - Mandatory `codex review --uncommitted` still cannot run because WindowsApps `codex.exe` returned `Access is denied`; independent worker, spec reviewer, and code-quality reviewer were used as the available pre-PR review gate.
+  - `git status --short --branch` showed only the PR4 modified files listed in this status update.
 - PR3 controller verification:
   - Worker implementation used TDD; initial red state was missing `ready_data_tools` module.
   - Spec-compliance reviewer found no PR3 scope gaps.
@@ -117,8 +141,8 @@
 - Retriever protocol allows swapping in vector/ready_data/agentic retrievers later
 
 ### Next PRs
-- PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier — open as #137; post-review source-label follow-up pending push/remote checks/merge
-- PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations`
+- PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier — merged as #137.
+- PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations` — local implementation/review in progress before PR creation.
 - PR5a: backend Agentic loop core (`planner.py`, `agentic_loop.py`, `/api/agentic-rag/chat`, metadata trace)
 - PR5b: Chat integration and frontend trace display with `rag_mode=agentic`
 - PR6: L2 formula/actuarial manifest (`formula_cards`, structured tables, calculation terms, formula tools)

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -4,12 +4,12 @@
 - Branch: `feat/agentic-rag-l1-regulation-tools`
 - Baseline: `origin/main` at `ac35a8a` (`Merge pull request #137 from ferryhe/feat/agentic-rag-summary-title-tools`).
 - Scope: PR4 — L1 regulation manifest, aliases, alias-first title search, section search, and relation tracing.
-- PR: pending creation for PR4.
+- PR: [#138](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/138) — open; remote checks/review gate pending.
 - Previous PRs: [#137](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/137) — merged; [#136](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/136) — merged; [#135](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/135) — merged; [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged; [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
 
 ### Current State
 
-- PR4 branch `feat/agentic-rag-l1-regulation-tools` was created from latest `main` after #137 merged, and now implements L1 regulation artifacts, read tools, read endpoints, and rag-admin regulation manifest build integration.
+- PR4 branch `feat/agentic-rag-l1-regulation-tools` was created from latest `main` after #137 merged, implements L1 regulation artifacts, read tools, read endpoints, and rag-admin regulation manifest build integration, and is published as [#138](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/138).
 - `ready_data_builder.build_l0(..., profile="regulation")` now emits the L1 profile artifacts declared in `manifest_profiles.py`: `doc_catalog.jsonl`, `title_aliases.jsonl`, `doc_summaries.jsonl`, `sections_structured.jsonl`, `relations_graph.json`, and `ready_data_manifest.json`. The existing L0 `general` manifest artifact list is unchanged.
 - `search_titles` now checks `title_aliases.jsonl` first for exact/near alias, identifier, document-number, or rule-number matches, returning `source="title_aliases"` and `matched_alias` for alias hits before fallback scoring.
 - Added `search_sections(query, output_dir, limit=...)` with stable document/section identity, heading, text snippet, score, and source fields. It prefers `sections_structured.jsonl` and falls back to L0 `sections.jsonl`.
@@ -18,7 +18,7 @@
 - Updated the rag-admin manifest build path so KBs with `manifest_profile="regulation"` can build ready L1 manifests through `/api/rag/knowledge-bases/{kb_id}/agentic-ready-manifest/build`; `formula` remains a declared but not-yet-implemented profile and records a failed manifest.
 - Review follow-up tightened PR4 behavior: `kb_id`-only Agentic search now resolves the KB's stored `manifest_profile`, generated L1 aliases include explicit `document_numbers` and `rule_numbers`, numeric alias matching uses bounded rule/document-number checks to avoid `Rule 7` matching `Rule 70`, and builder validation rejects manifest artifact path escapes plus orphan L1 structured-section/relation references.
 - Local `main` was fast-forwarded to `origin/main` at `ac35a8a` after merging #137, then PR4 branch `feat/agentic-rag-l1-regulation-tools` was created from that baseline.
-- Current plan position: PR0, PR1, the roadmap reconciliation PR, PR2, and PR3 are merged; PR4 is in local implementation/review before PR creation.
+- Current plan position: PR0, PR1, the roadmap reconciliation PR, PR2, and PR3 are merged; PR4 is open as #138 and awaiting the remote checks/review gate.
 - Added ready-data search functions that read `ready_data_manifest.json`, `doc_catalog.jsonl`, optional `doc_summaries.jsonl`, and `sections.jsonl`; missing `doc_summaries.jsonl` falls back to catalog summaries, while missing/invalid ready-data files return empty tool results or API errors.
 - PR3 remote review follow-up: Copilot correctly identified that partial `doc_summaries.jsonl` rows could mislabel catalog-only fallback hits as `source="doc_summaries"`. The search merge now tracks catalog and summary provenance per document and the partial-summary regression test asserts `source="doc_catalog"`.
 - Review follow-up tightened ready-data file access: manifest artifact paths are contained under the ready_data output directory; explicit and registry-resolved `output_dir` values must stay under the DB-adjacent `agentic_ready_data` directory; `output_dir` cannot be mixed with `kb_id` registry lookup.
@@ -142,7 +142,7 @@
 
 ### Next PRs
 - PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier — merged as #137.
-- PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations` — local implementation/review in progress before PR creation.
+- PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations` — open as #138; remote checks/review gate pending.
 - PR5a: backend Agentic loop core (`planner.py`, `agentic_loop.py`, `/api/agentic-rag/chat`, metadata trace)
 - PR5b: Chat integration and frontend trace display with `rag_mode=agentic`
 - PR6: L2 formula/actuarial manifest (`formula_cards`, structured tables, calculation terms, formula tools)

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -4,7 +4,7 @@
 - Branch: `feat/agentic-rag-l1-regulation-tools`
 - Baseline: `origin/main` at `ac35a8a` (`Merge pull request #137 from ferryhe/feat/agentic-rag-summary-title-tools`).
 - Scope: PR4 — L1 regulation manifest, aliases, alias-first title search, section search, and relation tracing.
-- PR: [#138](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/138) — open; remote checks/review gate pending.
+- PR: [#138](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/138) — open; `python-smoke` passed; Copilot review follow-up addressed locally and pending push/recheck.
 - Previous PRs: [#137](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/137) — merged; [#136](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/136) — merged; [#135](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/135) — merged; [#134](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/134) — merged; [#133](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/133) (PR1 ready_data builder) — merged.
 
 ### Current State
@@ -17,8 +17,9 @@
 - Added `/api/agentic-rag/search/sections` and `/api/agentic-rag/trace/relations`, both using the existing Agentic RAG output-dir/KB registry resolution and `catalog.read` authorization dependency.
 - Updated the rag-admin manifest build path so KBs with `manifest_profile="regulation"` can build ready L1 manifests through `/api/rag/knowledge-bases/{kb_id}/agentic-ready-manifest/build`; `formula` remains a declared but not-yet-implemented profile and records a failed manifest.
 - Review follow-up tightened PR4 behavior: `kb_id`-only Agentic search now resolves the KB's stored `manifest_profile`, generated L1 aliases include explicit `document_numbers` and `rule_numbers`, numeric alias matching uses bounded rule/document-number checks to avoid `Rule 7` matching `Rule 70`, and builder validation rejects manifest artifact path escapes plus orphan L1 structured-section/relation references.
+- PR4 #138 remote gate: GitHub `python-smoke` passed; Copilot left 3 valid inline comments. Follow-up fixes avoid general-profile section-entry memory duplication, keep `text_snippet` within its max length contract, and replace relation expansion duplicate checks with a set-backed relation key lookup.
 - Local `main` was fast-forwarded to `origin/main` at `ac35a8a` after merging #137, then PR4 branch `feat/agentic-rag-l1-regulation-tools` was created from that baseline.
-- Current plan position: PR0, PR1, the roadmap reconciliation PR, PR2, and PR3 are merged; PR4 is open as #138 and awaiting the remote checks/review gate.
+- Current plan position: PR0, PR1, the roadmap reconciliation PR, PR2, and PR3 are merged; PR4 is open as #138 with review follow-up pending remote recheck after push.
 - Added ready-data search functions that read `ready_data_manifest.json`, `doc_catalog.jsonl`, optional `doc_summaries.jsonl`, and `sections.jsonl`; missing `doc_summaries.jsonl` falls back to catalog summaries, while missing/invalid ready-data files return empty tool results or API errors.
 - PR3 remote review follow-up: Copilot correctly identified that partial `doc_summaries.jsonl` rows could mislabel catalog-only fallback hits as `source="doc_summaries"`. The search merge now tracks catalog and summary provenance per document and the partial-summary regression test asserts `source="doc_catalog"`.
 - Review follow-up tightened ready-data file access: manifest artifact paths are contained under the ready_data output directory; explicit and registry-resolved `output_dir` values must stay under the DB-adjacent `agentic_ready_data` directory; `output_dir` cannot be mixed with `kb_id` registry lookup.
@@ -84,6 +85,13 @@
   - `git diff --check` (pass; Git emitted LF/CRLF working-copy warnings only)
   - Mandatory `codex review --uncommitted` still cannot run because WindowsApps `codex.exe` returned `Access is denied`; independent worker, spec reviewer, and code-quality reviewer were used as the available pre-PR review gate.
   - `git status --short --branch` showed only the PR4 modified files listed in this status update.
+- PR4 #138 post-review follow-up verification:
+  - GitHub remote gate before follow-up: `python-smoke` passed; Copilot left 3 valid inline comments about general-profile memory duplication, text snippet max-length contract, and relation expansion duplicate-check complexity.
+  - `python -m pytest tests\agentic_rag\test_ready_data_tools.py tests\agentic_rag\test_ready_data_builder.py -q` (22 passed)
+  - `python -m py_compile ai_actuarial\agentic_rag\ready_data_builder.py ai_actuarial\agentic_rag\ready_data_tools.py ai_actuarial\agentic_rag\tools.py ai_actuarial\api\services\agentic_rag.py ai_actuarial\api\routers\agentic_rag.py ai_actuarial\api\services\rag_admin.py` (pass)
+  - `python -m pytest tests\agentic_rag\ tests\test_fastapi_agentic_rag_endpoints.py tests\test_fastapi_rag_admin_endpoints.py -q` (79 passed)
+  - `git diff --check` (pass; Git emitted LF/CRLF working-copy warnings only)
+  - Mandatory `codex review --uncommitted` still cannot run because WindowsApps `codex.exe` returned `Access is denied`; the blocker remains recorded for the PR gate.
 - PR3 controller verification:
   - Worker implementation used TDD; initial red state was missing `ready_data_tools` module.
   - Spec-compliance reviewer found no PR3 scope gaps.
@@ -142,7 +150,7 @@
 
 ### Next PRs
 - PR3: document location and summary tools (`search_summaries` first, basic `search_titles`) + basic question classifier — merged as #137.
-- PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations` — open as #138; remote checks/review gate pending.
+- PR4: L1 regulation manifest, aliases, alias-first `search_titles`, `search_sections`, `trace_relations` — open as #138; Copilot follow-up pending remote recheck after push.
 - PR5a: backend Agentic loop core (`planner.py`, `agentic_loop.py`, `/api/agentic-rag/chat`, metadata trace)
 - PR5b: Chat integration and frontend trace display with `rag_mode=agentic`
 - PR6: L2 formula/actuarial manifest (`formula_cards`, structured tables, calculation terms, formula tools)

--- a/ai_actuarial/agentic_rag/ready_data_builder.py
+++ b/ai_actuarial/agentic_rag/ready_data_builder.py
@@ -1,7 +1,7 @@
-"""Ready-data builder — L0 MVP.
+"""Ready-data builder for Agentic RAG ready_data artifacts.
 
 Reads existing catalog_items and global_chunks from the SQLite DB
-and produces the L0 ready_data artifacts:
+and produces ready_data artifacts:
 
   doc_catalog.jsonl   — document index with title, category, summary, headings
   sections.jsonl      — section-level chunks with heading_path and token_count
@@ -16,12 +16,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
-from .manifest_profiles import L0_GENERAL, PROFILES
+from .manifest_profiles import PROFILES
 
 try:
     from ai_actuarial.config import settings
@@ -67,6 +69,48 @@ SECTION_FIELDS = [
     "token_count",
 ]
 
+TITLE_ALIAS_FIELDS = [
+    "doc_id",
+    "file_url",
+    "title",
+    "aliases",
+    "identifiers",
+    "document_numbers",
+    "rule_numbers",
+]
+
+DOC_SUMMARY_FIELDS = [
+    "doc_id",
+    "file_url",
+    "title",
+    "category",
+    "summary",
+]
+
+STRUCTURED_SECTION_FIELDS = [
+    "section_id",
+    "doc_id",
+    "file_url",
+    "title",
+    "heading_path",
+    "heading",
+    "text",
+    "token_count",
+    "document_aliases",
+]
+
+RELATION_FIELDS = [
+    "relation_type",
+    "doc_id",
+    "file_url",
+    "title",
+    "alias",
+    "section_id",
+    "section_heading",
+    "target_type",
+    "target_id",
+]
+
 
 # ── Extraction helpers ────────────────────────────────────────────────────────
 
@@ -97,6 +141,55 @@ def _parse_keywords(raw: str | None) -> list[str]:
         except json.JSONDecodeError:
             pass
     return [k.strip() for k in raw.split(",") if k.strip()]
+
+
+def _unique_strings(values: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        key = text.lower()
+        if text and key not in seen:
+            seen.add(key)
+            out.append(text)
+    return out
+
+
+def _extract_identifier_parts(title: str, file_url: str) -> tuple[list[str], list[str], list[str]]:
+    document_numbers: list[str] = []
+    rule_numbers: list[str] = []
+    for match in re.finditer(r"(?:第\s*)?([0-9]+)\s*号", title, flags=re.IGNORECASE):
+        document_numbers.append(match.group(1))
+    for match in re.finditer(
+        r"\b(?:rule|article)\s*[-#: ]\s*([A-Za-z0-9_.-]+)",
+        title,
+        flags=re.IGNORECASE,
+    ):
+        rule_numbers.append(match.group(1))
+    identifiers: list[str] = [*document_numbers, *rule_numbers]
+    for match in re.finditer(
+        r"\b(?:regulation|guideline|standard)\s*[-#: ]\s*([A-Za-z0-9_.-]+)",
+        title,
+        flags=re.IGNORECASE,
+    ):
+        identifiers.append(match.group(1))
+    parsed = urlparse(file_url)
+    stem = Path(parsed.path or file_url).stem
+    if stem:
+        identifiers.append(stem)
+    return _unique_strings(identifiers), _unique_strings(document_numbers), _unique_strings(rule_numbers)
+
+
+def _build_doc_aliases(entry: dict[str, Any]) -> tuple[list[str], list[str], list[str], list[str]]:
+    title = str(entry.get("title") or "").strip()
+    file_url = str(entry.get("file_url") or entry.get("doc_id") or "").strip()
+    identifiers, document_numbers, rule_numbers = _extract_identifier_parts(title, file_url)
+    aliases = [title, *identifiers]
+    return _unique_strings(aliases), identifiers, document_numbers, rule_numbers
+
+
+def _section_heading(heading_path: list[str]) -> str:
+    return heading_path[-1] if heading_path else ""
 
 
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
@@ -136,11 +229,10 @@ def build_l0(
         )
     profile_def = PROFILES[profile]
 
-    # MVP only supports L0 general; fail fast for L1/L2
-    if profile != "general":
+    if profile not in {"general", "regulation"}:
         raise NotImplementedError(
-            f"Profile {profile!r} (L1/L2) is not yet implemented. "
-            f"Only 'general' (L0) is supported in this MVP."
+            f"Profile {profile!r} is not yet implemented. "
+            "Only 'general' (L0) and 'regulation' (L1) are supported."
         )
     if output_dir is None:
         if kb_id:
@@ -215,6 +307,7 @@ def build_l0(
 
     doc_catalog_path = os.path.join(output_dir, "doc_catalog.jsonl")
     doc_count = 0
+    catalog_entries: list[dict[str, Any]] = []
     with open(doc_catalog_path, "w", encoding="utf-8") as f:
         for row in catalog_rows:
             file_url = row["file_url"]
@@ -235,11 +328,13 @@ def build_l0(
                 "rag_chunk_count": row["rag_chunk_count"] or 0,
             }
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            catalog_entries.append(entry)
             doc_count += 1
 
     # ── 2. Build sections.jsonl ───────────────────────────────────────────
     section_count = 0
     sections_path = os.path.join(output_dir, "sections.jsonl")
+    section_entries: list[dict[str, Any]] = []
     with open(sections_path, "w", encoding="utf-8") as f:
         for row in chunk_rows:
             file_url = row["file_url"]
@@ -255,7 +350,98 @@ def build_l0(
                 "token_count": row["token_count"] or 0,
             }
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            section_entries.append(entry)
             section_count += 1
+
+    alias_rows: list[dict[str, Any]] = []
+    aliases_by_doc: dict[str, list[str]] = {}
+    if profile == "regulation":
+        for entry in catalog_entries:
+            aliases, identifiers, document_numbers, rule_numbers = _build_doc_aliases(entry)
+            aliases_by_doc[entry["doc_id"]] = aliases
+            alias_rows.append(
+                {
+                    "doc_id": entry["doc_id"],
+                    "file_url": entry["file_url"],
+                    "title": entry["title"],
+                    "aliases": aliases,
+                    "identifiers": identifiers,
+                    "document_numbers": document_numbers,
+                    "rule_numbers": rule_numbers,
+                }
+            )
+        title_aliases_path = os.path.join(output_dir, "title_aliases.jsonl")
+        with open(title_aliases_path, "w", encoding="utf-8") as f:
+            for row in alias_rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+        doc_summaries_path = os.path.join(output_dir, "doc_summaries.jsonl")
+        with open(doc_summaries_path, "w", encoding="utf-8") as f:
+            for entry in catalog_entries:
+                f.write(
+                    json.dumps(
+                        {
+                            "doc_id": entry["doc_id"],
+                            "file_url": entry["file_url"],
+                            "title": entry["title"],
+                            "category": entry["category"],
+                            "summary": entry["summary"],
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+
+        catalog_by_doc = {entry["doc_id"]: entry for entry in catalog_entries}
+        relations: list[dict[str, Any]] = []
+        structured_sections_path = os.path.join(output_dir, "sections_structured.jsonl")
+        with open(structured_sections_path, "w", encoding="utf-8") as f:
+            for section in section_entries:
+                doc = catalog_by_doc.get(section["doc_id"], {})
+                heading_path = section.get("heading_path") or []
+                heading = _section_heading(heading_path)
+                structured = {
+                    "section_id": section["section_id"],
+                    "doc_id": section["doc_id"],
+                    "file_url": doc.get("file_url", section["doc_id"]),
+                    "title": doc.get("title", section["doc_id"]),
+                    "heading_path": heading_path,
+                    "heading": heading,
+                    "text": section.get("text", ""),
+                    "token_count": section.get("token_count", 0),
+                    "document_aliases": aliases_by_doc.get(section["doc_id"], []),
+                }
+                f.write(json.dumps(structured, ensure_ascii=False) + "\n")
+                relations.append(
+                    {
+                        "relation_type": "document_has_section",
+                        "doc_id": structured["doc_id"],
+                        "file_url": structured["file_url"],
+                        "title": structured["title"],
+                        "section_id": structured["section_id"],
+                        "section_heading": heading,
+                        "target_type": "section",
+                        "target_id": structured["section_id"],
+                    }
+                )
+
+        for row in alias_rows:
+            for alias in row["aliases"]:
+                relations.append(
+                    {
+                        "relation_type": "alias_of",
+                        "doc_id": row["doc_id"],
+                        "file_url": row["file_url"],
+                        "title": row["title"],
+                        "alias": alias,
+                        "target_type": "document",
+                        "target_id": row["doc_id"],
+                    }
+                )
+
+        relations_path = os.path.join(output_dir, "relations_graph.json")
+        with open(relations_path, "w", encoding="utf-8") as f:
+            json.dump({"relations": relations}, f, indent=2, ensure_ascii=False)
 
     # ── 3. Build ready_data_manifest.json ─────────────────────────────────
     profile_def_artifacts = profile_def.artifacts
@@ -273,6 +459,10 @@ def build_l0(
         "schema_versions": {
             "doc_catalog_fields": DOC_CATALOG_FIELDS,
             "section_fields": SECTION_FIELDS,
+            "title_alias_fields": TITLE_ALIAS_FIELDS,
+            "doc_summary_fields": DOC_SUMMARY_FIELDS,
+            "structured_section_fields": STRUCTURED_SECTION_FIELDS,
+            "relation_fields": RELATION_FIELDS,
         },
     }
     manifest_path = os.path.join(output_dir, "ready_data_manifest.json")
@@ -281,7 +471,8 @@ def build_l0(
 
     conn.close()
     logger.info(
-        "L0 ready_data built: %d docs, %d sections → %s",
+        "%s ready_data built: %d docs, %d sections → %s",
+        profile,
         doc_count,
         section_count,
         output_dir,
@@ -307,6 +498,22 @@ def _safe_jsonl_load(file_path: str) -> tuple[list[dict], list[str]]:
     return entries, errors
 
 
+def _manifest_artifact_path(output_dir: str, artifact: Any) -> tuple[str | None, str | None]:
+    artifact_text = str(artifact or "").strip()
+    if not artifact_text:
+        return None, "artifact path is empty"
+    candidate = Path(artifact_text)
+    if candidate.is_absolute():
+        return None, f"artifact path escapes output_dir: {artifact_text}"
+    root = Path(output_dir).resolve()
+    resolved = (root / candidate).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return None, f"artifact path escapes output_dir: {artifact_text}"
+    return str(resolved), None
+
+
 def validate(output_dir: str) -> dict:
     """Validate built ready_data artifacts.
 
@@ -328,11 +535,19 @@ def validate(output_dir: str) -> dict:
         errors.append(f"ready_data_manifest.json: invalid JSON: {e}")
         return {"valid": False, "errors": errors, "warnings": warnings}
 
+    artifact_paths: dict[str, str] = {}
     for artifact in manifest.get("artifact_files", []):
-        path = os.path.join(output_dir, artifact)
+        artifact_text = str(artifact or "").strip()
+        path, path_error = _manifest_artifact_path(output_dir, artifact)
+        artifact_name = os.path.basename(artifact_text)
+        if path_error:
+            errors.append(path_error)
+            continue
+        if path and artifact_name:
+            artifact_paths[artifact_name] = path
         if not os.path.isfile(path):
             errors.append(f"artifact missing: {artifact}")
-        elif artifact.endswith(".jsonl"):
+        elif artifact_text.endswith(".jsonl"):
             # Validate JSONL: every line must parse
             bad_lines = 0
             with open(path, "r", encoding="utf-8") as af:
@@ -349,24 +564,31 @@ def validate(output_dir: str) -> dict:
             if bad_lines:
                 errors.append(f"{artifact}: {bad_lines} invalid JSON lines")
 
-        elif artifact.endswith(".json"):
+        elif artifact_text.endswith(".json"):
             try:
                 with open(path, "r", encoding="utf-8") as af:
                     json.load(af)
             except json.JSONDecodeError as e:
                 errors.append(f"{artifact}: invalid JSON: {e}")
 
-    # Cross-reference: doc_ids in sections must exist in catalog
-    doc_catalog_path = os.path.join(output_dir, "doc_catalog.jsonl")
-    sections_path = os.path.join(output_dir, "sections.jsonl")
-    if os.path.isfile(doc_catalog_path) and os.path.isfile(sections_path):
+    # Cross-reference: doc_ids in sections must exist in catalog.
+    doc_catalog_path = artifact_paths.get("doc_catalog.jsonl") or os.path.join(output_dir, "doc_catalog.jsonl")
+    sections_path = artifact_paths.get("sections.jsonl") or os.path.join(output_dir, "sections.jsonl")
+    catalog_entries: list[dict[str, Any]] = []
+    catalog_doc_ids: set[str] = set()
+    if os.path.isfile(doc_catalog_path):
         catalog_entries, cat_errors = _safe_jsonl_load(doc_catalog_path)
         errors.extend(cat_errors)
-        catalog_doc_ids: set[str] = {e.get("doc_id", "") for e in catalog_entries}
+        catalog_doc_ids = {e.get("doc_id", "") for e in catalog_entries}
 
+    section_entries: list[dict[str, Any]] = []
+    section_doc_ids: set[str] = set()
+    section_ids: set[str] = set()
+    if catalog_doc_ids and os.path.isfile(sections_path):
         section_entries, sec_errors = _safe_jsonl_load(sections_path)
         errors.extend(sec_errors)
-        section_doc_ids: set[str] = {e.get("doc_id", "") for e in section_entries}
+        section_doc_ids = {e.get("doc_id", "") for e in section_entries}
+        section_ids = {e.get("section_id", "") for e in section_entries if e.get("section_id")}
 
         orphan_sections = section_doc_ids - catalog_doc_ids
         if orphan_sections:
@@ -382,6 +604,61 @@ def validate(output_dir: str) -> dict:
                 f"(e.g. {list(docs_without_sections)[:3]})"
             )
 
+    structured_sections_path = artifact_paths.get("sections_structured.jsonl") or os.path.join(output_dir, "sections_structured.jsonl")
+    structured_section_ids: set[str] = set()
+    if catalog_doc_ids and os.path.isfile(structured_sections_path):
+        structured_entries, structured_errors = _safe_jsonl_load(structured_sections_path)
+        errors.extend(structured_errors)
+        structured_doc_ids = {e.get("doc_id", "") for e in structured_entries}
+        orphan_structured = structured_doc_ids - catalog_doc_ids
+        if orphan_structured:
+            errors.append(
+                f"{len(orphan_structured)} structured section doc_ids not in catalog "
+                f"(e.g. {list(orphan_structured)[:3]})"
+            )
+        structured_section_ids = {e.get("section_id", "") for e in structured_entries if e.get("section_id")}
+
+    relations_path = artifact_paths.get("relations_graph.json") or os.path.join(output_dir, "relations_graph.json")
+    if catalog_doc_ids and os.path.isfile(relations_path):
+        try:
+            with open(relations_path, "r", encoding="utf-8") as f:
+                graph = json.load(f)
+        except json.JSONDecodeError as e:
+            errors.append(f"relations_graph.json: invalid JSON: {e}")
+        else:
+            relations = graph.get("relations") if isinstance(graph, dict) else None
+            if not isinstance(relations, list):
+                errors.append("relations_graph.json: relations must be a list")
+            else:
+                relation_doc_ids = {
+                    row.get("doc_id", "")
+                    for row in relations
+                    if isinstance(row, dict) and row.get("doc_id")
+                }
+                orphan_relation_docs = relation_doc_ids - catalog_doc_ids
+                if orphan_relation_docs:
+                    errors.append(
+                        f"{len(orphan_relation_docs)} relation doc_ids not in catalog "
+                        f"(e.g. {list(orphan_relation_docs)[:3]})"
+                    )
+                relation_section_ids = {
+                    row.get("target_id", "")
+                    for row in relations
+                    if isinstance(row, dict) and row.get("target_type") == "section" and row.get("target_id")
+                }
+                relation_section_ids.update(
+                    row.get("section_id", "")
+                    for row in relations
+                    if isinstance(row, dict) and row.get("section_id")
+                )
+                known_section_ids = section_ids | structured_section_ids
+                orphan_relation_sections = relation_section_ids - known_section_ids
+                if orphan_relation_sections:
+                    errors.append(
+                        f"{len(orphan_relation_sections)} relation section targets not in sections "
+                        f"(e.g. {list(orphan_relation_sections)[:3]})"
+                    )
+
     return {
         "valid": len(errors) == 0,
         "errors": errors,
@@ -396,7 +673,7 @@ def main():
 
     import argparse
 
-    parser = argparse.ArgumentParser(description="Build L0 Agentic RAG ready_data")
+    parser = argparse.ArgumentParser(description="Build Agentic RAG ready_data")
     parser.add_argument("--db", default=None, help="SQLite DB path")
     parser.add_argument(
         "--output-dir", default=None, help="Output directory for ready_data"
@@ -404,8 +681,8 @@ def main():
     parser.add_argument(
         "--profile",
         default="general",
-        choices=["general"],
-        help="Manifest profile (only 'general' L0 supported in this MVP)",
+        choices=["general", "regulation"],
+        help="Manifest profile",
     )
     parser.add_argument("--kb-id", default=None, help="Optional knowledge-base ID to export")
     parser.add_argument("--validate", action="store_true", help="Validate after build")
@@ -420,10 +697,11 @@ def main():
     print(json.dumps(manifest, indent=2, ensure_ascii=False))
 
     if args.validate:
-        default_output_dir = os.path.join("data", "agentic_ready_data", args.profile, L0_GENERAL.version)
+        profile_version = PROFILES[args.profile].version
+        default_output_dir = os.path.join("data", "agentic_ready_data", args.profile, profile_version)
         if args.kb_id:
             safe_kb_id = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in args.kb_id)
-            default_output_dir = os.path.join("data", "agentic_ready_data", "kbs", safe_kb_id, args.profile, L0_GENERAL.version)
+            default_output_dir = os.path.join("data", "agentic_ready_data", "kbs", safe_kb_id, args.profile, profile_version)
         result = validate(
             args.output_dir
             or default_output_dir

--- a/ai_actuarial/agentic_rag/ready_data_builder.py
+++ b/ai_actuarial/agentic_rag/ready_data_builder.py
@@ -350,7 +350,8 @@ def build_l0(
                 "token_count": row["token_count"] or 0,
             }
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-            section_entries.append(entry)
+            if profile == "regulation":
+                section_entries.append(entry)
             section_count += 1
 
     alias_rows: list[dict[str, Any]] = []

--- a/ai_actuarial/agentic_rag/ready_data_tools.py
+++ b/ai_actuarial/agentic_rag/ready_data_tools.py
@@ -90,12 +90,18 @@ def _load_ready_data(output_dir: str | Path) -> dict[str, Any] | None:
     summary_rows = _read_jsonl(summaries_path)
     source = "doc_summaries" if summary_rows else "doc_catalog"
     sections = _read_jsonl(_artifact_path(root, manifest, "sections.jsonl"))
+    aliases = _read_jsonl(_artifact_path(root, manifest, "title_aliases.jsonl"))
+    sections_structured = _read_jsonl(_artifact_path(root, manifest, "sections_structured.jsonl"))
+    relations_graph = _read_json(_artifact_path(root, manifest, "relations_graph.json")) or {}
     return {
         "manifest": manifest,
         "catalog": catalog,
         "summaries": summary_rows,
         "summary_source": source,
         "sections": sections,
+        "aliases": aliases,
+        "sections_structured": sections_structured,
+        "relations_graph": relations_graph,
     }
 
 
@@ -164,6 +170,84 @@ def _format_result(row: dict[str, Any], *, score: float, source: str) -> dict[st
     }
 
 
+def _catalog_by_doc(catalog: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {_doc_key(row): row for row in catalog if _doc_key(row)}
+
+
+def _list_text(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [_norm(item) for item in value if _norm(item)]
+    text = _norm(value)
+    return [text] if text else []
+
+
+def _first_text(value: Any) -> str:
+    parts = _list_text(value)
+    return parts[-1] if parts else ""
+
+
+def _text_snippet(value: Any, max_chars: int = 240) -> str:
+    text = " ".join(_norm(value).split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "..."
+
+
+def _normalized_phrase(value: Any) -> str:
+    return " ".join(_norm(value).lower().split())
+
+
+def _bounded_phrase_contains(text: str, phrase: str) -> bool:
+    if not text or not phrase:
+        return False
+    pattern = r"(?<![\w])" + r"\s+".join(re.escape(part) for part in phrase.split()) + r"(?![\w])"
+    return bool(re.search(pattern, text, flags=re.IGNORECASE | re.UNICODE))
+
+
+def _number_alias_in_query(query_text: str, number: str) -> bool:
+    if not number:
+        return False
+    escaped = re.escape(number)
+    patterns = (
+        rf"(?<![A-Za-z0-9])(?:第\s*)?{escaped}\s*(?:号)?(?![A-Za-z0-9])",
+        rf"(?<![A-Za-z0-9])(?:rule|article)\s*[-#: ]\s*{escaped}(?![A-Za-z0-9])",
+    )
+    return any(re.search(pattern, query_text, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def _alias_match_score(query_text: str, alias_row: dict[str, Any]) -> tuple[float, str]:
+    query_lower = _normalized_phrase(query_text)
+    candidates: list[tuple[str, str]] = []
+    candidates.extend(("alias", item) for item in _list_text(alias_row.get("aliases")))
+    candidates.extend(("identifier", item) for item in _list_text(alias_row.get("identifiers")))
+    candidates.extend(("document_number", item) for item in _list_text(alias_row.get("document_numbers")))
+    candidates.extend(("rule_number", item) for item in _list_text(alias_row.get("rule_numbers")))
+    candidates.append(("title", _norm(alias_row.get("title"))))
+    best_score = 0.0
+    best_match = ""
+    for kind, candidate in candidates:
+        candidate_lower = _normalized_phrase(candidate)
+        if not candidate_lower:
+            continue
+        if query_lower == candidate_lower:
+            return 100.0, candidate
+        if kind in {"document_number", "rule_number"} or re.fullmatch(r"[0-9]+", candidate_lower):
+            if _number_alias_in_query(query_text, candidate_lower):
+                score = 92.0
+            else:
+                continue
+        elif _bounded_phrase_contains(query_lower, candidate_lower):
+            score = 88.0 + min(len(candidate_lower), len(query_lower)) / max(len(candidate_lower), len(query_lower))
+        elif len(_tokens(query_lower)) >= 2 and _bounded_phrase_contains(candidate_lower, query_lower):
+            score = 80.0 + min(len(candidate_lower), len(query_lower)) / max(len(candidate_lower), len(query_lower))
+        else:
+            continue
+        if score > best_score:
+            best_score = score
+            best_match = candidate
+    return best_score, best_match
+
+
 def _limit(value: int | None) -> int:
     try:
         parsed = int(value if value is not None else 10)
@@ -212,7 +296,7 @@ def search_summaries(query: str, *, output_dir: str | Path, limit: int = 10) -> 
 
 
 def search_titles(query: str, *, output_dir: str | Path, limit: int = 10) -> list[dict[str, Any]]:
-    """Search L0 ready-data document titles with lightweight keyword scoring."""
+    """Search ready-data document titles, preferring L1 aliases before scoring."""
     query_text = _norm(query)
     query_tokens = _tokens(query_text)
     if not query_tokens:
@@ -221,8 +305,30 @@ def search_titles(query: str, *, output_dir: str | Path, limit: int = 10) -> lis
     if not ready_data:
         return []
 
+    by_doc = _catalog_by_doc(ready_data["catalog"])
+    alias_hits: list[dict[str, Any]] = []
+    seen_alias_docs: set[str] = set()
+    for alias_row in ready_data["aliases"]:
+        score, matched_alias = _alias_match_score(query_text, alias_row)
+        if score <= 0:
+            continue
+        doc_id = _doc_key(alias_row)
+        row = dict(by_doc.get(doc_id, {}))
+        row.update({k: v for k, v in alias_row.items() if v not in (None, "")})
+        result = _format_result(row, score=score, source="title_aliases")
+        result["matched_alias"] = matched_alias
+        alias_hits.append(result)
+        seen_alias_docs.add(result["doc_id"])
+    if alias_hits:
+        alias_hits.sort(key=lambda item: (-float(item["score"]), item["title"].lower(), item["file_url"]))
+        if len(alias_hits) >= _limit(limit):
+            return alias_hits[: _limit(limit)]
+
     scored: list[dict[str, Any]] = []
     for row in ready_data["catalog"]:
+        doc_id = _doc_key(row)
+        if doc_id in seen_alias_docs:
+            continue
         headings = row.get("headings") or []
         heading_text = " ".join(_norm(item) for item in headings) if isinstance(headings, list) else _norm(headings)
         title = _norm(row.get("title"))
@@ -240,4 +346,124 @@ def search_titles(query: str, *, output_dir: str | Path, limit: int = 10) -> lis
         scored.append(_format_result(row, score=score, source="doc_catalog"))
 
     scored.sort(key=lambda item: (-float(item["score"]), item["title"].lower(), item["file_url"]))
+    return (alias_hits + scored)[: _limit(limit)]
+
+
+def search_sections(query: str, *, output_dir: str | Path, limit: int = 10) -> list[dict[str, Any]]:
+    """Search L1 structured sections, falling back to L0 sections when needed."""
+    query_text = _norm(query)
+    query_tokens = _tokens(query_text)
+    if not query_tokens:
+        return []
+    ready_data = _load_ready_data(output_dir)
+    if not ready_data:
+        return []
+
+    catalog = _catalog_by_doc(ready_data["catalog"])
+    source = "sections_structured" if ready_data["sections_structured"] else "sections"
+    section_rows = ready_data["sections_structured"] or ready_data["sections"]
+    scored: list[dict[str, Any]] = []
+    for section in section_rows:
+        doc_id = _norm(section.get("doc_id"))
+        if not doc_id:
+            continue
+        doc = catalog.get(doc_id, {})
+        heading_path = _list_text(section.get("heading_path"))
+        heading = _norm(section.get("heading")) or _first_text(heading_path)
+        text = _norm(section.get("text"))
+        alias_text = " ".join(_list_text(section.get("aliases")) + _list_text(section.get("document_aliases")))
+        score = (
+            _field_score(query_tokens, heading, 4.0)
+            + _field_score(query_tokens, " ".join(heading_path), 3.0)
+            + _field_score(query_tokens, text, 1.0)
+            + _field_score(query_tokens, _norm(doc.get("title")) or _norm(section.get("title")), 1.0)
+            + _field_score(query_tokens, alias_text, 4.0)
+        )
+        if query_text.lower() and query_text.lower() in f"{heading} {text}".lower():
+            score += 3.0
+        if score <= 0:
+            continue
+        file_url = _norm(section.get("file_url")) or _norm(doc.get("file_url")) or doc_id
+        scored.append(
+            {
+                "doc_id": doc_id,
+                "file_url": file_url,
+                "title": _norm(section.get("title")) or _norm(doc.get("title")) or file_url,
+                "section_id": _norm(section.get("section_id")),
+                "heading_path": heading_path,
+                "heading": heading,
+                "text_snippet": _text_snippet(text),
+                "score": round(float(score), 4),
+                "source": source,
+            }
+        )
+
+    scored.sort(key=lambda item: (-float(item["score"]), item["title"].lower(), item["section_id"]))
+    return scored[: _limit(limit)]
+
+
+def trace_relations(query_or_doc: str, *, output_dir: str | Path, limit: int = 10) -> list[dict[str, Any]]:
+    """Trace L1 relation rows for an alias, document, or section query."""
+    query_text = _norm(query_or_doc)
+    query_tokens = _tokens(query_text)
+    if not query_tokens:
+        return []
+    ready_data = _load_ready_data(output_dir)
+    if not ready_data:
+        return []
+    graph = ready_data.get("relations_graph") or {}
+    relations = graph.get("relations") if isinstance(graph, dict) else None
+    if not isinstance(relations, list):
+        return []
+
+    scored: list[dict[str, Any]] = []
+    matched_doc_ids: set[str] = set()
+    for row in relations:
+        if not isinstance(row, dict):
+            continue
+        haystack = " ".join(
+            _norm(row.get(key))
+            for key in (
+                "doc_id",
+                "file_url",
+                "title",
+                "alias",
+                "section_id",
+                "section_heading",
+                "target_id",
+                "target_type",
+                "relation_type",
+            )
+        )
+        score = _field_score(query_tokens, haystack, 2.0)
+        if query_text.lower() and query_text.lower() in haystack.lower():
+            score += 5.0
+        if score > 0:
+            matched_doc_ids.add(_norm(row.get("doc_id")))
+            result = dict(row)
+            result["score"] = round(float(score), 4)
+            result["source"] = "relations_graph"
+            scored.append(result)
+
+    if matched_doc_ids:
+        for row in relations:
+            if not isinstance(row, dict):
+                continue
+            doc_id = _norm(row.get("doc_id"))
+            if not doc_id or doc_id not in matched_doc_ids:
+                continue
+            if any(existing.get("relation_type") == row.get("relation_type") and existing.get("target_id") == row.get("target_id") for existing in scored):
+                continue
+            result = dict(row)
+            result["score"] = 0.5
+            result["source"] = "relations_graph"
+            scored.append(result)
+
+    scored.sort(
+        key=lambda item: (
+            -float(item.get("score") or 0),
+            _norm(item.get("relation_type")),
+            _norm(item.get("target_id")),
+        )
+    )
     return scored[: _limit(limit)]

--- a/ai_actuarial/agentic_rag/ready_data_tools.py
+++ b/ai_actuarial/agentic_rag/ready_data_tools.py
@@ -190,7 +190,11 @@ def _text_snippet(value: Any, max_chars: int = 240) -> str:
     text = " ".join(_norm(value).split())
     if len(text) <= max_chars:
         return text
-    return text[: max_chars - 1].rstrip() + "..."
+    if max_chars <= 0:
+        return ""
+    if max_chars <= 3:
+        return text[:max_chars]
+    return text[: max_chars - 3].rstrip() + "..."
 
 
 def _normalized_phrase(value: Any) -> str:
@@ -418,6 +422,7 @@ def trace_relations(query_or_doc: str, *, output_dir: str | Path, limit: int = 1
 
     scored: list[dict[str, Any]] = []
     matched_doc_ids: set[str] = set()
+    seen_relation_keys: set[tuple[str, str]] = set()
     for row in relations:
         if not isinstance(row, dict):
             continue
@@ -444,6 +449,7 @@ def trace_relations(query_or_doc: str, *, output_dir: str | Path, limit: int = 1
             result["score"] = round(float(score), 4)
             result["source"] = "relations_graph"
             scored.append(result)
+            seen_relation_keys.add((_norm(row.get("relation_type")), _norm(row.get("target_id"))))
 
     if matched_doc_ids:
         for row in relations:
@@ -452,12 +458,14 @@ def trace_relations(query_or_doc: str, *, output_dir: str | Path, limit: int = 1
             doc_id = _norm(row.get("doc_id"))
             if not doc_id or doc_id not in matched_doc_ids:
                 continue
-            if any(existing.get("relation_type") == row.get("relation_type") and existing.get("target_id") == row.get("target_id") for existing in scored):
+            relation_key = (_norm(row.get("relation_type")), _norm(row.get("target_id")))
+            if relation_key in seen_relation_keys:
                 continue
             result = dict(row)
             result["score"] = 0.5
             result["source"] = "relations_graph"
             scored.append(result)
+            seen_relation_keys.add(relation_key)
 
     scored.sort(
         key=lambda item: (

--- a/ai_actuarial/agentic_rag/tools.py
+++ b/ai_actuarial/agentic_rag/tools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from .ready_data_tools import search_summaries, search_titles
+from .ready_data_tools import search_sections, search_summaries, search_titles, trace_relations
 
 
 QuestionCategory = Literal["catalog", "locate", "summary", "document_qa"]
@@ -27,4 +27,11 @@ def classify_question(question: str) -> QuestionCategory:
     return "document_qa"
 
 
-__all__ = ["QuestionCategory", "classify_question", "search_summaries", "search_titles"]
+__all__ = [
+    "QuestionCategory",
+    "classify_question",
+    "search_sections",
+    "search_summaries",
+    "search_titles",
+    "trace_relations",
+]

--- a/ai_actuarial/api/routers/agentic_rag.py
+++ b/ai_actuarial/api/routers/agentic_rag.py
@@ -4,7 +4,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from ..deps import AuthContext, require_permissions
-from ..services.agentic_rag import AgenticRagError, search_ready_summaries, search_ready_titles
+from ..services.agentic_rag import (
+    AgenticRagError,
+    search_ready_sections,
+    search_ready_summaries,
+    search_ready_titles,
+    trace_ready_relations,
+)
 
 
 router = APIRouter()
@@ -41,5 +47,29 @@ def api_search_agentic_titles(
 ):
     try:
         return search_ready_titles(db_path=_db_path(request), payload=payload)
+    except AgenticRagError as exc:
+        return _error_response(exc)
+
+
+@router.post("/agentic-rag/search/sections")
+def api_search_agentic_sections(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return search_ready_sections(db_path=_db_path(request), payload=payload)
+    except AgenticRagError as exc:
+        return _error_response(exc)
+
+
+@router.post("/agentic-rag/trace/relations")
+def api_trace_agentic_relations(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("catalog.read")),
+):
+    try:
+        return trace_ready_relations(db_path=_db_path(request), payload=payload)
     except AgenticRagError as exc:
         return _error_response(exc)

--- a/ai_actuarial/api/services/agentic_rag.py
+++ b/ai_actuarial/api/services/agentic_rag.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from ai_actuarial.agentic_rag.ready_data_tools import search_summaries, search_titles
+from ai_actuarial.agentic_rag.ready_data_tools import (
+    search_sections,
+    search_summaries,
+    search_titles,
+    trace_relations,
+)
 from ai_actuarial.shared_runtime import parse_int_clamped
 from ai_actuarial.storage import Storage
 
@@ -56,7 +61,8 @@ def _resolve_ready_output_dir(
 ) -> tuple[str, str, str]:
     explicit_output_dir = _norm(payload.get("output_dir"))
     kb_id = _norm(payload.get("kb_id"))
-    profile = _norm(payload.get("profile") or payload.get("manifest_profile") or "general").lower() or "general"
+    requested_profile = _norm(payload.get("profile") or payload.get("manifest_profile")).lower()
+    profile = requested_profile or "general"
     if explicit_output_dir:
         if kb_id:
             raise AgenticRagError("output_dir cannot be combined with kb_id/profile registry lookup", status_code=400)
@@ -66,6 +72,13 @@ def _resolve_ready_output_dir(
 
     storage = Storage(db_path)
     try:
+        if not requested_profile:
+            row = storage._conn.execute(
+                "SELECT manifest_profile FROM rag_knowledge_bases WHERE kb_id = ?",
+                (kb_id,),
+            ).fetchone()
+            if row and _norm(row[0]):
+                profile = _norm(row[0]).lower()
         manifest = storage.get_agentic_ready_manifest(kb_id=kb_id, profile=profile)
     finally:
         storage.close()
@@ -116,4 +129,22 @@ def search_ready_titles(*, db_path: str, payload: Mapping[str, Any]) -> dict[str
         payload=payload,
         search_fn=search_titles,
         search_type="titles",
+    )
+
+
+def search_ready_sections(*, db_path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _search_response(
+        db_path=db_path,
+        payload=payload,
+        search_fn=search_sections,
+        search_type="sections",
+    )
+
+
+def trace_ready_relations(*, db_path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _search_response(
+        db_path=db_path,
+        payload=payload,
+        search_fn=trace_relations,
+        search_type="relations",
     )

--- a/ai_actuarial/api/services/rag_admin.py
+++ b/ai_actuarial/api/services/rag_admin.py
@@ -1058,23 +1058,6 @@ def build_agentic_ready_manifest(
             or getattr(kb, "manifest_profile", "general")
         )
         profile_def = PROFILES[profile]
-        if profile != "general":
-            message = (
-                f"Manifest profile '{profile}' is declared but not implemented in PR2; "
-                "falling back to standard RAG until its builder ships."
-            )
-            storage.upsert_agentic_ready_manifest(
-                kb_id=kid,
-                profile=profile,
-                profile_version=profile_def.version,
-                status="failed",
-                error_message=message,
-            )
-            return {
-                "kb_id": kid,
-                "manifest": _build_agentic_manifest_status(storage=storage, kb_id=kid, profile=profile),
-                "validation": {"valid": False, "errors": [message], "warnings": []},
-            }
 
         from ai_actuarial.agentic_rag import ready_data_builder
 

--- a/tests/agentic_rag/test_ready_data_builder.py
+++ b/tests/agentic_rag/test_ready_data_builder.py
@@ -146,6 +146,140 @@ def test_build_l0_basic(test_db_path, tmp_path):
     ]
 
 
+def test_build_regulation_profile_emits_l1_alias_and_relation_artifacts(test_db_path, tmp_path):
+    """Build L1 regulation artifacts without changing the L0 catalog contract."""
+    manifest = builder.build_l0(
+        db_path=test_db_path,
+        output_dir=str(tmp_path),
+        profile="regulation",
+    )
+
+    assert manifest["profile"] == "regulation"
+    assert manifest["doc_count"] == 1
+    assert manifest["section_count"] == 2
+    assert manifest["artifact_files"] == [
+        "doc_catalog.jsonl",
+        "title_aliases.jsonl",
+        "doc_summaries.jsonl",
+        "sections_structured.jsonl",
+        "relations_graph.json",
+        "ready_data_manifest.json",
+    ]
+
+    catalog = [
+        json.loads(line)
+        for line in (tmp_path / "doc_catalog.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert catalog[0]["title"] == "偿付能力监管规则第3号"
+    assert "headings" in catalog[0]
+
+    aliases = [
+        json.loads(line)
+        for line in (tmp_path / "title_aliases.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert aliases[0]["doc_id"] == "https://example.com/rule1"
+    assert "偿付能力监管规则第3号" in aliases[0]["aliases"]
+    assert "3" in aliases[0]["identifiers"]
+    assert aliases[0]["document_numbers"] == ["3"]
+    assert aliases[0]["rule_numbers"] == []
+
+    sections = [
+        json.loads(line)
+        for line in (tmp_path / "sections_structured.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert sections[0]["heading"] == "第一条"
+    assert sections[0]["document_aliases"] == aliases[0]["aliases"]
+
+    graph = json.loads((tmp_path / "relations_graph.json").read_text(encoding="utf-8"))
+    relation_types = {row["relation_type"] for row in graph["relations"]}
+    assert {"alias_of", "document_has_section"}.issubset(relation_types)
+
+    validation = builder.validate(str(tmp_path))
+    assert validation["valid"] is True
+
+
+def test_validate_rejects_manifest_artifact_paths_that_escape_output_dir(tmp_path):
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("{}\n", encoding="utf-8")
+    with open(tmp_path / "ready_data_manifest.json", "w", encoding="utf-8") as f:
+        json.dump({"artifact_files": ["../outside.jsonl"]}, f)
+
+    result = builder.validate(str(tmp_path))
+
+    assert result["valid"] is False
+    assert any("escapes output_dir" in error for error in result["errors"])
+
+
+def test_validate_rejects_orphan_l1_structured_sections_and_relations(tmp_path):
+    doc = {
+        "doc_id": "doc-a",
+        "file_url": "doc-a",
+        "title": "Rule A",
+        "category": "regulation",
+        "source_site": "",
+        "publish_date": "",
+        "summary": "",
+        "keywords": [],
+        "headings": [],
+        "rag_chunk_count": 1,
+    }
+    section = {
+        "section_id": "doc-a#s1",
+        "doc_id": "doc-a",
+        "heading_path": ["Article 1"],
+        "text": "hello",
+        "token_count": 1,
+    }
+    structured = {
+        "section_id": "doc-missing#s1",
+        "doc_id": "doc-missing",
+        "heading_path": ["Article 1"],
+        "text": "orphan",
+        "token_count": 1,
+    }
+    graph = {
+        "relations": [
+            {
+                "relation_type": "document_has_section",
+                "doc_id": "doc-missing",
+                "target_type": "section",
+                "target_id": "doc-missing#s2",
+            }
+        ]
+    }
+    with open(tmp_path / "doc_catalog.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(doc, ensure_ascii=False) + "\n")
+    with open(tmp_path / "sections.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(section, ensure_ascii=False) + "\n")
+    with open(tmp_path / "sections_structured.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(structured, ensure_ascii=False) + "\n")
+    with open(tmp_path / "relations_graph.json", "w", encoding="utf-8") as f:
+        json.dump(graph, f)
+    with open(tmp_path / "ready_data_manifest.json", "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "artifact_files": [
+                    "doc_catalog.jsonl",
+                    "sections.jsonl",
+                    "sections_structured.jsonl",
+                    "relations_graph.json",
+                    "ready_data_manifest.json",
+                ]
+            },
+            f,
+        )
+
+    result = builder.validate(str(tmp_path))
+
+    assert result["valid"] is False
+    assert any("structured section doc_ids not in catalog" in error for error in result["errors"])
+    assert any("relation doc_ids not in catalog" in error for error in result["errors"])
+    assert any("relation section targets not in sections" in error for error in result["errors"])
+
+
 def test_build_l0_can_scope_to_knowledge_base(test_db_path, tmp_path):
     """KB scoped builds should not leak catalog rows from other KBs."""
     conn = sqlite3.connect(test_db_path)

--- a/tests/agentic_rag/test_ready_data_tools.py
+++ b/tests/agentic_rag/test_ready_data_tools.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ai_actuarial.agentic_rag.ready_data_tools import search_summaries, search_titles
+from ai_actuarial.agentic_rag.ready_data_tools import (
+    search_sections,
+    search_summaries,
+    search_titles,
+    trace_relations,
+)
 from ai_actuarial.agentic_rag.tools import classify_question
 
 
@@ -125,6 +130,164 @@ def test_search_titles_scores_title_matches(tmp_path: Path) -> None:
     assert results[0]["title"] == "Reserve Method Note"
     assert results[0]["summary"]
     assert results[0]["source"] == "doc_catalog"
+
+
+def test_search_titles_prefers_exact_alias_before_fallback_scoring(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path)
+    _write_jsonl(
+        tmp_path / "title_aliases.jsonl",
+        [
+            {
+                "doc_id": "doc-reserve",
+                "file_url": "https://example.test/reserve.pdf",
+                "title": "Reserve Method Note",
+                "aliases": ["RBC Rule 7", "Rule 7"],
+                "identifiers": ["7"],
+            }
+        ],
+    )
+    manifest = json.loads((tmp_path / "ready_data_manifest.json").read_text(encoding="utf-8"))
+    manifest["profile"] = "regulation"
+    manifest["artifact_files"].append("title_aliases.jsonl")
+    (tmp_path / "ready_data_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    results = search_titles("RBC Rule 7", output_dir=str(tmp_path), limit=5)
+
+    assert results[0]["doc_id"] == "doc-reserve"
+    assert results[0]["source"] == "title_aliases"
+    assert results[0]["matched_alias"] == "RBC Rule 7"
+
+
+def test_search_titles_does_not_match_short_numeric_alias_inside_longer_rule_number(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path)
+    _write_jsonl(
+        tmp_path / "title_aliases.jsonl",
+        [
+            {
+                "doc_id": "doc-reserve",
+                "file_url": "https://example.test/reserve.pdf",
+                "title": "Reserve Method Note",
+                "aliases": ["RBC Rule 7", "Rule 7"],
+                "identifiers": ["7"],
+                "rule_numbers": ["7"],
+            },
+            {
+                "doc_id": "doc-capital",
+                "file_url": "https://example.test/capital.pdf",
+                "title": "RBC Rule 70 Capital Adequacy Guideline",
+                "aliases": ["RBC Rule 70", "Rule 70"],
+                "identifiers": ["70"],
+                "rule_numbers": ["70"],
+            },
+        ],
+    )
+    manifest = json.loads((tmp_path / "ready_data_manifest.json").read_text(encoding="utf-8"))
+    manifest["profile"] = "regulation"
+    manifest["artifact_files"].append("title_aliases.jsonl")
+    (tmp_path / "ready_data_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    results = search_titles("RBC Rule 70", output_dir=str(tmp_path), limit=5)
+
+    assert results[0]["doc_id"] == "doc-capital"
+    assert results[0]["matched_alias"] == "RBC Rule 70"
+    assert all(not (item["doc_id"] == "doc-reserve" and item["source"] == "title_aliases") for item in results)
+
+
+def test_search_sections_returns_stable_section_hits_from_l1_artifact(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path)
+    _write_jsonl(
+        tmp_path / "sections_structured.jsonl",
+        [
+            {
+                "section_id": "doc-capital#article-19",
+                "doc_id": "doc-capital",
+                "file_url": "https://example.test/capital.pdf",
+                "title": "Capital Adequacy Guideline",
+                "heading_path": ["Chapter 2", "Article 19"],
+                "heading": "Article 19",
+                "text": "Article 19 defines solvency capital requirement factors.",
+                "aliases": ["Article 19"],
+            },
+            {
+                "section_id": "doc-reserve#article-5",
+                "doc_id": "doc-reserve",
+                "file_url": "https://example.test/reserve.pdf",
+                "title": "Reserve Method Note",
+                "heading_path": ["Article 5"],
+                "heading": "Article 5",
+                "text": "Discount assumptions support reserve calculations.",
+            },
+        ],
+    )
+    manifest = json.loads((tmp_path / "ready_data_manifest.json").read_text(encoding="utf-8"))
+    manifest["artifact_files"].append("sections_structured.jsonl")
+    (tmp_path / "ready_data_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    results = search_sections("Article 19 solvency", output_dir=str(tmp_path), limit=1)
+
+    assert results == [
+        {
+            "doc_id": "doc-capital",
+            "file_url": "https://example.test/capital.pdf",
+            "title": "Capital Adequacy Guideline",
+            "section_id": "doc-capital#article-19",
+            "heading_path": ["Chapter 2", "Article 19"],
+            "heading": "Article 19",
+            "text_snippet": "Article 19 defines solvency capital requirement factors.",
+            "score": results[0]["score"],
+            "source": "sections_structured",
+        }
+    ]
+    assert results[0]["score"] > 0
+
+
+def test_trace_relations_returns_alias_doc_section_edges(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path)
+    (tmp_path / "relations_graph.json").write_text(
+        json.dumps(
+            {
+                "relations": [
+                    {
+                        "relation_type": "alias_of",
+                        "doc_id": "doc-capital",
+                        "file_url": "https://example.test/capital.pdf",
+                        "title": "Capital Adequacy Guideline",
+                        "alias": "RBC Rule 3",
+                        "target_type": "document",
+                        "target_id": "doc-capital",
+                    },
+                    {
+                        "relation_type": "document_has_section",
+                        "doc_id": "doc-capital",
+                        "file_url": "https://example.test/capital.pdf",
+                        "title": "Capital Adequacy Guideline",
+                        "section_id": "doc-capital#article-19",
+                        "section_heading": "Article 19",
+                        "target_type": "section",
+                        "target_id": "doc-capital#article-19",
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    manifest = json.loads((tmp_path / "ready_data_manifest.json").read_text(encoding="utf-8"))
+    manifest["artifact_files"].append("relations_graph.json")
+    (tmp_path / "ready_data_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    results = trace_relations("RBC Rule 3", output_dir=str(tmp_path), limit=5)
+
+    assert [item["relation_type"] for item in results] == ["alias_of", "document_has_section"]
+    assert all(item["doc_id"] == "doc-capital" for item in results)
+    assert results[0]["source"] == "relations_graph"
+
+
+def test_l1_tools_tolerate_missing_optional_artifacts(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path, include_summaries=False)
+
+    assert search_sections("capital", output_dir=str(tmp_path), limit=3)[0]["source"] == "sections"
+    assert trace_relations("capital", output_dir=str(tmp_path), limit=3) == []
 
 
 def test_search_summaries_falls_back_to_catalog_summary_when_doc_summaries_missing(tmp_path: Path) -> None:

--- a/tests/agentic_rag/test_ready_data_tools.py
+++ b/tests/agentic_rag/test_ready_data_tools.py
@@ -241,6 +241,32 @@ def test_search_sections_returns_stable_section_hits_from_l1_artifact(tmp_path: 
     assert results[0]["score"] > 0
 
 
+def test_search_sections_bounds_text_snippet_length(tmp_path: Path) -> None:
+    _write_ready_data(tmp_path)
+    _write_jsonl(
+        tmp_path / "sections_structured.jsonl",
+        [
+            {
+                "section_id": "doc-capital#long",
+                "doc_id": "doc-capital",
+                "file_url": "https://example.test/capital.pdf",
+                "title": "Capital Adequacy Guideline",
+                "heading_path": ["Capital"],
+                "heading": "Capital",
+                "text": "solvency " + ("capital " * 80),
+            }
+        ],
+    )
+    manifest = json.loads((tmp_path / "ready_data_manifest.json").read_text(encoding="utf-8"))
+    manifest["artifact_files"].append("sections_structured.jsonl")
+    (tmp_path / "ready_data_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    results = search_sections("solvency capital", output_dir=str(tmp_path), limit=1)
+
+    assert len(results[0]["text_snippet"]) <= 240
+    assert results[0]["text_snippet"].endswith("...")
+
+
 def test_trace_relations_returns_alias_doc_section_edges(tmp_path: Path) -> None:
     _write_ready_data(tmp_path)
     (tmp_path / "relations_graph.json").write_text(
@@ -255,6 +281,16 @@ def test_trace_relations_returns_alias_doc_section_edges(tmp_path: Path) -> None
                         "alias": "RBC Rule 3",
                         "target_type": "document",
                         "target_id": "doc-capital",
+                    },
+                    {
+                        "relation_type": "document_has_section",
+                        "doc_id": "doc-capital",
+                        "file_url": "https://example.test/capital.pdf",
+                        "title": "Capital Adequacy Guideline",
+                        "section_id": "doc-capital#article-19",
+                        "section_heading": "Article 19",
+                        "target_type": "section",
+                        "target_id": "doc-capital#article-19",
                     },
                     {
                         "relation_type": "document_has_section",

--- a/tests/test_fastapi_agentic_rag_endpoints.py
+++ b/tests/test_fastapi_agentic_rag_endpoints.py
@@ -97,12 +97,52 @@ def _write_ready_data(output_dir: Path) -> None:
             }
         ],
     )
+    _write_jsonl(
+        output_dir / "sections_structured.jsonl",
+        [
+            {
+                "section_id": "doc-a#article-19",
+                "doc_id": "doc-a",
+                "file_url": "https://example.test/a.pdf",
+                "title": "Capital Adequacy Guideline",
+                "heading_path": ["Capital", "Article 19"],
+                "heading": "Article 19",
+                "text": "Article 19 defines required capital and solvency ratio rules.",
+            }
+        ],
+    )
+    (output_dir / "relations_graph.json").write_text(
+        json.dumps(
+            {
+                "relations": [
+                    {
+                        "relation_type": "document_has_section",
+                        "doc_id": "doc-a",
+                        "file_url": "https://example.test/a.pdf",
+                        "title": "Capital Adequacy Guideline",
+                        "section_id": "doc-a#article-19",
+                        "section_heading": "Article 19",
+                        "target_type": "section",
+                        "target_id": "doc-a#article-19",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
     (output_dir / "ready_data_manifest.json").write_text(
         json.dumps(
             {
                 "profile": "general",
                 "profile_version": "1",
-                "artifact_files": ["doc_catalog.jsonl", "doc_summaries.jsonl", "sections.jsonl"],
+                "artifact_files": [
+                    "doc_catalog.jsonl",
+                    "doc_summaries.jsonl",
+                    "sections.jsonl",
+                    "sections_structured.jsonl",
+                    "relations_graph.json",
+                ],
             },
             ensure_ascii=False,
         ),
@@ -173,6 +213,99 @@ def test_fastapi_agentic_rag_title_search_resolves_registry_ready_manifest(tmp_p
     assert body["profile"] == "general"
     assert body["output_dir"] == str(ready_dir)
     assert body["results"][0]["title"] == "Reserve Method Note"
+
+
+def test_fastapi_agentic_rag_section_search_uses_explicit_output_dir(tmp_path: Path, monkeypatch) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "explicit"
+    _write_ready_data(ready_dir)
+
+    response = client.post(
+        "/api/agentic-rag/search/sections",
+        json={"query": "Article 19 solvency", "limit": 2, "output_dir": str(ready_dir)},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["search_type"] == "sections"
+    assert body["count"] == 1
+    assert body["results"][0]["section_id"] == "doc-a#article-19"
+    assert body["results"][0]["source"] == "sections_structured"
+
+
+def test_fastapi_agentic_rag_section_search_uses_kb_manifest_profile_by_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "kbs" / "kb-regulation" / "regulation" / "1"
+    _write_ready_data(ready_dir)
+    manifest = json.loads((ready_dir / "ready_data_manifest.json").read_text(encoding="utf-8"))
+    manifest["profile"] = "regulation"
+    (ready_dir / "ready_data_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    storage = Storage(str(db_path))
+    try:
+        manager = KnowledgeBaseManager(storage)
+        manager.create_kb(kb_id="kb-regulation", name="Regulation KB", kb_mode="manual", manifest_profile="regulation")
+        storage.upsert_agentic_ready_manifest(
+            kb_id="kb-regulation",
+            profile="regulation",
+            profile_version="1",
+            status="ready",
+            output_dir=str(ready_dir),
+            artifact_files=[
+                "doc_catalog.jsonl",
+                "doc_summaries.jsonl",
+                "sections.jsonl",
+                "sections_structured.jsonl",
+                "relations_graph.json",
+            ],
+            doc_count=2,
+            section_count=1,
+            built_at="2026-06-14T00:00:00+00:00",
+            source_db=str(db_path),
+        )
+    finally:
+        storage.close()
+
+    response = client.post(
+        "/api/agentic-rag/search/sections",
+        json={"query": "Article 19 solvency", "limit": 2, "kb_id": "kb-regulation"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["profile"] == "regulation"
+    assert body["output_dir"] == str(ready_dir)
+    assert body["results"][0]["section_id"] == "doc-a#article-19"
+
+    relation_response = client.post(
+        "/api/agentic-rag/trace/relations",
+        json={"query": "Article 19", "limit": 2, "kb_id": "kb-regulation"},
+    )
+
+    assert relation_response.status_code == 200, relation_response.text
+    relation_body = relation_response.json()
+    assert relation_body["profile"] == "regulation"
+    assert relation_body["results"][0]["relation_type"] == "document_has_section"
+
+
+def test_fastapi_agentic_rag_trace_relations_uses_explicit_output_dir(tmp_path: Path, monkeypatch) -> None:
+    client, _db_path = _build_client(tmp_path, monkeypatch)
+    ready_dir = tmp_path / "agentic_ready_data" / "explicit"
+    _write_ready_data(ready_dir)
+
+    response = client.post(
+        "/api/agentic-rag/trace/relations",
+        json={"query": "Article 19", "limit": 2, "output_dir": str(ready_dir)},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["search_type"] == "relations"
+    assert body["count"] == 1
+    assert body["results"][0]["relation_type"] == "document_has_section"
+    assert body["results"][0]["source"] == "relations_graph"
 
 
 def test_fastapi_agentic_rag_search_returns_empty_results_for_no_match(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_fastapi_rag_admin_endpoints.py
+++ b/tests/test_fastapi_rag_admin_endpoints.py
@@ -544,7 +544,7 @@ def test_fastapi_rag_admin_agentic_ready_manifest_build_is_kb_scoped(tmp_path: P
     assert stale_manifest["stale_reason"]
 
 
-def test_fastapi_rag_admin_agentic_ready_manifest_records_unsupported_profile_failure(
+def test_fastapi_rag_admin_agentic_ready_manifest_builds_regulation_profile(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -569,10 +569,44 @@ def test_fastapi_rag_admin_agentic_ready_manifest_records_unsupported_profile_fa
     assert build.status_code == 200, build.text
     manifest = build.json()["manifest"]
     assert manifest["profile"] == "regulation"
+    assert manifest["status"] == "ready"
+    assert manifest["usable"] is True
+    assert manifest["fallback_mode"] == "agentic"
+    output_dir = Path(manifest["output_dir"])
+    assert (output_dir / "title_aliases.jsonl").is_file()
+    assert (output_dir / "sections_structured.jsonl").is_file()
+    assert (output_dir / "relations_graph.json").is_file()
+
+
+def test_fastapi_rag_admin_agentic_ready_manifest_records_formula_profile_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch)
+
+    create_kb = client.post(
+        "/api/rag/knowledge-bases",
+        json={
+            "kb_id": "kb-formula-manifest",
+            "name": "Formula Manifest KB",
+            "kb_mode": "manual",
+            "file_urls": [seed["alpha_url"]],
+            "manifest_profile": "formula",
+        },
+    )
+    assert create_kb.status_code == 201, create_kb.text
+
+    build = client.post(
+        "/api/rag/knowledge-bases/kb-formula-manifest/agentic-ready-manifest/build",
+        json={},
+    )
+    assert build.status_code == 200, build.text
+    manifest = build.json()["manifest"]
+    assert manifest["profile"] == "formula"
     assert manifest["status"] == "failed"
     assert manifest["usable"] is False
     assert manifest["fallback_mode"] == "standard"
-    assert "not implemented" in manifest["error_message"]
+    assert "not yet implemented" in manifest["error_message"]
 
 
 def test_fastapi_rag_admin_agentic_manifest_rejects_output_dir_escape(


### PR DESCRIPTION
## Summary
- add regulation L1 ready_data artifact generation: title aliases, doc summaries, structured sections, relations graph
- add alias-first title lookup plus section search and relation tracing tools/endpoints
- let KB registry lookups default to the KB manifest_profile and allow rag-admin to build regulation manifests

## Validation
- python -m py_compile ai_actuarial\agentic_rag\ready_data_builder.py ai_actuarial\agentic_rag\ready_data_tools.py ai_actuarial\agentic_rag\tools.py ai_actuarial\api\services\agentic_rag.py ai_actuarial\api\routers\agentic_rag.py ai_actuarial\api\services\rag_admin.py
- python -m pytest tests\agentic_rag\ tests\test_fastapi_agentic_rag_endpoints.py tests\test_fastapi_rag_admin_endpoints.py -q (78 passed)
- python -m ai_actuarial.agentic_rag.ready_data_builder --help
- git diff --check
- codex review --uncommitted blocked: WindowsApps codex.exe returned Access is denied; worker/spec/code-quality subagent reviews were used instead.