### PR TITLE
feat: add web listening agent rule API

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,34 +1,39 @@
 # Project Status
 
 - Date: 2026-06-16
-- Branch: `codex/p0-2-customer-dashboard`
-- Baseline: `origin/main` at `0f882cf`.
-- Scope: P0-2 Dashboard 客户化 customer-facing homepage.
-- PR: [#148](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/148) — open; CI in progress at creation time.
-- Previous PRs: [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) — merged; [#146](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/146) — merged; [#145](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/145) — merged.
+- Branch: `task/p0-3-web-listening-agent-rule`
+- Baseline: `origin/main` at `014dd30`.
+- Scope: P0-3 web-listening agent rule backend support.
+- PR: not opened in this delegated coder step.
+- Previous PRs: [#148](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/148) — merged; [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) — merged; [#146](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/146) — merged; [#145](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/145) — merged.
 
 ## Current State
 
-- Dashboard now presents customer-facing entry points: browse materials, browse categories, and ask Agent.
-- Dashboard category list loads from `/api/categories?mode=used`; category rows link into Database with the selected category filter.
-- Dashboard weekly additions load from `/api/files?limit=24&order_by=first_seen&order_dir=desc`, filter this calendar week by `first_seen` client-side, and open FileDetail via `buildFileDetailPath`.
-- `/api/files` now supports `order_by=first_seen` so the Dashboard samples newest additions rather than most recently re-seen files.
-- Dashboard no longer renders backend/ops-oriented cataloged file counts, active task counts, task/knowledge/RAG/chunk/embedding statuses, or Tasks/Knowledge quick actions.
-- English and Chinese dashboard i18n strings were updated for customer-facing labels.
-- Added a focused source regression test for the Dashboard customer-facing contract.
-- Local `docker-compose.override.yml` still has an unrelated production override diff and must remain uncommitted for this PR.
+- Added backend-first web-listening rule support for schema version `web-listening-agent-rule.v1`.
+- New rule helpers generate deterministic human-editable YAML drafts from `website_url` + `goal` without fetching the target site, validate YAML/object payloads, and materialize rules into the existing `sites` and `scheduled_tasks` config shapes.
+- Added API endpoints:
+  - `POST /api/web-listening/rules/draft`
+  - `POST /api/web-listening/rules/validate`
+  - `POST /api/web-listening/rules/materialize`
+- Materialization backs up `sites.yaml` with collision-resistant backup names, upserts by site/task name for idempotency, notifies the runtime config bridge, and returns `requires_scheduler_reinit: false`.
+- `task_runtime` now passes `collect_page_content` from YAML site rows into `SiteConfig`.
+- Ops read now exposes advanced site fields needed by web-listening rules: `allow_url_patterns`, `queries`, `file_exts`, and `collect_page_content`.
+- Agentic RAG code was not touched.
+- Local `docker-compose.override.yml` still has an unrelated production override diff and must remain uncommitted.
 
 ## Verification
 
-- `python3 -m pytest tests/test_dashboard_react_source.py tests/test_react_fastapi_authority.py tests/test_fastapi_read_endpoints.py -q` passed (9 tests; 3 pre-existing SWIG/import warnings).
-- `npm test` passed and ran the Vite production build; Vite still emits the existing large chunk warning.
+- `python3 -m pytest tests/test_web_listening_rule.py -q` passed (4 tests; 3 pre-existing SWIG/import warnings).
+- `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py tests/test_web_listening_rule.py -q` passed (29 tests; 3 pre-existing SWIG/import warnings).
+- `python3 -m py_compile ai_actuarial/web_listening_rule.py ai_actuarial/api/services/ops_write.py ai_actuarial/api/routers/ops_write.py ai_actuarial/api/services/ops_read.py ai_actuarial/task_runtime.py` passed.
 - `git diff --check` passed.
-- Independent spec review pass 2: PASS after `first_seen` ordering fix.
-- Independent code-quality/security review pass 2: PASS after `first_seen` ordering fix.
-- Copilot comments addressed: independent Dashboard API loading with `Promise.allSettled`, consistent loading/zero stat counts, and PR status doc updated.
-- Mandatory local Codex review gate attempted with `codex exec review --base origin/main` but blocked by expired/reused Codex auth refresh token (401); Hermes independent reviewers were used for this gate.
+- Broader combined command `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py tests/test_fastapi_ops_read_endpoints.py tests/test_web_listening_rule.py -q` had 34 passed and 1 failed in `test_rate_limit_defaults_are_enforced_from_runtime_features`: expected 400 but got 403 because the operator token was rate-limited during the combined run. The same single test also fails on a clean `origin/main` worktree, so this is pre-existing and not caused by this branch.
+- Independent spec review initially flagged untracked new files and protected `docker-compose.override.yml` as PR packaging blockers; task files must be explicitly added and the production override must stay uncommitted.
+- Independent code-quality/security review flagged backup filename collision on rapid idempotent materialization; fixed by adding microsecond precision and regression assertions for distinct backups.
+- Mandatory local Codex CLI review gate was attempted and blocked by expired/reused Codex auth refresh token (401); Hermes independent spec and code-quality reviewers passed after the backup fix.
 
 ## Notes
 
 - Sibling repositories remain out of scope for this project run.
 - Do not copy secrets, `.env` files, generated credentials, active Docker volumes, logs, or local production overrides into this PR.
+- No push/PR was performed per delegated task instruction.

--- a/ai_actuarial/api/routers/ops_write.py
+++ b/ai_actuarial/api/routers/ops_write.py
@@ -17,6 +17,7 @@ from ..services.ops_write import (
     delete_provider_credential,
     delete_scheduled_task,
     delete_site,
+    draft_web_listening_rule,
     export_sites_yaml,
     get_catalog_stats,
     get_chunk_generation_stats,
@@ -24,6 +25,7 @@ from ..services.ops_write import (
     import_provider_credentials_from_env,
     import_sites,
     list_backups,
+    materialize_web_listening_rule,
     reencrypt_provider_credentials,
     request_task_stop,
     reinitialize_scheduler,
@@ -38,6 +40,7 @@ from ..services.ops_write import (
     update_scheduled_task,
     update_site,
     upsert_provider_credential,
+    validate_web_listening_rule,
 )
 
 router = APIRouter()
@@ -60,6 +63,42 @@ def _config_write_auth_token() -> str:
 
 def _handle_ops_error(exc: OpsWriteError) -> JSONResponse:
     return JSONResponse(status_code=exc.status_code, content={"error": exc.message})
+
+
+@router.post("/web-listening/rules/draft")
+def api_web_listening_rules_draft(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
+):
+    try:
+        return draft_web_listening_rule(payload)
+    except OpsWriteError as exc:
+        return _handle_ops_error(exc)
+
+
+@router.post("/web-listening/rules/validate")
+def api_web_listening_rules_validate(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("sites.write")),
+):
+    try:
+        return validate_web_listening_rule(payload)
+    except OpsWriteError as exc:
+        return _handle_ops_error(exc)
+
+
+@router.post("/web-listening/rules/materialize")
+def api_web_listening_rules_materialize(
+    payload: dict[str, object],
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("sites.write", "schedule.write")),
+):
+    try:
+        return materialize_web_listening_rule(payload, bridge=_bridge(request))
+    except OpsWriteError as exc:
+        return _handle_ops_error(exc)
 
 
 @router.post("/config/sites/add")

--- a/ai_actuarial/api/services/ops_read.py
+++ b/ai_actuarial/api/services/ops_read.py
@@ -116,6 +116,10 @@ def get_config_sites() -> dict[str, object]:
                 "exclude_prefixes": site.get("exclude_prefixes", []),
                 "schedule_interval": site.get("schedule_interval"),
                 "content_selector": site.get("content_selector", ""),
+                "allow_url_patterns": site.get("allow_url_patterns", []),
+                "queries": site.get("queries", []),
+                "file_exts": site.get("file_exts", site_defaults.get("file_exts", [])),
+                "collect_page_content": bool(site.get("collect_page_content", False)),
             }
         )
     global_schedule = site_defaults.get("schedule_interval")

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -47,6 +47,13 @@ from ai_actuarial.rag.defaults import get_embedding_model_defaults
 from ai_actuarial.api.services.import_batches import ImportBatchError, load_import_batch
 from ai_actuarial.security import UnsafeUrlError, ensure_safe_http_url
 from ai_actuarial.storage import Storage
+from ai_actuarial.web_listening_rule import (
+    WebListeningRuleError,
+    generate_draft_rule,
+    materialize_rule,
+    rule_to_yaml,
+    validate_rule,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -302,7 +309,7 @@ def _should_auto_backup() -> bool:
 
 def _backup_config(label: str = "") -> str:
     backups_dir = _ensure_backup_dir()
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     suffix = f"_{label}" if label else ""
     backup_name = f"sites_{ts}{suffix}.yaml"
     backup_path = backups_dir / backup_name
@@ -551,6 +558,99 @@ def _site_url_is_safe(url: str, *, errors: list[str] | None = None, site_name: s
             label = f" for site '{site_name}'" if site_name else ""
             errors.append(f"Unsafe site URL{label}: {exc}")
         return False
+
+
+def draft_web_listening_rule(data: dict[str, Any]) -> dict[str, Any]:
+    payload = _coerce_required_dict(data)
+    try:
+        rule = generate_draft_rule(
+            website_url=str(payload.get("website_url") or ""),
+            goal=str(payload.get("goal") or ""),
+            name=str(payload.get("name") or "").strip() or None,
+        )
+    except WebListeningRuleError as exc:
+        raise OpsWriteError(str(exc)) from exc
+    return {
+        "success": True,
+        "rule": rule.model_dump(mode="json"),
+        "yaml": rule_to_yaml(rule),
+        "warnings": ["Draft generation does not fetch the website; review and edit before materializing."],
+    }
+
+
+def validate_web_listening_rule(data: dict[str, Any]) -> dict[str, Any]:
+    payload = _coerce_required_dict(data)
+    raw_rule = payload.get("rule_yaml") or payload.get("yaml") or payload.get("rule")
+    if raw_rule is None:
+        raise OpsWriteError("rule or rule_yaml is required")
+    rule, errors, warnings = validate_rule(raw_rule, check_url_safety=True)
+    result: dict[str, Any] = {
+        "success": not errors,
+        "valid": not errors,
+        "errors": errors,
+        "warnings": warnings,
+    }
+    if rule is not None:
+        materialized = materialize_rule(rule)
+        result.update(
+            {
+                "rule": rule.model_dump(mode="json"),
+                "yaml": rule_to_yaml(rule),
+                "materialized_config": materialized.model_dump(mode="json"),
+            }
+        )
+    return result
+
+
+def materialize_web_listening_rule(data: dict[str, Any], *, bridge: BridgeState | None = None) -> dict[str, Any]:
+    payload = _coerce_required_dict(data)
+    raw_rule = payload.get("rule_yaml") or payload.get("yaml") or payload.get("rule")
+    if raw_rule is None:
+        raise OpsWriteError("rule or rule_yaml is required")
+    rule, errors, warnings = validate_rule(raw_rule, check_url_safety=True)
+    if errors or rule is None:
+        raise OpsWriteError("; ".join(errors) or "Invalid web listening rule")
+
+    materialized = materialize_rule(rule)
+    config_data = _load_config_data()
+    sites = list(config_data.get("sites") or [])
+    tasks = list(config_data.get("scheduled_tasks") or [])
+
+    site_name = str(materialized.site.get("name") or "")
+    task_name = str(materialized.scheduled_task.get("name") or "")
+    updated_site = False
+    for index, site in enumerate(sites):
+        if str(site.get("name") or "") == site_name:
+            sites[index] = dict(materialized.site)
+            updated_site = True
+            break
+    if not updated_site:
+        sites.append(dict(materialized.site))
+
+    updated_task = False
+    for index, task in enumerate(tasks):
+        if str(task.get("name") or "") == task_name:
+            tasks[index] = dict(materialized.scheduled_task)
+            updated_task = True
+            break
+    if not updated_task:
+        tasks.append(dict(materialized.scheduled_task))
+
+    backup_name = _backup_config("before_web_listening_rule")
+    config_data["sites"] = sites
+    config_data["scheduled_tasks"] = tasks
+    _write_config_data(config_data)
+    _notify_site_config_updated(bridge, config_data)
+    return {
+        "success": True,
+        "rule": rule.model_dump(mode="json"),
+        "yaml": rule_to_yaml(rule),
+        "warnings": warnings,
+        "materialized_config": materialized.model_dump(mode="json"),
+        "backup": backup_name,
+        "updated": {"site": updated_site, "scheduled_task": updated_task},
+        "requires_scheduler_reinit": False,
+    }
 
 
 def export_sites_yaml() -> tuple[str, str]:

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -1163,6 +1163,7 @@ class NativeTaskRuntime:
                 content_selector=str(row.get("content_selector") or "").strip() or None,
                 allow_url_patterns=self._coerce_list(row.get("allow_url_patterns")),
                 queries=list(row.get("queries") or []),
+                collect_page_content=bool(row.get("collect_page_content", False)),
                 check_database=bool(data.get("check_database", True)),
             )
             for row in site_rows

--- a/ai_actuarial/web_listening_rule.py
+++ b/ai_actuarial/web_listening_rule.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+from urllib.parse import urlparse
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+from ai_actuarial.security import UnsafeUrlError, ensure_safe_http_url
+
+SCHEMA_VERSION = "web-listening-agent-rule.v1"
+DEFAULT_FILE_EXTS = [".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"]
+_DEFAULT_EXCLUDE_KEYWORDS = ["newsletter", "news letter", "login", "signin", "register"]
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
+
+
+class WebListeningRuleError(ValueError):
+    pass
+
+
+class AcquisitionProfile(BaseModel):
+    name: str = Field(..., min_length=1)
+    website_url: str = Field(..., min_length=1)
+    goal: str = Field(..., min_length=1)
+    max_pages: int = Field(default=25, ge=1, le=1000)
+    max_depth: int = Field(default=2, ge=0, le=10)
+    delay_seconds: float = Field(default=0.5, ge=0, le=60)
+    file_exts: list[str] = Field(default_factory=lambda: list(DEFAULT_FILE_EXTS))
+    collect_page_content: bool = True
+
+    @field_validator("name", "website_url", "goal")
+    @classmethod
+    def _strip_required_text(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("must be non-empty")
+        return normalized
+
+    @field_validator("file_exts")
+    @classmethod
+    def _normalize_file_exts(cls, value: list[str]) -> list[str]:
+        out: list[str] = []
+        for item in value or []:
+            ext = str(item or "").strip().lower()
+            if not ext:
+                continue
+            if not ext.startswith("."):
+                ext = f".{ext}"
+            if ext not in out:
+                out.append(ext)
+        return out or list(DEFAULT_FILE_EXTS)
+
+
+class MonitorTask(BaseModel):
+    name: str = Field(..., min_length=1)
+    schedule_interval: str = "weekly"
+    enabled: bool = True
+
+    @field_validator("name", "schedule_interval")
+    @classmethod
+    def _strip_required_text(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("must be non-empty")
+        return normalized
+
+
+class SectionSelection(BaseModel):
+    content_selector: str | None = None
+    allow_url_patterns: list[str] = Field(default_factory=list)
+
+    @field_validator("content_selector")
+    @classmethod
+    def _strip_optional_text(cls, value: str | None) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
+
+    @field_validator("allow_url_patterns")
+    @classmethod
+    def _normalize_patterns(cls, value: list[str]) -> list[str]:
+        out: list[str] = []
+        for item in value or []:
+            pattern = str(item or "").strip()
+            if not pattern:
+                continue
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError(f"invalid regex {pattern!r}: {exc}") from exc
+            if pattern not in out:
+                out.append(pattern)
+        return out
+
+
+class MonitorScope(BaseModel):
+    keywords: list[str] = Field(default_factory=list)
+    exclude_keywords: list[str] = Field(default_factory=lambda: list(_DEFAULT_EXCLUDE_KEYWORDS))
+    exclude_prefixes: list[str] = Field(default_factory=list)
+    queries: list[str] = Field(default_factory=list)
+
+    @field_validator("keywords", "exclude_keywords", "exclude_prefixes", "queries")
+    @classmethod
+    def _normalize_string_list(cls, value: list[str]) -> list[str]:
+        out: list[str] = []
+        for item in value or []:
+            normalized = str(item or "").strip()
+            if normalized and normalized not in out:
+                out.append(normalized)
+        return out
+
+
+class WebListeningAgentRuleV1(BaseModel):
+    schema_version: Literal["web-listening-agent-rule.v1"] = SCHEMA_VERSION
+    acquisition_profile: AcquisitionProfile
+    monitor_task: MonitorTask
+    section_selection: SectionSelection = Field(default_factory=SectionSelection)
+    monitor_scope: MonitorScope = Field(default_factory=MonitorScope)
+
+    @model_validator(mode="after")
+    def _validate_url_and_schedule(self) -> "WebListeningAgentRuleV1":
+        url = self.acquisition_profile.website_url
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("acquisition_profile.website_url must be an absolute http(s) URL")
+        if not _is_valid_schedule_interval(self.monitor_task.schedule_interval):
+            raise ValueError("monitor_task.schedule_interval must be daily, weekly, daily at HH:MM, or every N hours/minutes")
+        return self
+
+
+class MaterializedConfig(BaseModel):
+    site: dict[str, Any]
+    scheduled_task: dict[str, Any]
+    acquisition_profile: AcquisitionProfile
+    monitor_task: MonitorTask
+    section_selection: SectionSelection
+    monitor_scope: MonitorScope
+
+
+def rule_from_yaml_or_dict(value: str | dict[str, Any]) -> WebListeningAgentRuleV1:
+    if isinstance(value, str):
+        try:
+            parsed = yaml.safe_load(value) or {}
+        except yaml.YAMLError as exc:
+            raise WebListeningRuleError(f"Invalid YAML: {exc}") from exc
+    elif isinstance(value, dict):
+        parsed = dict(value)
+    else:
+        raise WebListeningRuleError("Rule must be a YAML string or object")
+    try:
+        return WebListeningAgentRuleV1.model_validate(parsed)
+    except ValidationError as exc:
+        raise WebListeningRuleError(_validation_error_text(exc)) from exc
+
+
+def validate_rule(value: str | dict[str, Any], *, check_url_safety: bool = True) -> tuple[WebListeningAgentRuleV1 | None, list[str], list[str]]:
+    warnings: list[str] = []
+    try:
+        rule = rule_from_yaml_or_dict(value)
+    except WebListeningRuleError as exc:
+        return None, [str(exc)], warnings
+    if check_url_safety:
+        try:
+            ensure_safe_http_url(rule.acquisition_profile.website_url)
+        except UnsafeUrlError as exc:
+            return None, [f"Unsafe website URL: {exc}"], warnings
+    if not rule.monitor_scope.keywords:
+        warnings.append("monitor_scope.keywords is empty; crawler will treat all pages as relevant.")
+    if not rule.section_selection.allow_url_patterns:
+        warnings.append("section_selection.allow_url_patterns is empty; crawl scope is domain-wide within max_depth.")
+    return rule, [], warnings
+
+
+def generate_draft_rule(*, website_url: str, goal: str, name: str | None = None) -> WebListeningAgentRuleV1:
+    url = str(website_url or "").strip()
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise WebListeningRuleError("website_url must be an absolute http(s) URL")
+    goal_text = str(goal or "").strip()
+    if not goal_text:
+        raise WebListeningRuleError("goal is required")
+    host = parsed.netloc.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    site_name = str(name or "").strip() or f"Web Listening: {host}"
+    keywords = _keywords_from_goal(goal_text)
+    path_pattern = re.escape(parsed.path.rstrip("/") or "/")
+    allow_patterns = [path_pattern] if parsed.path and parsed.path != "/" else []
+    acquisition = AcquisitionProfile(name=site_name, website_url=url, goal=goal_text)
+    monitor_task = MonitorTask(name=f"{site_name} Monitor", schedule_interval="weekly", enabled=True)
+    section_selection = SectionSelection(content_selector="main", allow_url_patterns=allow_patterns)
+    scope = MonitorScope(
+        keywords=keywords,
+        exclude_keywords=list(_DEFAULT_EXCLUDE_KEYWORDS),
+        exclude_prefixes=[],
+        queries=[f"site:{host} {goal_text} filetype:pdf"],
+    )
+    return WebListeningAgentRuleV1(
+        acquisition_profile=acquisition,
+        monitor_task=monitor_task,
+        section_selection=section_selection,
+        monitor_scope=scope,
+    )
+
+
+def rule_to_yaml(rule: WebListeningAgentRuleV1) -> str:
+    return yaml.safe_dump(rule.model_dump(mode="json"), sort_keys=False, allow_unicode=True)
+
+
+def materialize_rule(rule: WebListeningAgentRuleV1) -> MaterializedConfig:
+    acquisition = rule.acquisition_profile
+    task = rule.monitor_task
+    sections = rule.section_selection
+    scope = rule.monitor_scope
+    site: dict[str, Any] = {
+        "name": acquisition.name,
+        "url": acquisition.website_url,
+        "max_pages": acquisition.max_pages,
+        "max_depth": acquisition.max_depth,
+        "delay_seconds": acquisition.delay_seconds,
+        "file_exts": list(acquisition.file_exts),
+        "collect_page_content": acquisition.collect_page_content,
+        "web_listening_rule_schema_version": rule.schema_version,
+    }
+    if scope.keywords:
+        site["keywords"] = list(scope.keywords)
+    if scope.exclude_keywords:
+        site["exclude_keywords"] = list(scope.exclude_keywords)
+    if scope.exclude_prefixes:
+        site["exclude_prefixes"] = list(scope.exclude_prefixes)
+    if sections.content_selector:
+        site["content_selector"] = sections.content_selector
+    if sections.allow_url_patterns:
+        site["allow_url_patterns"] = list(sections.allow_url_patterns)
+    if scope.queries:
+        site["queries"] = list(scope.queries)
+
+    scheduled_task = {
+        "name": task.name,
+        "type": "scheduled",
+        "interval": task.schedule_interval,
+        "enabled": task.enabled,
+        "params": {
+            "site": acquisition.name,
+            "name": f"Scheduled: {acquisition.name}",
+            "check_database": True,
+        },
+        "web_listening_rule_schema_version": rule.schema_version,
+    }
+    return MaterializedConfig(
+        site=site,
+        scheduled_task=scheduled_task,
+        acquisition_profile=acquisition,
+        monitor_task=task,
+        section_selection=sections,
+        monitor_scope=scope,
+    )
+
+
+def _keywords_from_goal(goal: str) -> list[str]:
+    stop = {"and", "the", "for", "from", "with", "about", "into", "latest", "updates", "update", "monitor", "track", "find"}
+    out: list[str] = []
+    for match in _WORD_RE.finditer(goal.lower()):
+        word = match.group(0).strip("-_")
+        if word and word not in stop and word not in out:
+            out.append(word)
+        if len(out) >= 8:
+            break
+    return out or [goal.strip()]
+
+
+def _is_valid_schedule_interval(interval: str) -> bool:
+    normalized = str(interval or "").strip().lower()
+    if normalized in {"daily", "weekly"}:
+        return True
+    if normalized.startswith("daily at "):
+        parts = normalized.replace("daily at ", "", 1).strip().split(":", 1)
+        if len(parts) != 2:
+            return False
+        try:
+            hour = int(parts[0])
+            minute = int(parts[1])
+        except ValueError:
+            return False
+        return 0 <= hour <= 23 and 0 <= minute <= 59
+    if normalized.startswith("every "):
+        parts = normalized.split()
+        if len(parts) != 3:
+            return False
+        try:
+            qty = int(parts[1])
+        except ValueError:
+            return False
+        return qty > 0 and parts[2] in {"hour", "hours", "minute", "minutes"}
+    return False
+
+
+def _validation_error_text(exc: ValidationError) -> str:
+    parts = []
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error.get("loc", ())) or "rule"
+        parts.append(f"{loc}: {error.get('msg', 'invalid value')}")
+    return "; ".join(parts) or str(exc)

--- a/tests/test_web_listening_rule.py
+++ b/tests/test_web_listening_rule.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+from ai_actuarial.task_runtime import NativeTaskRuntime
+from ai_actuarial.web_listening_rule import generate_draft_rule, materialize_rule, rule_to_yaml, validate_rule
+from tests.test_fastapi_ops_read_endpoints import _build_test_client, _patch_available_models
+from tests.test_fastapi_ops_write_endpoints import _BridgeRecorder, _install_bridge, _install_public_dns_resolver
+
+
+def test_web_listening_rule_draft_validate_and_materialize_helpers(monkeypatch) -> None:
+    _install_public_dns_resolver(monkeypatch, "example.com")
+    rule = generate_draft_rule(website_url="https://example.com/research", goal="Monitor actuarial AI research reports")
+
+    assert rule.schema_version == "web-listening-agent-rule.v1"
+    assert rule.acquisition_profile.name == "Web Listening: example.com"
+    assert rule.section_selection.content_selector == "main"
+    assert rule.section_selection.allow_url_patterns == ["/research"]
+    assert "actuarial" in rule.monitor_scope.keywords
+
+    normalized, errors, warnings = validate_rule(rule_to_yaml(rule))
+    assert errors == []
+    assert normalized is not None
+    assert warnings == []
+
+    materialized = materialize_rule(normalized)
+    assert materialized.site["name"] == "Web Listening: example.com"
+    assert materialized.site["collect_page_content"] is True
+    assert materialized.site["content_selector"] == "main"
+    assert materialized.site["allow_url_patterns"] == ["/research"]
+    assert materialized.scheduled_task["type"] == "scheduled"
+    assert materialized.scheduled_task["params"]["site"] == "Web Listening: example.com"
+
+
+def test_web_listening_rule_validation_reports_errors(monkeypatch) -> None:
+    rule, errors, warnings = validate_rule(
+        {
+            "schema_version": "web-listening-agent-rule.v1",
+            "acquisition_profile": {"name": "Bad", "website_url": "ftp://example.com", "goal": "AI"},
+            "monitor_task": {"name": "Bad Monitor", "schedule_interval": "hourly"},
+        }
+    )
+    assert rule is None
+    assert errors
+    assert warnings == []
+
+
+def test_web_listening_rule_routes_materialize_idempotently(tmp_path: Path, monkeypatch) -> None:
+    _patch_available_models(monkeypatch)
+    _install_public_dns_resolver(monkeypatch, "rules.example")
+    client, app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=False)
+    recorder = _BridgeRecorder()
+    _install_bridge(app, recorder)
+    headers = {"X-Auth-Token": str(seed["operator_token"])}
+    config_path = Path(os.environ["CONFIG_PATH"])
+
+    draft = client.post(
+        "/api/web-listening/rules/draft",
+        json={
+            "website_url": "https://rules.example/insights",
+            "goal": "Monitor reserving and generative AI publications",
+            "name": "Rules Example Insights",
+        },
+        headers=headers,
+    )
+    assert draft.status_code == 200, draft.text
+    draft_body = draft.json()
+    assert draft_body["success"] is True
+    assert "schema_version: web-listening-agent-rule.v1" in draft_body["yaml"]
+
+    rule = draft_body["rule"]
+    rule["acquisition_profile"]["max_pages"] = 12
+    rule["monitor_task"]["schedule_interval"] = "daily at 03:15"
+    rule["section_selection"]["allow_url_patterns"] = ["/insights", "/globalassets/"]
+    rule["monitor_scope"]["exclude_prefixes"] = ["archive_"]
+
+    validation = client.post("/api/web-listening/rules/validate", json={"rule": rule}, headers=headers)
+    assert validation.status_code == 200, validation.text
+    validation_body = validation.json()
+    assert validation_body["valid"] is True
+    assert validation_body["materialized_config"]["site"]["max_pages"] == 12
+
+    first = client.post("/api/web-listening/rules/materialize", json={"rule": rule}, headers=headers)
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+    assert first_body["success"] is True
+    assert first_body["requires_scheduler_reinit"] is False
+    assert first_body["updated"] == {"site": False, "scheduled_task": False}
+    assert recorder.last_site_config is not None
+
+    second = client.post("/api/web-listening/rules/materialize", json={"rule_yaml": first_body["yaml"]}, headers=headers)
+    assert second.status_code == 200, second.text
+    second_body = second.json()
+    assert second_body["updated"] == {"site": True, "scheduled_task": True}
+    assert second_body["backup"] != first_body["backup"]
+    backup_dir = config_path.parent / "backups"
+    assert (backup_dir / first_body["backup"]).exists()
+    assert (backup_dir / second_body["backup"]).exists()
+
+    written = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    matching_sites = [site for site in written["sites"] if site["name"] == "Rules Example Insights"]
+    matching_tasks = [task for task in written["scheduled_tasks"] if task["name"] == "Rules Example Insights Monitor"]
+    assert len(matching_sites) == 1
+    assert len(matching_tasks) == 1
+    site = matching_sites[0]
+    assert site["url"] == "https://rules.example/insights"
+    assert site["collect_page_content"] is True
+    assert site["content_selector"] == "main"
+    assert site["allow_url_patterns"] == ["/insights", "/globalassets/"]
+    assert site["exclude_prefixes"] == ["archive_"]
+    assert site["web_listening_rule_schema_version"] == "web-listening-agent-rule.v1"
+    task = matching_tasks[0]
+    assert task["type"] == "scheduled"
+    assert task["interval"] == "daily at 03:15"
+    assert task["params"]["site"] == "Rules Example Insights"
+
+    read_back = client.get("/api/config/sites", headers=headers)
+    assert read_back.status_code == 200, read_back.text
+    read_site = next(site for site in read_back.json()["sites"] if site["name"] == "Rules Example Insights")
+    assert read_site["collect_page_content"] is True
+    assert read_site["allow_url_patterns"] == ["/insights", "/globalassets/"]
+
+
+def test_task_runtime_passes_collect_page_content_from_yaml() -> None:
+    runtime = NativeTaskRuntime()
+    site_configs = runtime._site_configs_for_run(
+        {
+            "defaults": {"max_pages": 5, "max_depth": 1, "file_exts": [".pdf"]},
+            "sites": [
+                {
+                    "name": "Content Site",
+                    "url": "https://content.example",
+                    "collect_page_content": True,
+                    "content_selector": "article",
+                    "allow_url_patterns": ["/research"],
+                }
+            ],
+        },
+        {"site": "Content Site"},
+    )
+    assert len(site_configs) == 1
+    assert site_configs[0].collect_page_content is True
+    assert site_configs[0].content_selector == "article"
+    assert site_configs[0].allow_url_patterns == ["/research"]


### PR DESCRIPTION
## Summary
- add web-listening-agent-rule.v1 models/helpers for deterministic YAML drafts from website URL + goal
- add draft/validate/materialize API endpoints that materialize rules into sites + scheduled_tasks config
- pass collect_page_content through scheduled runtime and expose advanced site fields in ops read

## Validation
- python3 -m pytest tests/test_web_listening_rule.py tests/test_fastapi_ops_write_endpoints.py -q
- python3 -m py_compile ai_actuarial/web_listening_rule.py ai_actuarial/api/services/ops_write.py ai_actuarial/api/routers/ops_write.py ai_actuarial/api/services/ops_read.py ai_actuarial/task_runtime.py
- git diff --check

## Notes
- Local Codex CLI review gate was attempted but blocked by expired/reused Codex auth refresh token (401); independent Hermes spec/code-quality reviewers passed after fixes.
- Broader ops-read suite has a pre-existing rate-limit assertion failure on clean origin/main: tests/test_fastapi_ops_read_endpoints.py::test_rate_limit_defaults_are_enforced_from_runtime_features returns 403 instead of expected 400.