### PR TITLE
feat: add markdown conversion config

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,35 +1,29 @@
 # Project Status
 
 - Date: 2026-06-16
-- Branch: `codex/docs-status-readme-review-fixes`
-- Baseline: `origin/main` at `ee7b6d8`.
-- Scope: README/docs/project metadata cleanup after the merged Agentic RAG QA follow-up.
-- PR: [#146](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/146).
-- Previous PRs: [#145](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/145) — merged; [#143](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/143) — merged; [#142](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/142) — merged.
+- Branch: `codex/p0-1-markdown-conversion-config`
+- Baseline: `origin/main` at `32ebedd`.
+- Scope: P0-1 Markdown conversion config split and admin/UI/runtime integration.
+- PR: pending creation.
+- Previous PRs: [#146](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/146) — merged; [#145](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/145) — merged.
 
 ## Current State
 
-- `main` now includes the 2026 FastAPI/React migration, security/RBAC hardening, and the planned Agentic RAG implementation sequence through PR #142.
-- PR #143 reconciled the Agentic RAG status file after the planned sequence.
-- PR #145 merged the local-QA follow-up for CJK ready_data query matching, Agentic Chat KB section-count labels, and raw Agentic score display.
-- This branch updates English/Chinese README content, the docs index, the Agentic RAG guide, and the service start guide so they describe the current post-PR #145 state.
-- This branch aligns frontend runtime metadata with Vite 7 by documenting Node.js `^20.19.0 || >=22.12.0` and adding the same range to `package.json -> engines`.
-- This branch removes unused direct Node server-era package dependencies that were left from the retired Express/Passport/Postgres/Drizzle runtime surface after source searches found no imports.
-- `npm test` now runs the maintained frontend build instead of an always-failing placeholder.
+- This branch adds `config/markdown_conversion.yaml` as the markdown conversion runtime source of truth for default tool, enabled tools, format-specific candidate chains, paid/API auto toggles, tuning knobs, and scan limits.
+- Backend read/write endpoints now expose `/api/config/markdown-conversion` with existing `config.read` / `config.write` authorization and optional `CONFIG_WRITE_AUTH_TOKEN` guard.
+- Markdown conversion runtime now defaults to configured `auto`, keeps `auto` from resolving to `docling`, runs configured candidate chains, skips unconfigured paid/API tools in auto mode, rejects disabled explicit tools, and clamps scan counts to configured limits with a hard safety cap.
+- Frontend Markdown task surfaces and FileDetail conversion controls now load tool order/defaults/limits from the markdown conversion config API instead of hardcoding the OpenDataLoader-first order.
+- Local `docker-compose.override.yml` still has an unrelated production override diff and must remain uncommitted for this PR.
 
 ## Verification
 
-- `npm.cmd install --package-lock-only` passed after package metadata cleanup.
-- `npm.cmd install` restored local `node_modules` after a clean-install probe hit Windows EPERM cleanup locks in ignored native package directories; install completed with cleanup warnings only.
-- `npm.cmd test` passed and now runs `npm run build` / Vite production build; Vite still emits the existing large-chunk warning.
-- Markdown link scan for the root READMEs and maintained docs touched in this branch passed.
-- Source/package search found no maintained-code imports or root package entries for the removed Express/Passport/Postgres/Drizzle-era dependencies.
-- `git diff --check` passed with LF/CRLF working-copy warnings only.
-- Independent agent review #1 (README/docs/status consistency) found no Critical, Important, or Minor findings and recommended PASS.
-- Independent agent review #2 (package/dependency diff) found no Critical, Important, or Minor findings and recommended PASS.
-- Mandatory local `codex review --uncommitted` remains blocked by WindowsApps `codex.exe` returning `Access is denied`.
+- `python3 -m pytest tests/test_markdown_conversion_config.py tests/test_doc_to_md_engine_defaults.py tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip -q` passed: 13 tests.
+- `npm test` passed and ran the Vite production build; Vite still emits the existing large chunk warning.
+- `git diff --check` passed.
+- Independent spec review pass 2: PASS.
+- Independent code-quality/security review pass 2: PASS for markdown conversion scope after excluding `docker-compose.override.yml`; noted the unrelated override as not-to-commit.
 
 ## Notes
 
 - Sibling repositories remain out of scope for this project run.
-- Do not copy secrets, `.env` files, generated credentials, or unreviewed artifacts across projects.
+- Do not copy secrets, `.env` files, generated credentials, active Docker volumes, logs, or local production overrides into this PR.

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -4,7 +4,7 @@
 - Branch: `codex/p0-1-markdown-conversion-config`
 - Baseline: `origin/main` at `32ebedd`.
 - Scope: P0-1 Markdown conversion config split and admin/UI/runtime integration.
-- PR: pending creation.
+- PR: [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) — open; CI passed; Copilot comments addressed.
 - Previous PRs: [#146](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/146) — merged; [#145](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/145) — merged.
 
 ## Current State
@@ -17,11 +17,13 @@
 
 ## Verification
 
-- `python3 -m pytest tests/test_markdown_conversion_config.py tests/test_doc_to_md_engine_defaults.py tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip -q` passed: 13 tests.
-- `npm test` passed and ran the Vite production build; Vite still emits the existing large chunk warning.
+- `python3 -m pytest tests/test_markdown_conversion_config.py tests/test_doc_to_md_engine_defaults.py tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip -q` passed: 13 tests after Copilot fixes.
+- `npm test` passed and ran the Vite production build after Copilot fixes; Vite still emits the existing large chunk warning.
 - `git diff --check` passed.
+- GitHub CI `python-smoke` passed on PR #147.
 - Independent spec review pass 2: PASS.
 - Independent code-quality/security review pass 2: PASS for markdown conversion scope after excluding `docker-compose.override.yml`; noted the unrelated override as not-to-commit.
+- Copilot review comments addressed: stable POST tool ordering, markdown tuning config cache, UI scan count lower bound, markdown config payload guard, and removal of an unused task runtime parameter.
 
 ## Notes
 

--- a/ai_actuarial/ai_runtime.py
+++ b/ai_actuarial/ai_runtime.py
@@ -12,6 +12,8 @@ from ai_actuarial.shared_runtime import get_sites_config_path, load_yaml
 
 logger = logging.getLogger(__name__)
 
+_MARKDOWN_CONVERSION_TUNING_CACHE: dict[str, Any] = {"path": None, "mtime_ns": None, "config": None}
+
 AI_SUPPORTED_PROVIDERS = {
     "openai",
     "azure_openai",
@@ -913,12 +915,28 @@ def apply_ocr_runtime_environment(runtime: OCRRuntime) -> None:
 def _apply_markdown_conversion_tuning(engine: str) -> None:
     """Project non-secret markdown conversion tuning config into legacy env settings."""
     try:
-        from ai_actuarial.markdown_conversion_config import load_markdown_conversion_config
+        from ai_actuarial.markdown_conversion_config import (
+            get_markdown_conversion_config_path,
+            load_markdown_conversion_config,
+        )
     except Exception:
         return
 
     try:
-        cfg = load_markdown_conversion_config()
+        path = get_markdown_conversion_config_path()
+        try:
+            mtime_ns = os.stat(path).st_mtime_ns
+        except OSError:
+            mtime_ns = None
+        if (
+            _MARKDOWN_CONVERSION_TUNING_CACHE.get("path") == path
+            and _MARKDOWN_CONVERSION_TUNING_CACHE.get("mtime_ns") == mtime_ns
+            and isinstance(_MARKDOWN_CONVERSION_TUNING_CACHE.get("config"), dict)
+        ):
+            cfg = _MARKDOWN_CONVERSION_TUNING_CACHE["config"]
+        else:
+            cfg = load_markdown_conversion_config(path)
+            _MARKDOWN_CONVERSION_TUNING_CACHE.update({"path": path, "mtime_ns": mtime_ns, "config": cfg})
     except Exception:
         logger.exception("Failed to load markdown conversion tuning config")
         return

--- a/ai_actuarial/ai_runtime.py
+++ b/ai_actuarial/ai_runtime.py
@@ -901,12 +901,86 @@ def apply_ocr_runtime_environment(runtime: OCRRuntime) -> None:
             os.environ[base_env] = runtime.base_url
 
     os.environ["DEFAULT_ENGINE"] = runtime.engine
+    _apply_markdown_conversion_tuning(runtime.engine)
     if runtime.provider == "mistral":
         os.environ["MISTRAL_DEFAULT_MODEL"] = runtime.model
     elif runtime.provider == "siliconflow":
         os.environ["SILICONFLOW_DEFAULT_MODEL"] = runtime.model
 
     _reload_settings_if_available()
+
+
+def _apply_markdown_conversion_tuning(engine: str) -> None:
+    """Project non-secret markdown conversion tuning config into legacy env settings."""
+    try:
+        from ai_actuarial.markdown_conversion_config import load_markdown_conversion_config
+    except Exception:
+        return
+
+    try:
+        cfg = load_markdown_conversion_config()
+    except Exception:
+        logger.exception("Failed to load markdown conversion tuning config")
+        return
+
+    tool_cfg = ((cfg.get("tools") or {}).get(str(engine or "").strip().lower()) or {})
+    tuning = tool_cfg.get("tuning") if isinstance(tool_cfg, dict) else {}
+    if not isinstance(tuning, Mapping):
+        return
+
+    env_map = {
+        "opendataloader": {
+            "hybrid": "OPENDATALOADER_HYBRID",
+            "use_struct_tree": "OPENDATALOADER_USE_STRUCT_TREE",
+        },
+        "markitdown": {
+            "enable_plugins": "MARKITDOWN_ENABLE_PLUGINS",
+            "enable_builtins": "MARKITDOWN_ENABLE_BUILTINS",
+        },
+        "docling": {
+            "max_pages": "DOCLING_MAX_PAGES",
+            "raise_on_error": "DOCLING_RAISE_ON_ERROR",
+        },
+        "marker": {
+            "use_llm": "MARKER_USE_LLM",
+            "processors": "MARKER_PROCESSORS",
+            "page_range": "MARKER_PAGE_RANGE",
+            "extract_images": "MARKER_EXTRACT_IMAGES",
+            "llm_service": "MARKER_LLM_SERVICE",
+        },
+        "mistral": {
+            "max_pdf_tokens": "MISTRAL_MAX_PDF_TOKENS",
+            "max_pages_per_chunk": "MISTRAL_MAX_PAGES_PER_CHUNK",
+            "timeout_seconds": "MISTRAL_TIMEOUT_SECONDS",
+            "retry_attempts": "MISTRAL_RETRY_ATTEMPTS",
+            "extract_header": "MISTRAL_EXTRACT_HEADER",
+            "extract_footer": "MISTRAL_EXTRACT_FOOTER",
+        },
+        "deepseekocr": {
+            "max_input_tokens": "SILICONFLOW_MAX_INPUT_TOKENS",
+            "chunk_overlap_tokens": "SILICONFLOW_CHUNK_OVERLAP_TOKENS",
+            "timeout_seconds": "SILICONFLOW_TIMEOUT_SECONDS",
+            "retry_attempts": "SILICONFLOW_RETRY_ATTEMPTS",
+        },
+        "mathpix": {
+            "timeout_seconds": "MATHPIX_TIMEOUT_SECONDS",
+            "retry_attempts": "MATHPIX_RETRY_ATTEMPTS",
+            "poll_interval_seconds": "MATHPIX_POLL_INTERVAL_SECONDS",
+            "output_format": "MATHPIX_OUTPUT_FORMAT",
+            "base_url": "MATHPIX_BASE_URL",
+        },
+    }.get(str(engine or "").strip().lower(), {})
+
+    for key, env_name in env_map.items():
+        if key not in tuning:
+            continue
+        value = tuning.get(key)
+        if value is None:
+            os.environ.pop(env_name, None)
+        elif isinstance(value, bool):
+            os.environ[env_name] = "true" if value else "false"
+        else:
+            os.environ[env_name] = str(value)
 
 
 def resolve_provider_credentials(
@@ -1149,7 +1223,7 @@ def _resolve_ocr_engine(provider: str, model: str, *, engine_override: str | Non
     if engine_override:
         normalized_override = str(engine_override).strip().lower()
         if normalized_override == "auto":
-            return "docling"
+            return "auto"
         return normalized_override
 
     normalized_provider = _normalize_provider(provider, default="local")

--- a/ai_actuarial/api/routers/ops_read.py
+++ b/ai_actuarial/api/routers/ops_read.py
@@ -16,6 +16,7 @@ from ..services.ops_read import (
     get_config_sites,
     get_global_logs,
     get_llm_providers,
+    get_markdown_conversion_config,
     get_schedule_status,
     get_scheduled_tasks,
     get_search_engines,
@@ -186,6 +187,14 @@ def api_config_backend_settings(
     _auth: AuthContext = Depends(require_permissions("config.read")),
 ) -> dict[str, object]:
     return get_backend_settings()
+
+
+@router.get("/config/markdown-conversion")
+def api_config_markdown_conversion(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.read")),
+) -> dict[str, object]:
+    return get_markdown_conversion_config()
 
 
 @router.get("/config/llm-providers")

--- a/ai_actuarial/api/routers/ops_write.py
+++ b/ai_actuarial/api/routers/ops_write.py
@@ -34,6 +34,7 @@ from ..services.ops_write import (
     update_ai_routing,
     update_backend_settings,
     update_categories_config,
+    update_markdown_conversion_config,
     update_scheduled_task,
     update_site,
     upsert_provider_credential,
@@ -239,6 +240,23 @@ def api_config_categories_update(
             if not provided_token or provided_token != expected_token:
                 return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return update_categories_config(payload)
+    except OpsWriteError as exc:
+        return _handle_ops_error(exc)
+
+
+@router.post("/config/markdown-conversion")
+def api_config_markdown_conversion_update(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("config.write")),
+):
+    try:
+        expected_token = _config_write_auth_token()
+        if expected_token:
+            provided_token = request.headers.get("X-Auth-Token")
+            if not provided_token or provided_token != expected_token:
+                return JSONResponse(status_code=403, content={"error": "Forbidden"})
+        return update_markdown_conversion_config(payload)
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
 

--- a/ai_actuarial/api/services/ops_read.py
+++ b/ai_actuarial/api/services/ops_read.py
@@ -13,6 +13,7 @@ from ai_actuarial.ai_runtime import (
     build_model_discovery_credentials,
     resolve_search_engine_credentials,
 )
+from ai_actuarial.markdown_conversion_config import get_markdown_conversion_options
 from ai_actuarial.config import settings
 from ai_actuarial.services.token_encryption import TokenEncryption
 from ai_actuarial.shared_runtime import (
@@ -92,6 +93,10 @@ def get_search_engines(*, storage: Storage | None = None) -> dict[str, list[dict
             }
         )
     return {"engines": engines}
+
+
+def get_markdown_conversion_config() -> dict[str, Any]:
+    return get_markdown_conversion_options()
 
 
 def get_config_sites() -> dict[str, object]:

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -42,6 +42,7 @@ from ai_actuarial.shared_runtime import (
     serialize_backend_settings,
 )
 from ai_actuarial.config import settings
+from ai_actuarial.markdown_conversion_config import write_markdown_conversion_config
 from ai_actuarial.rag.defaults import get_embedding_model_defaults
 from ai_actuarial.api.services.import_batches import ImportBatchError, load_import_batch
 from ai_actuarial.security import UnsafeUrlError, ensure_safe_http_url
@@ -757,6 +758,33 @@ def update_categories_config(data: dict[str, Any]) -> dict[str, Any]:
         "ai_filter_keywords": normalized_ai_filter_keywords,
         "ai_keywords": normalized_ai_keywords,
         "success": True,
+    }
+
+
+def update_markdown_conversion_config(data: dict[str, Any]) -> dict[str, Any]:
+    payload = _coerce_required_dict(data)
+    candidate = payload.get("config") if isinstance(payload.get("config"), dict) else payload
+    normalized = write_markdown_conversion_config(candidate)
+    _reload_runtime_caches()
+    return {
+        "success": True,
+        "config": normalized,
+        "tools": [
+            {
+                "name": name,
+                "provider": tool.get("provider"),
+                "displayName": tool.get("display_name", name),
+                "display_name": tool.get("display_name", name),
+                "enabled": bool(tool.get("enabled", True)),
+                "auto_enabled": bool(tool.get("auto_enabled", False)),
+                "paid_or_api": bool(tool.get("paid_or_api", False)),
+            }
+            for name, tool in (normalized.get("tools") or {}).items()
+            if isinstance(tool, dict) and bool(tool.get("enabled", True))
+        ],
+        "default_tool": normalized.get("default_tool", "auto"),
+        "formats": normalized.get("formats", {}),
+        "limits": normalized.get("limits", {}),
     }
 
 

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -42,7 +42,7 @@ from ai_actuarial.shared_runtime import (
     serialize_backend_settings,
 )
 from ai_actuarial.config import settings
-from ai_actuarial.markdown_conversion_config import write_markdown_conversion_config
+from ai_actuarial.markdown_conversion_config import list_conversion_tools, write_markdown_conversion_config
 from ai_actuarial.rag.defaults import get_embedding_model_defaults
 from ai_actuarial.api.services.import_batches import ImportBatchError, load_import_batch
 from ai_actuarial.security import UnsafeUrlError, ensure_safe_http_url
@@ -769,19 +769,7 @@ def update_markdown_conversion_config(data: dict[str, Any]) -> dict[str, Any]:
     return {
         "success": True,
         "config": normalized,
-        "tools": [
-            {
-                "name": name,
-                "provider": tool.get("provider"),
-                "displayName": tool.get("display_name", name),
-                "display_name": tool.get("display_name", name),
-                "enabled": bool(tool.get("enabled", True)),
-                "auto_enabled": bool(tool.get("auto_enabled", False)),
-                "paid_or_api": bool(tool.get("paid_or_api", False)),
-            }
-            for name, tool in (normalized.get("tools") or {}).items()
-            if isinstance(tool, dict) and bool(tool.get("enabled", True))
-        ],
+        "tools": list_conversion_tools(normalized),
         "default_tool": normalized.get("default_tool", "auto"),
         "formats": normalized.get("formats", {}),
         "limits": normalized.get("limits", {}),

--- a/ai_actuarial/markdown_conversion_config.py
+++ b/ai_actuarial/markdown_conversion_config.py
@@ -1,0 +1,400 @@
+"""Markdown conversion configuration loading and normalization.
+
+The markdown conversion surface is intentionally separate from ``ai_config``:
+AI routing chooses model providers, while this module owns document-conversion
+engine ordering, format routing, API/paid auto-run switches, and engine tuning
+knobs.  Missing config is compatible and falls back to conservative local-only
+auto chains.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+ENGINE_PROVIDERS: dict[str, str] = {
+    "auto": "auto",
+    "opendataloader": "local",
+    "markitdown": "local",
+    "docling": "local",
+    "marker": "local",
+    "local": "local",
+    "mistral": "mistral",
+    "deepseekocr": "siliconflow",
+    "mathpix": "mathpix",
+}
+
+PAID_OR_API_ENGINES = {"mistral", "deepseekocr", "mathpix"}
+LOCAL_ENGINES = {engine for engine, provider in ENGINE_PROVIDERS.items() if provider == "local"}
+HARD_MAX_SCAN_COUNT = 10000
+
+DEFAULT_MARKDOWN_CONVERSION_CONFIG: dict[str, Any] = {
+    "version": 1,
+    "default_tool": "auto",
+    "tools": {
+        "auto": {
+            "display_name": "Auto (configured chain)",
+            "provider": "auto",
+            "enabled": True,
+            "auto_enabled": True,
+            "paid_or_api": False,
+        },
+        "opendataloader": {
+            "display_name": "OpenDataLoader",
+            "provider": "local",
+            "enabled": True,
+            "auto_enabled": True,
+            "paid_or_api": False,
+            "tuning": {
+                "hybrid": None,
+                "use_struct_tree": False,
+            },
+        },
+        "markitdown": {
+            "display_name": "MarkItDown",
+            "provider": "local",
+            "enabled": True,
+            "auto_enabled": True,
+            "paid_or_api": False,
+            "tuning": {
+                "enable_plugins": True,
+                "enable_builtins": True,
+            },
+        },
+        "docling": {
+            "display_name": "Docling",
+            "provider": "local",
+            "enabled": True,
+            "auto_enabled": True,
+            "paid_or_api": False,
+            "tuning": {
+                "max_pages": None,
+                "raise_on_error": True,
+            },
+        },
+        "marker": {
+            "display_name": "Marker",
+            "provider": "local",
+            "enabled": True,
+            "auto_enabled": False,
+            "paid_or_api": False,
+            "tuning": {
+                "use_llm": False,
+                "processors": None,
+                "page_range": None,
+                "extract_images": False,
+                "llm_service": None,
+            },
+        },
+        "local": {
+            "display_name": "Local (Basic)",
+            "provider": "local",
+            "enabled": True,
+            "auto_enabled": True,
+            "paid_or_api": False,
+            "tuning": {},
+        },
+        "mistral": {
+            "display_name": "Mistral OCR",
+            "provider": "mistral",
+            "enabled": True,
+            "auto_enabled": False,
+            "paid_or_api": True,
+            "model": "mistral-ocr-latest",
+            "tuning": {
+                "max_pdf_tokens": 9000,
+                "max_pages_per_chunk": 10,
+                "timeout_seconds": 60,
+                "retry_attempts": 3,
+                "extract_header": True,
+                "extract_footer": True,
+            },
+        },
+        "deepseekocr": {
+            "display_name": "DeepSeek OCR",
+            "provider": "siliconflow",
+            "enabled": True,
+            "auto_enabled": False,
+            "paid_or_api": True,
+            "model": "deepseek-ai/DeepSeek-OCR",
+            "tuning": {
+                "max_input_tokens": 3500,
+                "chunk_overlap_tokens": 200,
+                "timeout_seconds": 60,
+                "retry_attempts": 3,
+            },
+        },
+        "mathpix": {
+            "display_name": "Mathpix",
+            "provider": "mathpix",
+            "enabled": True,
+            "auto_enabled": False,
+            "paid_or_api": True,
+            "model": "mathpix",
+            "tuning": {
+                "timeout_seconds": 120,
+                "retry_attempts": 3,
+                "poll_interval_seconds": 5,
+                "output_format": "md",
+                "base_url": "https://api.mathpix.com/v3",
+            },
+        },
+    },
+    "formats": {
+        "pdf": {
+            "extensions": [".pdf"],
+            "candidate_chain": ["opendataloader", "markitdown", "docling", "local"],
+        },
+        "office": {
+            "extensions": [".docx", ".pptx"],
+            "candidate_chain": ["markitdown", "docling", "local"],
+        },
+        "image": {
+            "extensions": [".png", ".jpg", ".jpeg", ".webp", ".bmp"],
+            "candidate_chain": ["local"],
+        },
+        "default": {
+            "extensions": [],
+            "candidate_chain": ["markitdown", "docling", "local"],
+        },
+    },
+    "limits": {
+        "default_scan_count": 50,
+        "max_scan_count": 2000,
+    },
+}
+
+
+def get_markdown_conversion_config_path() -> str:
+    return os.getenv("MARKDOWN_CONVERSION_CONFIG_PATH", "config/markdown_conversion.yaml")
+
+
+def markdown_conversion_config_file_exists(path: str | None = None) -> bool:
+    return Path(path or get_markdown_conversion_config_path()).exists()
+
+
+def _deep_merge(base: dict[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
+    result = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, Mapping) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result
+
+
+def _read_yaml(path: str) -> dict[str, Any]:
+    if not path or not Path(path).exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def _bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _normalize_tools(config: dict[str, Any]) -> None:
+    raw_tools = config.get("tools") if isinstance(config.get("tools"), dict) else {}
+    tools: dict[str, dict[str, Any]] = {}
+    for name, default_tool in DEFAULT_MARKDOWN_CONVERSION_CONFIG["tools"].items():
+        raw_tool = raw_tools.get(name) if isinstance(raw_tools.get(name), dict) else {}
+        tool = _deep_merge(default_tool, raw_tool)
+        engine = str(name).strip().lower()
+        provider = str(tool.get("provider") or ENGINE_PROVIDERS.get(engine) or "local").strip().lower()
+        tool["name"] = engine
+        tool["provider"] = provider
+        tool["enabled"] = _bool(tool.get("enabled"), True)
+        tool["paid_or_api"] = _bool(tool.get("paid_or_api"), engine in PAID_OR_API_ENGINES)
+        # Conservative default: paid/API tools never join auto mode unless explicitly enabled.
+        tool["auto_enabled"] = _bool(tool.get("auto_enabled"), False if tool["paid_or_api"] else bool(tool["enabled"]))
+        tool["display_name"] = str(tool.get("display_name") or engine).strip() or engine
+        if not isinstance(tool.get("tuning"), dict):
+            tool["tuning"] = {}
+        tools[engine] = tool
+
+    # Preserve any future custom engines from config, but normalize safe defaults.
+    for raw_name, raw_tool in raw_tools.items():
+        engine = str(raw_name or "").strip().lower()
+        if not engine or engine in tools or not isinstance(raw_tool, dict):
+            continue
+        provider = str(raw_tool.get("provider") or ENGINE_PROVIDERS.get(engine) or "local").strip().lower()
+        paid_or_api = _bool(raw_tool.get("paid_or_api"), provider != "local")
+        tools[engine] = {
+            **deepcopy(raw_tool),
+            "name": engine,
+            "provider": provider,
+            "display_name": str(raw_tool.get("display_name") or engine).strip() or engine,
+            "enabled": _bool(raw_tool.get("enabled"), True),
+            "paid_or_api": paid_or_api,
+            "auto_enabled": _bool(raw_tool.get("auto_enabled"), False if paid_or_api else True),
+            "tuning": raw_tool.get("tuning") if isinstance(raw_tool.get("tuning"), dict) else {},
+        }
+    config["tools"] = tools
+
+
+def _normalize_formats(config: dict[str, Any]) -> None:
+    tools = config["tools"]
+    raw_formats = config.get("formats") if isinstance(config.get("formats"), dict) else {}
+    formats: dict[str, dict[str, Any]] = {}
+    for fmt, default_fmt in DEFAULT_MARKDOWN_CONVERSION_CONFIG["formats"].items():
+        raw_fmt = raw_formats.get(fmt) if isinstance(raw_formats.get(fmt), dict) else {}
+        entry = _deep_merge(default_fmt, raw_fmt)
+        extensions = entry.get("extensions") if isinstance(entry.get("extensions"), list) else []
+        chain = entry.get("candidate_chain") if isinstance(entry.get("candidate_chain"), list) else []
+        entry["extensions"] = [str(ext).strip().lower() for ext in extensions if str(ext).strip()]
+        entry["candidate_chain"] = [
+            str(engine).strip().lower()
+            for engine in chain
+            if str(engine).strip().lower() in tools
+            and tools[str(engine).strip().lower()].get("enabled", True)
+        ]
+        formats[fmt] = entry
+    config["formats"] = formats
+
+
+def normalize_markdown_conversion_config(raw_config: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    config = _deep_merge(DEFAULT_MARKDOWN_CONVERSION_CONFIG, raw_config or {})
+    default_tool = str(config.get("default_tool") or "auto").strip().lower()
+    config["default_tool"] = default_tool or "auto"
+    _normalize_tools(config)
+    tools_raw = config.get("tools")
+    tools: dict[str, dict[str, Any]] = tools_raw if isinstance(tools_raw, dict) else {}
+    if config["default_tool"] not in tools or not tools[config["default_tool"]].get("enabled", True):
+        config["default_tool"] = "auto" if tools.get("auto", {}).get("enabled", True) else next(
+            (name for name, tool in tools.items() if isinstance(tool, dict) and tool.get("enabled", True)),
+            "auto",
+        )
+    _normalize_formats(config)
+    raw_limits = config.get("limits")
+    limits: dict[str, Any] = raw_limits if isinstance(raw_limits, dict) else {}
+    try:
+        limits["default_scan_count"] = min(HARD_MAX_SCAN_COUNT, max(1, int(limits.get("default_scan_count") or 50)))
+    except Exception:
+        limits["default_scan_count"] = 50
+    try:
+        limits["max_scan_count"] = min(
+            HARD_MAX_SCAN_COUNT,
+            max(limits["default_scan_count"], int(limits.get("max_scan_count") or 2000)),
+        )
+    except Exception:
+        limits["max_scan_count"] = min(HARD_MAX_SCAN_COUNT, max(limits["default_scan_count"], 2000))
+    config["limits"] = limits
+    return config
+
+
+def load_markdown_conversion_config(path: str | None = None) -> dict[str, Any]:
+    return normalize_markdown_conversion_config(_read_yaml(path or get_markdown_conversion_config_path()))
+
+
+def write_markdown_conversion_config(config: Mapping[str, Any], path: str | None = None) -> dict[str, Any]:
+    normalized = normalize_markdown_conversion_config(config)
+    target = Path(path or get_markdown_conversion_config_path())
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    backup = target.with_suffix(target.suffix + ".bak")
+    if target.exists():
+        backup.write_bytes(target.read_bytes())
+
+    fd, temp_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=str(target.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(normalized, handle, sort_keys=False, allow_unicode=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, target)
+    except Exception:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+        raise
+    return normalized
+
+
+def format_key_for_path(path: str | Path, config: Mapping[str, Any] | None = None) -> str:
+    cfg = normalize_markdown_conversion_config(config) if config is not None else load_markdown_conversion_config()
+    suffix = Path(path).suffix.lower()
+    for name, fmt in (cfg.get("formats") or {}).items():
+        if name == "default":
+            continue
+        extensions = fmt.get("extensions") if isinstance(fmt, dict) else []
+        if suffix in set(extensions or []):
+            return str(name)
+    return "default"
+
+
+def candidate_chain_for_path(path: str | Path, config: Mapping[str, Any] | None = None, *, auto_only: bool = True) -> list[str]:
+    cfg = normalize_markdown_conversion_config(config) if config is not None else load_markdown_conversion_config()
+    fmt = (cfg.get("formats") or {}).get(format_key_for_path(path, cfg), {})
+    tools = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
+    chain = fmt.get("candidate_chain") if isinstance(fmt, dict) and isinstance(fmt.get("candidate_chain"), list) else []
+    result: list[str] = []
+    for raw_engine in chain:
+        engine = str(raw_engine).strip().lower()
+        tool = tools.get(engine) if isinstance(tools.get(engine), dict) else {}
+        if not tool or not tool.get("enabled", True):
+            continue
+        if auto_only and not tool.get("auto_enabled", False):
+            continue
+        result.append(engine)
+    return result
+
+
+def list_conversion_tools(config: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+    cfg = normalize_markdown_conversion_config(config) if config is not None else load_markdown_conversion_config()
+    tools = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
+    ordered: list[str] = []
+    default_tool = str(cfg.get("default_tool") or "auto").strip().lower()
+    if default_tool in tools:
+        ordered.append(default_tool)
+    for fmt in (cfg.get("formats") or {}).values():
+        chain = fmt.get("candidate_chain") if isinstance(fmt, dict) else []
+        for raw_engine in chain or []:
+            engine = str(raw_engine).strip().lower()
+            if engine in tools and engine not in ordered:
+                ordered.append(engine)
+    for engine in tools:
+        if engine not in ordered:
+            ordered.append(engine)
+    return [
+        {
+            "name": engine,
+            "provider": str(tools[engine].get("provider") or ENGINE_PROVIDERS.get(engine) or "local"),
+            "displayName": str(tools[engine].get("display_name") or engine),
+            "display_name": str(tools[engine].get("display_name") or engine),
+            "enabled": bool(tools[engine].get("enabled", True)),
+            "auto_enabled": bool(tools[engine].get("auto_enabled", False)),
+            "paid_or_api": bool(tools[engine].get("paid_or_api", False)),
+        }
+        for engine in ordered
+        if tools[engine].get("enabled", True)
+    ]
+
+
+def get_markdown_conversion_options() -> dict[str, Any]:
+    cfg = load_markdown_conversion_config()
+    return {
+        "config": cfg,
+        "tools": list_conversion_tools(cfg),
+        "default_tool": cfg.get("default_tool", "auto"),
+        "formats": cfg.get("formats", {}),
+        "limits": cfg.get("limits", {}),
+        "config_path_set": bool(os.getenv("MARKDOWN_CONVERSION_CONFIG_PATH")),
+    }

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -16,7 +16,8 @@ from urllib.parse import urlparse
 
 import schedule
 
-from ai_actuarial.ai_runtime import get_search_runtime_credentials, resolve_ocr_runtime
+from ai_actuarial.ai_runtime import apply_ocr_runtime_environment, get_search_runtime_credentials, resolve_ocr_runtime
+from ai_actuarial.markdown_conversion_config import HARD_MAX_SCAN_COUNT, candidate_chain_for_path, load_markdown_conversion_config
 from ai_actuarial.catalog_incremental import run_catalog_for_urls, run_incremental_catalog
 from ai_actuarial.collectors.base import CollectionConfig, CollectionResult
 from ai_actuarial.collectors.file import FileCollector
@@ -880,10 +881,22 @@ class NativeTaskRuntime:
                 metadata={"source_type": "markdown_conversion"},
             )
 
-        conversion_tool = str(data.get("conversion_tool") or "opendataloader").strip().lower()
-        ocr_runtime = resolve_ocr_runtime(storage=storage, yaml_config=config, engine_override=conversion_tool)
-        if ocr_runtime.provider != "local" and not ocr_runtime.api_key:
-            raise RuntimeError(f"OCR provider '{ocr_runtime.provider}' is not configured")
+        md_config = load_markdown_conversion_config()
+        conversion_tool = str(data.get("conversion_tool") or md_config.get("default_tool") or "auto").strip().lower() or "auto"
+        explicit_runtime = None
+        if conversion_tool != "auto":
+            explicit_tool_cfg = (md_config.get("tools") or {}).get(conversion_tool) or {}
+            if not isinstance(explicit_tool_cfg, dict) or not explicit_tool_cfg.get("enabled", True):
+                raise RuntimeError(f"Markdown conversion tool '{conversion_tool}' is disabled or not configured")
+            explicit_model = explicit_tool_cfg.get("model")
+            explicit_runtime = resolve_ocr_runtime(
+                storage=storage,
+                yaml_config=config,
+                engine_override=conversion_tool,
+                model_override=str(explicit_model).strip() if explicit_model else None,
+            )
+            if explicit_runtime.provider != "local" and not explicit_runtime.api_key:
+                raise RuntimeError(f"OCR provider '{explicit_runtime.provider}' is not configured")
 
         overwrite_existing = bool(data.get("overwrite_existing", False))
         skip_existing = bool(data.get("skip_existing", True)) and not overwrite_existing
@@ -893,6 +906,8 @@ class NativeTaskRuntime:
         skipped = 0
         total = len(file_rows)
         progress(0, total, "Starting markdown conversion")
+        last_resolved_engine = explicit_runtime.engine if explicit_runtime is not None else "auto"
+        last_provider = explicit_runtime.provider if explicit_runtime is not None else "auto"
 
         for index, row in enumerate(file_rows, start=1):
             file_url = str(row.get("url") or "").strip()
@@ -909,20 +924,25 @@ class NativeTaskRuntime:
                 progress(index, total, f"Missing file {index}/{total}")
                 continue
             try:
-                output = _convert_document_path(
+                output, provider = self._convert_markdown_candidate_chain(
                     local_path,
-                    engine=ocr_runtime.engine,  # type: ignore[arg-type]
-                    model=ocr_runtime.model,
-                    api_key=ocr_runtime.api_key,
-                    base_url=ocr_runtime.base_url,
+                    conversion_tool=conversion_tool,
+                    explicit_runtime=explicit_runtime,
+                    storage=storage,
+                    config=config,
+                    md_config=md_config,
                 )
+                last_resolved_engine = output.engine
+                source_model = str(output.model)
+                source_engine = str(output.engine)
                 ok, reason = storage.update_file_markdown(
                     file_url,
                     output.markdown,
-                    markdown_source=f"{output.engine}:{output.model}".strip(":"),
+                    markdown_source=f"{source_engine}:{source_model}".strip(":"),
                 )
                 if ok:
                     converted += 1
+                    last_provider = provider
                 else:
                     errors.append(f"{file_url}: {reason or 'markdown update failed'}")
             except Exception as exc:  # noqa: BLE001
@@ -938,10 +958,68 @@ class NativeTaskRuntime:
             metadata={
                 "source_type": "markdown_conversion",
                 "conversion_tool": conversion_tool,
-                "resolved_engine": ocr_runtime.engine,
-                "provider": ocr_runtime.provider,
+                "resolved_engine": last_resolved_engine,
+                "provider": last_provider,
             },
         )
+
+    def _convert_markdown_candidate_chain(
+        self,
+        local_path: Path,
+        *,
+        conversion_tool: str,
+        explicit_runtime: Any | None,
+        storage: Storage,
+        config: dict[str, Any],
+        md_config: dict[str, Any],
+    ) -> Any:
+        if explicit_runtime is not None:
+            apply_ocr_runtime_environment(explicit_runtime)
+            output = _convert_document_path(
+                local_path,
+                engine=explicit_runtime.engine,  # type: ignore[arg-type]
+                model=explicit_runtime.model,
+                api_key=explicit_runtime.api_key,
+                base_url=explicit_runtime.base_url,
+            )
+            return output, explicit_runtime.provider
+
+        candidates = candidate_chain_for_path(local_path, md_config, auto_only=True)
+        if not candidates:
+            raise RuntimeError(f"No auto conversion candidates configured for {local_path.name}")
+
+        last_exc: Exception | None = None
+        skipped_unconfigured: list[str] = []
+        for candidate in candidates:
+            tool_cfg = (md_config.get("tools") or {}).get(candidate) or {}
+            candidate_model = tool_cfg.get("model") if isinstance(tool_cfg, dict) else None
+            runtime = resolve_ocr_runtime(
+                storage=storage,
+                yaml_config=config,
+                engine_override=candidate,
+                model_override=str(candidate_model).strip() if candidate_model else None,
+            )
+            if runtime.provider != "local" and not runtime.api_key:
+                skipped_unconfigured.append(candidate)
+                continue
+            try:
+                apply_ocr_runtime_environment(runtime)
+                output = _convert_document_path(
+                    local_path,
+                    engine=runtime.engine,  # type: ignore[arg-type]
+                    model=runtime.model,
+                    api_key=runtime.api_key,
+                    base_url=runtime.base_url,
+                )
+                return output, runtime.provider
+            except Exception as exc:  # noqa: BLE001 - auto mode tries fallbacks
+                last_exc = exc
+                continue
+
+        details = ""
+        if skipped_unconfigured:
+            details = f" (skipped unconfigured API tools: {', '.join(skipped_unconfigured)})"
+        raise RuntimeError(f"Auto conversion failed for {local_path.name}{details}") from last_exc
 
     def _run_chunk_generation(
         self,
@@ -1146,7 +1224,12 @@ class NativeTaskRuntime:
         where = _CONVERTIBLE_MARKDOWN_PREDICATE + category_sql
         if skip_existing:
             where += " AND (c.markdown_content IS NULL OR c.markdown_content = '')"
-        limit = self._positive_int(data.get("scan_count"), 50)
+        md_config = load_markdown_conversion_config()
+        raw_limits = md_config.get("limits")
+        limits = raw_limits if isinstance(raw_limits, dict) else {}
+        default_limit = self._positive_int(limits.get("default_scan_count"), 50)
+        max_limit = min(HARD_MAX_SCAN_COUNT, max(default_limit, self._positive_int(limits.get("max_scan_count"), 2000)))
+        limit = min(self._positive_int(data.get("scan_count"), default_limit), max_limit)
         offset = max(0, self._positive_int(data.get("scan_start_index"), 1) - 1)
         rows = conn.execute(
             f"""

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -926,7 +926,6 @@ class NativeTaskRuntime:
             try:
                 output, provider = self._convert_markdown_candidate_chain(
                     local_path,
-                    conversion_tool=conversion_tool,
                     explicit_runtime=explicit_runtime,
                     storage=storage,
                     config=config,
@@ -967,7 +966,6 @@ class NativeTaskRuntime:
         self,
         local_path: Path,
         *,
-        conversion_tool: str,
         explicit_runtime: Any | None,
         storage: Storage,
         config: dict[str, Any],

--- a/client/src/components/FormFields.tsx
+++ b/client/src/components/FormFields.tsx
@@ -11,11 +11,11 @@ export function FormField({ label, children, hint }: { label: string; children: 
   );
 }
 
-export function InputField({ value, onChange, placeholder, type = "text", testId }: {
-  value: string; onChange: (v: string) => void; placeholder?: string; type?: string; testId?: string;
+export function InputField({ value, onChange, placeholder, type = "text", min, max, testId }: {
+  value: string; onChange: (v: string) => void; placeholder?: string; type?: string; min?: number; max?: number; testId?: string;
 }) {
   return (
-    <input type={type} value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder}
+    <input type={type} value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} min={min} max={max}
       className="w-full px-3 py-2 text-sm rounded-lg border border-border bg-background focus:outline-none focus:ring-2 focus:ring-ring"
       data-testid={testId} />
   );

--- a/client/src/hooks/use-task-options.ts
+++ b/client/src/hooks/use-task-options.ts
@@ -13,12 +13,19 @@ export interface ConversionTool {
   displayName: string;
 }
 
+export interface MarkdownConversionLimits {
+  defaultScanCount: number;
+  maxScanCount: number;
+}
+
 interface TaskOptions {
   engines: SearchEngine[];
   providers: string[];
   categories: string[];
   conversionTools: string[];
   conversionToolsInfo: ConversionTool[];
+  defaultConversionTool: string;
+  markdownConversionLimits: MarkdownConversionLimits;
   catalogProviders: string[];
   loading: boolean;
   error: string | null;
@@ -61,6 +68,20 @@ interface AiModelsResponse {
   [key: string]: unknown;
 }
 
+interface MarkdownConversionConfigResponse {
+  tools?: Array<{
+    name?: string;
+    provider?: string;
+    displayName?: string;
+    display_name?: string;
+    enabled?: boolean;
+  }>;
+  default_tool?: string;
+  limits?: { default_scan_count?: number; max_scan_count?: number };
+  config?: { default_tool?: string; limits?: { default_scan_count?: number; max_scan_count?: number } };
+  [key: string]: unknown;
+}
+
 const FALLBACK_ENGINES: SearchEngine[] = [
   { name: "Brave Search", value: "brave", available: true },
   { name: "Google (SerpAPI)", value: "google", available: true },
@@ -68,13 +89,13 @@ const FALLBACK_ENGINES: SearchEngine[] = [
   { name: "Tavily", value: "tavily", available: true },
 ];
 
-const FALLBACK_CONVERSION_TOOLS = ["opendataloader", "markitdown", "mistral", "docling", "mathpix"];
+const FALLBACK_CONVERSION_TOOLS = ["auto", "opendataloader", "markitdown", "docling", "local"];
 const FALLBACK_CONVERSION_TOOLS_INFO: ConversionTool[] = [
+  { name: "auto", provider: "auto", displayName: "Auto (configured chain)" },
   { name: "opendataloader", provider: "local", displayName: "OpenDataLoader" },
   { name: "markitdown", provider: "local", displayName: "MarkItDown" },
-  { name: "mistral", provider: "mistral", displayName: "Mistral OCR" },
   { name: "docling", provider: "local", displayName: "Docling" },
-  { name: "mathpix", provider: "mathpix", displayName: "Mathpix" },
+  { name: "local", provider: "local", displayName: "Local (Basic)" },
 ];
 
 const cache: {
@@ -83,11 +104,14 @@ const cache: {
   categories?: string[];
   conversionTools?: string[];
   conversionToolsInfo?: ConversionTool[];
+  defaultConversionTool?: string;
+  markdownConversionLimits?: MarkdownConversionLimits;
   catalogProviders?: string[];
   timestamp?: number;
 } = {};
 
 const CACHE_TTL = 60000;
+const FALLBACK_MARKDOWN_CONVERSION_LIMITS: MarkdownConversionLimits = { defaultScanCount: 50, maxScanCount: 2000 };
 
 function isCacheValid(): boolean {
   return !!cache.timestamp && Date.now() - cache.timestamp < CACHE_TTL;
@@ -196,6 +220,10 @@ export function useTaskOptions(): TaskOptions {
   const [categories, setCategories] = useState<string[]>(cache.categories || []);
   const [conversionTools, setConversionTools] = useState<string[]>(cache.conversionTools || FALLBACK_CONVERSION_TOOLS);
   const [conversionToolsInfo, setConversionToolsInfo] = useState<ConversionTool[]>(cache.conversionToolsInfo || FALLBACK_CONVERSION_TOOLS_INFO);
+  const [defaultConversionTool, setDefaultConversionTool] = useState<string>(cache.defaultConversionTool || "auto");
+  const [markdownConversionLimits, setMarkdownConversionLimits] = useState<MarkdownConversionLimits>(
+    cache.markdownConversionLimits || FALLBACK_MARKDOWN_CONVERSION_LIMITS
+  );
   const [catalogProviders, setCatalogProviders] = useState<string[]>(cache.catalogProviders || []);
   const [loading, setLoading] = useState(!isCacheValid());
   const [error, setError] = useState<string | null>(null);
@@ -208,6 +236,8 @@ export function useTaskOptions(): TaskOptions {
       setCategories(cache.categories || []);
       setConversionTools(cache.conversionTools || FALLBACK_CONVERSION_TOOLS);
       setConversionToolsInfo(cache.conversionToolsInfo || FALLBACK_CONVERSION_TOOLS_INFO);
+      setDefaultConversionTool(cache.defaultConversionTool || "auto");
+      setMarkdownConversionLimits(cache.markdownConversionLimits || FALLBACK_MARKDOWN_CONVERSION_LIMITS);
       setCatalogProviders(cache.catalogProviders || []);
       return;
     }
@@ -220,9 +250,10 @@ export function useTaskOptions(): TaskOptions {
       apiGet<ProviderResponse>("/api/config/llm-providers"),
       apiGet<CategoryResponse>("/api/categories?mode=used"),
       apiGet<AiModelsResponse>("/api/config/ai-models"),
+      apiGet<MarkdownConversionConfigResponse>("/api/config/markdown-conversion"),
     ]);
 
-    const [enginesResult, providersResult, categoriesResult, modelsResult] = results;
+    const [enginesResult, providersResult, categoriesResult, modelsResult, markdownConfigResult] = results;
 
     let fetchedEngines = FALLBACK_ENGINES;
     if (enginesResult.status === "fulfilled" && enginesResult.value?.engines) {
@@ -251,6 +282,8 @@ export function useTaskOptions(): TaskOptions {
 
     let fetchedTools = FALLBACK_CONVERSION_TOOLS;
     let fetchedToolsInfo = FALLBACK_CONVERSION_TOOLS_INFO;
+    let fetchedDefaultConversionTool = "auto";
+    let fetchedMarkdownConversionLimits = FALLBACK_MARKDOWN_CONVERSION_LIMITS;
     let fetchedCatalogProviders: string[] = [];
     const knownProviders =
       providersResult.status === "fulfilled" && providersResult.value?.known && typeof providersResult.value.known === "object"
@@ -262,13 +295,37 @@ export function useTaskOptions(): TaskOptions {
     // show a tool as available when its provider key is missing.
     const configuredProviderNamesSet = new Set(fetchedProviders);
 
+    const markdownConfigLoaded = markdownConfigResult.status === "fulfilled";
+    if (markdownConfigLoaded) {
+      const mdConfig = markdownConfigResult.value;
+      const toolsFromApi = Array.isArray(mdConfig.tools) ? mdConfig.tools : [];
+      if (toolsFromApi.length > 0) {
+        fetchedToolsInfo = toolsFromApi
+          .filter((tool) => tool.enabled !== false && tool.name)
+          .map((tool) => ({
+            name: String(tool.name),
+            provider: String(tool.provider || "local"),
+            displayName: String(tool.displayName || tool.display_name || tool.name),
+          }));
+        fetchedTools = fetchedToolsInfo.map((tool) => tool.name);
+      }
+      fetchedDefaultConversionTool = String(mdConfig.default_tool || mdConfig.config?.default_tool || fetchedTools[0] || "auto");
+      const limits = mdConfig.limits || mdConfig.config?.limits || {};
+      fetchedMarkdownConversionLimits = {
+        defaultScanCount: Number(limits.default_scan_count || FALLBACK_MARKDOWN_CONVERSION_LIMITS.defaultScanCount),
+        maxScanCount: Number(limits.max_scan_count || FALLBACK_MARKDOWN_CONVERSION_LIMITS.maxScanCount),
+      };
+    }
     if (modelsResult.status === "fulfilled") {
       const modelRes = modelsResult.value;
       if (modelRes?.available && typeof modelRes.available === "object") {
-        const ocrTools = extractOcrTools(modelRes.available, configuredProviderNamesSet);
-        if (ocrTools.length > 0) {
-          fetchedToolsInfo = ocrTools;
-          fetchedTools = ocrTools.map((t) => t.name);
+        if (!markdownConfigLoaded) {
+          const ocrTools = extractOcrTools(modelRes.available, configuredProviderNamesSet);
+          if (ocrTools.length > 0) {
+            fetchedToolsInfo = ocrTools;
+            fetchedTools = ocrTools.map((t) => t.name);
+            fetchedDefaultConversionTool = fetchedTools[0] || fetchedDefaultConversionTool;
+          }
         }
         fetchedCatalogProviders = extractConfiguredCatalogSelection(
           modelRes.available,
@@ -290,6 +347,8 @@ export function useTaskOptions(): TaskOptions {
     cache.categories = fetchedCategories;
     cache.conversionTools = fetchedTools;
     cache.conversionToolsInfo = fetchedToolsInfo;
+    cache.defaultConversionTool = fetchedDefaultConversionTool;
+    cache.markdownConversionLimits = fetchedMarkdownConversionLimits;
     cache.catalogProviders = fetchedCatalogProviders;
     cache.timestamp = Date.now();
 
@@ -298,6 +357,8 @@ export function useTaskOptions(): TaskOptions {
     setCategories(fetchedCategories);
     setConversionTools(fetchedTools);
     setConversionToolsInfo(fetchedToolsInfo);
+    setDefaultConversionTool(fetchedDefaultConversionTool);
+    setMarkdownConversionLimits(fetchedMarkdownConversionLimits);
     setCatalogProviders(fetchedCatalogProviders);
     setLoading(false);
 
@@ -320,5 +381,5 @@ export function useTaskOptions(): TaskOptions {
     fetchOptions(true);
   }, [fetchOptions]);
 
-  return { engines, providers, categories, conversionTools, conversionToolsInfo, catalogProviders, loading, error, refresh };
+  return { engines, providers, categories, conversionTools, conversionToolsInfo, defaultConversionTool, markdownConversionLimits, catalogProviders, loading, error, refresh };
 }

--- a/client/src/hooks/use-task-options.ts
+++ b/client/src/hooks/use-task-options.ts
@@ -98,6 +98,9 @@ const FALLBACK_CONVERSION_TOOLS_INFO: ConversionTool[] = [
   { name: "local", provider: "local", displayName: "Local (Basic)" },
 ];
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
 const cache: {
   engines?: SearchEngine[];
   providers?: string[];
@@ -295,9 +298,9 @@ export function useTaskOptions(): TaskOptions {
     // show a tool as available when its provider key is missing.
     const configuredProviderNamesSet = new Set(fetchedProviders);
 
-    const markdownConfigLoaded = markdownConfigResult.status === "fulfilled";
+    const markdownConfigLoaded = markdownConfigResult.status === "fulfilled" && isRecord(markdownConfigResult.value);
     if (markdownConfigLoaded) {
-      const mdConfig = markdownConfigResult.value;
+      const mdConfig = markdownConfigResult.value as MarkdownConversionConfigResponse;
       const toolsFromApi = Array.isArray(mdConfig.tools) ? mdConfig.tools : [];
       if (toolsFromApi.length > 0) {
         fetchedToolsInfo = toolsFromApi

--- a/client/src/pages/FileDetail.tsx
+++ b/client/src/pages/FileDetail.tsx
@@ -516,13 +516,14 @@ export default function FileDetail() {
   const mdEditMode = mdTab === "edit";
 
   useEffect(() => {
+    const fallbackEngine = taskOptions.defaultConversionTool || taskOptions.conversionToolsInfo[0]?.name || "auto";
     if (!convertEngine && taskOptions.conversionToolsInfo.length > 0) {
-      setConvertEngine(taskOptions.conversionToolsInfo[0].name);
+      setConvertEngine(fallbackEngine);
     } else if (convertEngine && taskOptions.conversionToolsInfo.length > 0) {
       const valid = taskOptions.conversionToolsInfo.some((t) => t.name === convertEngine);
-      if (!valid) setConvertEngine(taskOptions.conversionToolsInfo[0].name);
+      if (!valid) setConvertEngine(fallbackEngine);
     }
-  }, [taskOptions.conversionToolsInfo, convertEngine]);
+  }, [taskOptions.conversionToolsInfo, taskOptions.defaultConversionTool, convertEngine]);
 
   useEffect(() => { fetchFile(); }, [fetchFile]);
 

--- a/client/src/pages/tasks/MarkdownForm.tsx
+++ b/client/src/pages/tasks/MarkdownForm.tsx
@@ -8,12 +8,13 @@ import { ScheduleFromTaskButton } from "./ScheduleFromTaskButton";
 
 export function MarkdownForm({ onSubmit, submitting }: { onSubmit: (d: Record<string, unknown>) => void; submitting: boolean }) {
   const { t } = useTranslation();
-  const { conversionTools, categories: dynamicCategories } = useTaskOptions();
+  const { conversionToolsInfo, defaultConversionTool, markdownConversionLimits, categories: dynamicCategories } = useTaskOptions();
   const [scopeMode, setScopeMode] = useState("index");
   const [category, setCategory] = useState("");
-  const [scanCount, setScanCount] = useState("50");
+  const [scanCount, setScanCount] = useState(String(markdownConversionLimits.defaultScanCount));
+  const [scanCountTouched, setScanCountTouched] = useState(false);
   const [startIndex, setStartIndex] = useState("");
-  const [tool, setTool] = useState("opendataloader");
+  const [tool, setTool] = useState(defaultConversionTool || "auto");
   const [skipExisting, setSkipExisting] = useState(true);
   const [overwriteExisting, setOverwriteExisting] = useState(false);
   const [stats, setStats] = useState<Record<string, unknown> | null>(null);
@@ -23,15 +24,22 @@ export function MarkdownForm({ onSubmit, submitting }: { onSubmit: (d: Record<st
     ...dynamicCategories.map((c) => ({ value: c, label: c })),
   ];
 
-  const tools = conversionTools.length > 0
-    ? conversionTools.map((t) => ({ value: t, label: t.charAt(0).toUpperCase() + t.slice(1) }))
-    : [
-        { value: "opendataloader", label: "OpenDataLoader" },
-        { value: "markitdown", label: "MarkItDown" },
-        { value: "mistral", label: "Mistral OCR" },
-        { value: "docling", label: "Docling" },
-        { value: "mathpix", label: "Mathpix" },
-      ];
+  const tools = conversionToolsInfo.length > 0
+    ? conversionToolsInfo.map((t) => ({ value: t.name, label: t.displayName || t.name }))
+    : [{ value: "auto", label: "Auto (configured chain)" }];
+
+  useEffect(() => {
+    const fallbackTool = defaultConversionTool || conversionToolsInfo[0]?.name || "auto";
+    if (!tool || !conversionToolsInfo.some((candidate) => candidate.name === tool)) {
+      setTool(fallbackTool);
+    }
+  }, [conversionToolsInfo, defaultConversionTool, tool]);
+
+  useEffect(() => {
+    if (!scanCountTouched) {
+      setScanCount(String(markdownConversionLimits.defaultScanCount));
+    }
+  }, [markdownConversionLimits.defaultScanCount, scanCountTouched]);
 
   const loadStats = useCallback(async (cat?: string) => {
     setStatsLoading(true);
@@ -65,7 +73,7 @@ export function MarkdownForm({ onSubmit, submitting }: { onSubmit: (d: Record<st
       conversion_tool: tool,
       scope_mode: scopeMode,
       category: scopeMode === "category" ? category : undefined,
-      scan_count: parseInt(scanCount) || 50,
+      scan_count: Math.min(parseInt(scanCount) || markdownConversionLimits.defaultScanCount, markdownConversionLimits.maxScanCount),
       scan_start_index: startIndex ? parseInt(startIndex) : undefined,
       skip_existing: skipExisting,
       overwrite_existing: overwriteExisting,
@@ -88,8 +96,17 @@ export function MarkdownForm({ onSubmit, submitting }: { onSubmit: (d: Record<st
         <FormField label={t("tasks.form.conversion_tool")}>
           <SelectField value={tool} onChange={setTool} options={tools} testId="select-tool" />
         </FormField>
-        <FormField label={t("tasks.form.scan_count")} hint={t("tasks.form.max_hint") + " 2000"}>
-          <InputField value={scanCount} onChange={setScanCount} placeholder="50" type="number" testId="input-md-scan-count" />
+        <FormField label={t("tasks.form.scan_count")} hint={t("tasks.form.max_hint") + ` ${markdownConversionLimits.maxScanCount}`}>
+          <InputField
+            value={scanCount}
+            onChange={(value) => {
+              setScanCountTouched(true);
+              setScanCount(value);
+            }}
+            placeholder={String(markdownConversionLimits.defaultScanCount)}
+            type="number"
+            testId="input-md-scan-count"
+          />
         </FormField>
       </div>
       <FormField label={t("tasks.form.start_index")} hint={t("tasks.form.start_index_hint")}>

--- a/client/src/pages/tasks/MarkdownForm.tsx
+++ b/client/src/pages/tasks/MarkdownForm.tsx
@@ -67,13 +67,14 @@ export function MarkdownForm({ onSubmit, submitting }: { onSubmit: (d: Record<st
 
   const buildTask = (): Record<string, unknown> | null => {
     if (scopeMode === "category" && !category.trim()) return null;
+    const parsedScanCount = parseInt(scanCount, 10) || markdownConversionLimits.defaultScanCount;
     return {
       type: "markdown_conversion",
       name: `Markdown (${tool})`,
       conversion_tool: tool,
       scope_mode: scopeMode,
       category: scopeMode === "category" ? category : undefined,
-      scan_count: Math.min(parseInt(scanCount) || markdownConversionLimits.defaultScanCount, markdownConversionLimits.maxScanCount),
+      scan_count: Math.max(1, Math.min(parsedScanCount, markdownConversionLimits.maxScanCount)),
       scan_start_index: startIndex ? parseInt(startIndex) : undefined,
       skip_existing: skipExisting,
       overwrite_existing: overwriteExisting,
@@ -105,6 +106,8 @@ export function MarkdownForm({ onSubmit, submitting }: { onSubmit: (d: Record<st
             }}
             placeholder={String(markdownConversionLimits.defaultScanCount)}
             type="number"
+            min={1}
+            max={markdownConversionLimits.maxScanCount}
             testId="input-md-scan-count"
           />
         </FormField>

--- a/config/markdown_conversion.yaml
+++ b/config/markdown_conversion.yaml
@@ -1,0 +1,129 @@
+version: 1
+default_tool: auto
+tools:
+  auto:
+    display_name: Auto (configured chain)
+    provider: auto
+    enabled: true
+    auto_enabled: true
+    paid_or_api: false
+  opendataloader:
+    display_name: OpenDataLoader
+    provider: local
+    enabled: true
+    auto_enabled: true
+    paid_or_api: false
+    tuning:
+      hybrid: null
+      use_struct_tree: false
+  markitdown:
+    display_name: MarkItDown
+    provider: local
+    enabled: true
+    auto_enabled: true
+    paid_or_api: false
+    tuning:
+      enable_plugins: true
+      enable_builtins: true
+  docling:
+    display_name: Docling
+    provider: local
+    enabled: true
+    auto_enabled: true
+    paid_or_api: false
+    tuning:
+      max_pages: null
+      raise_on_error: true
+  marker:
+    display_name: Marker
+    provider: local
+    enabled: true
+    auto_enabled: false
+    paid_or_api: false
+    tuning:
+      use_llm: false
+      processors: null
+      page_range: null
+      extract_images: false
+      llm_service: null
+  local:
+    display_name: Local (Basic)
+    provider: local
+    enabled: true
+    auto_enabled: true
+    paid_or_api: false
+    tuning: {}
+  mistral:
+    display_name: Mistral OCR
+    provider: mistral
+    enabled: true
+    auto_enabled: false
+    paid_or_api: true
+    model: mistral-ocr-latest
+    tuning:
+      max_pdf_tokens: 9000
+      max_pages_per_chunk: 10
+      timeout_seconds: 60
+      retry_attempts: 3
+      extract_header: true
+      extract_footer: true
+  deepseekocr:
+    display_name: DeepSeek OCR
+    provider: siliconflow
+    enabled: true
+    auto_enabled: false
+    paid_or_api: true
+    model: deepseek-ai/DeepSeek-OCR
+    tuning:
+      max_input_tokens: 3500
+      chunk_overlap_tokens: 200
+      timeout_seconds: 60
+      retry_attempts: 3
+  mathpix:
+    display_name: Mathpix
+    provider: mathpix
+    enabled: true
+    auto_enabled: false
+    paid_or_api: true
+    model: mathpix
+    tuning:
+      timeout_seconds: 120
+      retry_attempts: 3
+      poll_interval_seconds: 5
+      output_format: md
+      base_url: https://api.mathpix.com/v3
+formats:
+  pdf:
+    extensions:
+    - .pdf
+    candidate_chain:
+    - opendataloader
+    - markitdown
+    - docling
+    - local
+  office:
+    extensions:
+    - .docx
+    - .pptx
+    candidate_chain:
+    - markitdown
+    - docling
+    - local
+  image:
+    extensions:
+    - .png
+    - .jpg
+    - .jpeg
+    - .webp
+    - .bmp
+    candidate_chain:
+    - local
+  default:
+    extensions: []
+    candidate_chain:
+    - markitdown
+    - docling
+    - local
+limits:
+  default_scan_count: 50
+  max_scan_count: 2000

--- a/doc_to_md/registry.py
+++ b/doc_to_md/registry.py
@@ -69,39 +69,46 @@ def _import_engine(engine: str):
 
 
 def pick_auto_engine(path: Path) -> str:
-    """Pick a reasonable default engine based on extension.
+    """Pick the first configured auto candidate without triggering paid/API tools by default."""
 
-Conservative default: prefer local tools first to avoid unexpected paid API calls.
-"""
+    candidates = _auto_candidates(path)
+    if candidates:
+        return candidates[0]
+    try:
+        from ai_actuarial.markdown_conversion_config import markdown_conversion_config_file_exists
 
-    suffix = path.suffix.lower()
-    if suffix == ".pdf":
-        return "opendataloader"
-    if suffix in {".docx", ".pptx"}:
-        return "markitdown"
-    if suffix in {".png", ".jpg", ".jpeg", ".webp", ".bmp"}:
-        return "deepseekocr"
+        if markdown_conversion_config_file_exists():
+            raise RuntimeError(f"No auto conversion candidates configured for {path.name}")
+    except RuntimeError:
+        raise
+    except Exception:
+        pass
     return "markitdown"
 
 
 def _auto_candidates(path: Path) -> list[str]:
+    try:
+        from ai_actuarial.markdown_conversion_config import (
+            candidate_chain_for_path,
+            markdown_conversion_config_file_exists,
+        )
+
+        candidates = candidate_chain_for_path(path, auto_only=True)
+        if candidates:
+            return candidates
+        if markdown_conversion_config_file_exists():
+            return []
+    except Exception:
+        pass
+
     suffix = path.suffix.lower()
     if suffix == ".pdf":
-        return [
-            "opendataloader",
-            "markitdown",
-            "mistral",
-            "docling",
-            "mathpix",
-            "marker",
-            "deepseekocr",
-            "local",
-        ]
+        return ["opendataloader", "markitdown", "docling", "local"]
     if suffix in {".docx", ".pptx"}:
-        return ["markitdown", "docling", "mistral", "mathpix", "local"]
+        return ["markitdown", "docling", "local"]
     if suffix in {".png", ".jpg", ".jpeg", ".webp", ".bmp"}:
-        return ["mathpix", "deepseekocr", "mistral", "local"]
-    return ["markitdown", "docling", "mistral", "local"]
+        return ["local"]
+    return ["markitdown", "docling", "local"]
 
 
 def convert_path(

--- a/tests/test_doc_to_md_engine_defaults.py
+++ b/tests/test_doc_to_md_engine_defaults.py
@@ -11,10 +11,12 @@ def test_registry_supports_recommended_markdown_engines():
     assert registry._import_engine("mathpix").__name__ == "MathpixEngine"
 
 
-def test_auto_pdf_candidates_start_with_recommended_default_tools():
+def test_auto_pdf_candidates_use_configured_local_safe_default_chain():
     candidates = registry._auto_candidates(Path("sample.pdf"))
 
-    assert candidates[:5] == ["opendataloader", "markitdown", "mistral", "docling", "mathpix"]
+    assert candidates == ["opendataloader", "markitdown", "docling", "local"]
+    assert "mistral" not in candidates
+    assert "mathpix" not in candidates
 
 
 def test_settings_accepts_new_markdown_engine_configuration():

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -317,6 +317,44 @@ def test_site_config_write_rejects_unsafe_urls(tmp_path: Path, monkeypatch) -> N
     assert "Import Blocked" not in site_names
 
 
+def test_markdown_conversion_config_read_write_endpoint_roundtrip(tmp_path: Path, monkeypatch) -> None:
+    _patch_available_models(monkeypatch)
+    markdown_config_path = tmp_path / "markdown_conversion.yaml"
+    monkeypatch.setenv("MARKDOWN_CONVERSION_CONFIG_PATH", str(markdown_config_path))
+    client, _app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
+    admin_headers = {"X-Auth-Token": str(seed["admin_token"])}
+
+    unauthenticated = client.get("/api/config/markdown-conversion")
+    assert unauthenticated.status_code == 401
+
+    forbidden = client.post(
+        "/api/config/markdown-conversion",
+        json={"default_tool": "markitdown"},
+        headers={"Authorization": f"Bearer {seed['reader_token']}"},
+    )
+    assert forbidden.status_code == 403
+
+    update = client.post(
+        "/api/config/markdown-conversion",
+        json={
+            "default_tool": "markitdown",
+            "limits": {"default_scan_count": 25, "max_scan_count": 50000},
+            "formats": {"pdf": {"candidate_chain": ["mistral", "markitdown", "local"]}},
+        },
+        headers=admin_headers,
+    )
+    assert update.status_code == 200, update.text
+    body = update.json()
+    assert body["success"] is True
+    assert body["config"]["default_tool"] == "markitdown"
+    assert body["config"]["limits"]["max_scan_count"] == 10000
+    assert body["config"]["formats"]["pdf"]["candidate_chain"] == ["mistral", "markitdown", "local"]
+
+    read_back = client.get("/api/config/markdown-conversion", headers=admin_headers)
+    assert read_back.status_code == 200, read_back.text
+    assert read_back.json()["config"]["default_tool"] == "markitdown"
+    assert markdown_config_path.exists()
+
 
 def test_backend_settings_write_roundtrip_is_native_fastapi(tmp_path: Path, monkeypatch) -> None:
     _patch_available_models(monkeypatch)

--- a/tests/test_markdown_conversion_config.py
+++ b/tests/test_markdown_conversion_config.py
@@ -1,0 +1,139 @@
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_actuarial.markdown_conversion_config import (
+    candidate_chain_for_path,
+    get_markdown_conversion_options,
+    list_conversion_tools,
+    load_markdown_conversion_config,
+    normalize_markdown_conversion_config,
+    write_markdown_conversion_config,
+)
+from ai_actuarial.ai_runtime import resolve_ocr_runtime
+from doc_to_md.registry import pick_auto_engine
+
+
+def test_default_config_uses_auto_and_local_only_auto_chains(monkeypatch, tmp_path):
+    missing = tmp_path / "missing-markdown.yaml"
+    monkeypatch.setenv("MARKDOWN_CONVERSION_CONFIG_PATH", str(missing))
+
+    cfg = load_markdown_conversion_config()
+
+    assert cfg["default_tool"] == "auto"
+    assert candidate_chain_for_path(Path("example.pdf"), cfg) == ["opendataloader", "markitdown", "docling", "local"]
+    assert candidate_chain_for_path(Path("example.png"), cfg) == ["local"]
+    for api_tool in ("mistral", "deepseekocr", "mathpix"):
+        assert cfg["tools"][api_tool]["paid_or_api"] is True
+        assert cfg["tools"][api_tool]["auto_enabled"] is False
+        assert api_tool not in candidate_chain_for_path(Path("example.pdf"), cfg)
+
+
+def test_configured_candidate_order_is_preserved_but_paid_tools_skip_auto_by_default():
+    cfg = normalize_markdown_conversion_config(
+        {
+            "default_tool": "auto",
+            "formats": {"pdf": {"candidate_chain": ["mistral", "markitdown", "mathpix", "local"]}},
+        }
+    )
+
+    assert candidate_chain_for_path(Path("example.pdf"), cfg, auto_only=False) == ["mistral", "markitdown", "mathpix", "local"]
+    assert candidate_chain_for_path(Path("example.pdf"), cfg, auto_only=True) == ["markitdown", "local"]
+
+
+def test_paid_tool_can_join_auto_only_when_explicitly_enabled():
+    cfg = normalize_markdown_conversion_config(
+        {
+            "tools": {"mistral": {"auto_enabled": True}},
+            "formats": {"pdf": {"candidate_chain": ["mistral", "markitdown"]}},
+        }
+    )
+
+    assert candidate_chain_for_path(Path("example.pdf"), cfg) == ["mistral", "markitdown"]
+
+
+def test_conversion_tools_are_returned_in_config_order():
+    cfg = normalize_markdown_conversion_config(
+        {
+            "default_tool": "auto",
+            "formats": {"pdf": {"candidate_chain": ["markitdown", "docling", "local"]}},
+        }
+    )
+
+    names = [tool["name"] for tool in list_conversion_tools(cfg)]
+
+    assert names[:4] == ["auto", "markitdown", "docling", "local"]
+
+
+def test_write_and_read_markdown_conversion_config(monkeypatch, tmp_path):
+    target = tmp_path / "markdown_conversion.yaml"
+    monkeypatch.setenv("MARKDOWN_CONVERSION_CONFIG_PATH", str(target))
+
+    written = write_markdown_conversion_config(
+        {
+            "default_tool": "markitdown",
+            "formats": {"default": {"candidate_chain": ["local"]}},
+        }
+    )
+    loaded = load_markdown_conversion_config()
+    raw_file = yaml.safe_load(target.read_text())
+
+    assert written["default_tool"] == "markitdown"
+    assert loaded["default_tool"] == "markitdown"
+    assert raw_file["default_tool"] == "markitdown"
+    assert get_markdown_conversion_options()["default_tool"] == "markitdown"
+
+
+def test_registry_auto_picker_uses_config_without_paid_api(monkeypatch, tmp_path):
+    target = tmp_path / "markdown_conversion.yaml"
+    target.write_text(
+        yaml.safe_dump(
+            {
+                "formats": {"pdf": {"candidate_chain": ["mistral", "local"]}},
+            }
+        )
+    )
+    monkeypatch.setenv("MARKDOWN_CONVERSION_CONFIG_PATH", str(target))
+
+    assert pick_auto_engine(Path("example.pdf")) == "local"
+
+
+def test_registry_auto_picker_does_not_fallback_when_config_disables_chain(monkeypatch, tmp_path):
+    target = tmp_path / "markdown_conversion.yaml"
+    target.write_text(
+        yaml.safe_dump(
+            {
+                "tools": {"opendataloader": {"enabled": False}},
+                "formats": {"pdf": {"candidate_chain": ["opendataloader"]}},
+            }
+        )
+    )
+    monkeypatch.setenv("MARKDOWN_CONVERSION_CONFIG_PATH", str(target))
+
+    with pytest.raises(RuntimeError, match="No auto conversion candidates"):
+        pick_auto_engine(Path("example.pdf"))
+    assert candidate_chain_for_path(Path("example.pdf")) == []
+
+
+def test_scan_count_limits_are_capped_to_safe_maximum():
+    cfg = normalize_markdown_conversion_config(
+        {
+            "limits": {
+                "default_scan_count": 999999999,
+                "max_scan_count": 999999999,
+            }
+        }
+    )
+
+    assert cfg["limits"]["default_scan_count"] == 10000
+    assert cfg["limits"]["max_scan_count"] == 10000
+
+
+def test_resolve_ocr_runtime_auto_does_not_become_docling(monkeypatch):
+    monkeypatch.delenv("DEFAULT_ENGINE", raising=False)
+
+    runtime = resolve_ocr_runtime(engine_override="auto", yaml_config={"ai_config": {"ocr": {"provider": "local", "model": "docling"}}})
+
+    assert runtime.engine == "auto"


### PR DESCRIPTION
## Summary
- add `config/markdown_conversion.yaml` as the markdown conversion runtime source of truth
- expose read/write admin APIs for markdown conversion config
- make markdown runtime/tool auto-selection follow configured candidate chains and avoid paid/API tools by default
- update Markdown task/FileDetail UI tool options to load order/defaults/limits from config with legacy fallback

## Verification
- `python3 -m pytest tests/test_markdown_conversion_config.py tests/test_doc_to_md_engine_defaults.py tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip -q`
- `npm test`
- `git diff --check origin/main...HEAD && git diff --check`
- independent Hermes spec review: PASS
- independent Hermes code-quality/security review: PASS

## Notes
- local production `docker-compose.override.yml` remains uncommitted and is not part of this PR
- no production deploy/restart performed
