### PR TITLE
feat: add weekly updates API

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,39 +1,37 @@
 # Project Status
 
 - Date: 2026-06-16
-- Branch: `task/p0-3-web-listening-agent-rule`
-- Baseline: `origin/main` at `014dd30`.
-- Scope: P0-3 web-listening agent rule backend support.
+- Branch: `task/p1-1-weekly-updates`
+- Baseline: `origin/main` at `63a0e54` per delegated task context.
+- Scope: P1-1 Weekly Updates API backend/storage/task-runtime support with focused tests.
 - PR: not opened in this delegated coder step.
 - Previous PRs: [#148](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/148) — merged; [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) — merged; [#146](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/146) — merged; [#145](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/145) — merged.
 
 ## Current State
 
-- Added backend-first web-listening rule support for schema version `web-listening-agent-rule.v1`.
-- New rule helpers generate deterministic human-editable YAML drafts from `website_url` + `goal` without fetching the target site, validate YAML/object payloads, and materialize rules into the existing `sites` and `scheduled_tasks` config shapes.
-- Added API endpoints:
-  - `POST /api/web-listening/rules/draft`
-  - `POST /api/web-listening/rules/validate`
-  - `POST /api/web-listening/rules/materialize`
-- Materialization backs up `sites.yaml` with collision-resistant backup names, upserts by site/task name for idempotency, notifies the runtime config bridge, and returns `requires_scheduler_reinit: false`.
-- `task_runtime` now passes `collect_page_content` from YAML site rows into `SiteConfig`.
-- Ops read now exposes advanced site fields needed by web-listening rules: `allow_url_patterns`, `queries`, `file_exts`, and `collect_page_content`.
+- Added `weekly_update_summaries` SQLite table initialization plus storage helpers to upsert/list/latest weekly summaries.
+- Added first-seen period query for weekly new files using `files.first_seen >= period_start AND files.first_seen < period_end`; `last_seen` is not used for new-file inclusion.
+- Added Weekly Updates read API endpoints protected by `files.read`:
+  - `GET /api/weekly-updates`
+  - `GET /api/weekly-updates/latest`
+- Empty latest response returns HTTP 200 with `{"summary": null}`.
+- Added weekly summary generation service with UTC ISO week default period convention `[Monday 00:00, next Monday 00:00)` and metadata explicitly marking content-change detection as disabled for v1.
+- Added `NativeTaskRuntime` support for collection type `weekly_summary` to generate and persist a summary.
+- Added `weekly_summary` to ops write scheduled-task and collection-run validation allowlists so it can be launched through the existing UI/API task paths.
 - Agentic RAG code was not touched.
 - Local `docker-compose.override.yml` still has an unrelated production override diff and must remain uncommitted.
 
 ## Verification
 
-- `python3 -m pytest tests/test_web_listening_rule.py -q` passed (4 tests; 3 pre-existing SWIG/import warnings).
-- `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py tests/test_web_listening_rule.py -q` passed (29 tests; 3 pre-existing SWIG/import warnings).
-- `python3 -m py_compile ai_actuarial/web_listening_rule.py ai_actuarial/api/services/ops_write.py ai_actuarial/api/routers/ops_write.py ai_actuarial/api/services/ops_read.py ai_actuarial/task_runtime.py` passed.
+- `python3 -m pytest tests/test_weekly_updates.py -q` passed (4 tests; 3 pre-existing SWIG/import warnings).
+- `python3 -m pytest tests/test_fastapi_read_endpoints.py tests/test_weekly_updates.py -q` passed (10 tests; 3 pre-existing SWIG/import warnings).
+- `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py::test_scheduled_tasks_write_and_schedule_reinit_roundtrip -q` passed (1 test; 3 pre-existing SWIG/import warnings) after adding `weekly_summary` validation allowlist coverage.
+- `python3 -m py_compile ai_actuarial/storage.py ai_actuarial/api/services/weekly_updates.py ai_actuarial/api/routers/weekly_updates.py ai_actuarial/api/app.py ai_actuarial/task_runtime.py ai_actuarial/api/services/ops_write.py tests/test_weekly_updates.py tests/test_fastapi_ops_write_endpoints.py` passed.
 - `git diff --check` passed.
-- Broader combined command `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py tests/test_fastapi_ops_read_endpoints.py tests/test_web_listening_rule.py -q` had 34 passed and 1 failed in `test_rate_limit_defaults_are_enforced_from_runtime_features`: expected 400 but got 403 because the operator token was rate-limited during the combined run. The same single test also fails on a clean `origin/main` worktree, so this is pre-existing and not caused by this branch.
-- Independent spec review initially flagged untracked new files and protected `docker-compose.override.yml` as PR packaging blockers; task files must be explicitly added and the production override must stay uncommitted.
-- Independent code-quality/security review flagged backup filename collision on rapid idempotent materialization; fixed by adding microsecond precision and regression assertions for distinct backups.
-- Mandatory local Codex CLI review gate was attempted and blocked by expired/reused Codex auth refresh token (401); Hermes independent spec and code-quality reviewers passed after the backup fix.
 
 ## Notes
 
+- Focused regression coverage confirms a file with recent `last_seen` but old `first_seen` is excluded, while current-period `first_seen` is included.
 - Sibling repositories remain out of scope for this project run.
 - Do not copy secrets, `.env` files, generated credentials, active Docker volumes, logs, or local production overrides into this PR.
-- No push/PR was performed per delegated task instruction.
+- No commit, push, or PR was performed per delegated task instruction.

--- a/ai_actuarial/api/app.py
+++ b/ai_actuarial/api/app.py
@@ -24,6 +24,7 @@ from .routers.migration import router as migration_router
 from .routers.ops_read import router as ops_read_router
 from .routers.ops_write import router as ops_write_router
 from .routers.read import router as read_router
+from .routers.weekly_updates import router as weekly_updates_router
 from .routers.metrics import router as metrics_router
 from ai_actuarial.config import settings
 from ai_actuarial.shared_auth import hash_token
@@ -228,6 +229,7 @@ def create_app() -> FastAPI:
     app.include_router(metrics_router, prefix="/api", tags=["metrics"])
     app.include_router(migration_router, prefix="/api", tags=["migration"])
     app.include_router(read_router, prefix="/api", tags=["read"])
+    app.include_router(weekly_updates_router, prefix="/api", tags=["weekly-updates"])
     app.include_router(auth_router, prefix="/api", tags=["auth"])
     app.include_router(ops_read_router, prefix="/api", tags=["ops-read"])
     app.include_router(ops_write_router, prefix="/api", tags=["ops-write"])

--- a/ai_actuarial/api/routers/weekly_updates.py
+++ b/ai_actuarial/api/routers/weekly_updates.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from ..deps import AuthContext, require_permissions
+from ..services.weekly_updates import (
+    get_latest_weekly_update_summary,
+    list_weekly_update_summaries,
+    parse_weekly_update_list_query,
+)
+from .read import _get_db_path
+
+router = APIRouter()
+
+
+@router.get("/weekly-updates")
+def api_weekly_updates(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("files.read")),
+) -> dict[str, object]:
+    query = parse_weekly_update_list_query(request.query_params)
+    return list_weekly_update_summaries(db_path=_get_db_path(request), **query)
+
+
+@router.get("/weekly-updates/latest")
+def api_weekly_updates_latest(
+    request: Request,
+    _auth: AuthContext = Depends(require_permissions("files.read")),
+) -> dict[str, object]:
+    return get_latest_weekly_update_summary(db_path=_get_db_path(request))

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -65,6 +65,7 @@ _VALID_SCHEDULED_TASK_TYPES = [
     "catalog",
     "markdown_conversion",
     "chunk_generation",
+    "weekly_summary",
     "rag_indexing",
     "kb_index_build",
 ]
@@ -88,6 +89,7 @@ _VALID_COLLECTION_TYPES = {
     "quick_check",
     "markdown_conversion",
     "chunk_generation",
+    "weekly_summary",
     "rag_indexing",
     "kb_index_build",
 }

--- a/ai_actuarial/api/services/weekly_updates.py
+++ b/ai_actuarial/api/services/weekly_updates.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+from ai_actuarial.shared_runtime import parse_int_clamped
+from ai_actuarial.storage import Storage
+
+WEEKLY_UPDATE_FILE_FIELDS: tuple[str, ...] = (
+    "url",
+    "title",
+    "source_site",
+    "source_page_url",
+    "original_filename",
+    "bytes",
+    "content_type",
+    "published_time",
+    "first_seen",
+    "last_seen",
+    "summary",
+    "category",
+    "keywords",
+)
+
+
+def current_utc_iso_week_period(now: datetime | None = None) -> tuple[str, str]:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+    start = (current - timedelta(days=current.weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=7)
+    return start.isoformat(), end.isoformat()
+
+
+def parse_weekly_update_list_query(raw_query: Mapping[str, str | None]) -> dict[str, int]:
+    return {
+        "limit": parse_int_clamped(raw_query.get("limit", 20), default=20, min_value=1, max_value=100),
+        "offset": parse_int_clamped(raw_query.get("offset", 0), default=0, min_value=0, max_value=1_000_000),
+    }
+
+
+def _project_weekly_file(row: dict[str, Any]) -> dict[str, Any]:
+    return {field: row.get(field) for field in WEEKLY_UPDATE_FILE_FIELDS}
+
+
+def _format_summary_markdown(*, period_start: str, period_end: str, files: list[dict[str, Any]]) -> str:
+    lines = [
+        f"# Weekly Updates ({period_start} to {period_end})",
+        "",
+        f"New files: {len(files)}",
+    ]
+    if not files:
+        return "\n".join(lines) + "\n"
+
+    lines.extend(["", "## New Files"])
+    for file_row in files:
+        title = str(file_row.get("title") or file_row.get("original_filename") or file_row.get("url") or "Untitled")
+        url = str(file_row.get("url") or "")
+        source = str(file_row.get("source_site") or "")
+        first_seen = str(file_row.get("first_seen") or "")
+        suffix = f" ({source})" if source else ""
+        lines.append(f"- [{title}]({url}){suffix} — first seen {first_seen}")
+    return "\n".join(lines) + "\n"
+
+
+def generate_weekly_update_summary(
+    *,
+    db_path: str,
+    period_start: str | None = None,
+    period_end: str | None = None,
+    max_files: int = 500,
+) -> dict[str, Any]:
+    if not period_start or not period_end:
+        default_start, default_end = current_utc_iso_week_period()
+        period_start = period_start or default_start
+        period_end = period_end or default_end
+
+    storage = Storage(db_path)
+    try:
+        files = [
+            _project_weekly_file(row)
+            for row in storage.list_files_first_seen_between(
+                period_start=period_start,
+                period_end=period_end,
+                limit=max(1, int(max_files or 500)),
+            )
+        ]
+        summary = {
+            "period_start": period_start,
+            "period_end": period_end,
+            "file_count": len(files),
+            "files": files,
+            "summary_markdown": _format_summary_markdown(
+                period_start=period_start,
+                period_end=period_end,
+                files=files,
+            ),
+            "metadata": {
+                "logic": "files.first_seen >= period_start AND files.first_seen < period_end",
+                "content_change_detection": False,
+            },
+        }
+        stored = storage.upsert_weekly_update_summary(summary)
+    finally:
+        storage.close()
+    return stored
+
+
+def list_weekly_update_summaries(*, db_path: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
+    storage = Storage(db_path)
+    try:
+        summaries, total = storage.list_weekly_update_summaries(limit=limit, offset=offset)
+    finally:
+        storage.close()
+    return {"summaries": summaries, "total": total, "limit": limit, "offset": offset}
+
+
+def get_latest_weekly_update_summary(*, db_path: str) -> dict[str, Any]:
+    storage = Storage(db_path)
+    try:
+        summary = storage.get_latest_weekly_update_summary()
+    finally:
+        storage.close()
+    return {"summary": summary}

--- a/ai_actuarial/storage.py
+++ b/ai_actuarial/storage.py
@@ -48,6 +48,7 @@ class Storage:
             "kb_index_versions",
             "kb_index_items",
             "agentic_ready_manifests",
+            "weekly_update_summaries",
             "rag_knowledge_bases",
             "users",
             "user_quotas",
@@ -504,6 +505,21 @@ class Storage:
         )
         self._conn.execute(
             """
+            CREATE TABLE IF NOT EXISTS weekly_update_summaries (
+                id TEXT PRIMARY KEY,
+                period_start TEXT NOT NULL,
+                period_end TEXT NOT NULL,
+                generated_at TEXT NOT NULL,
+                file_count INTEGER NOT NULL DEFAULT 0,
+                files_json TEXT NOT NULL DEFAULT '[]',
+                summary_markdown TEXT NOT NULL DEFAULT '',
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                UNIQUE(period_start, period_end)
+            )
+            """
+        )
+        self._conn.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_file_chunk_sets_file_url
             ON file_chunk_sets(file_url)
             """
@@ -542,6 +558,12 @@ class Storage:
             """
             CREATE INDEX IF NOT EXISTS idx_agentic_ready_manifests_kb_profile
             ON agentic_ready_manifests(kb_id, profile)
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_weekly_update_summaries_period
+            ON weekly_update_summaries(period_start, period_end)
             """
         )
         self._ensure_columns(
@@ -1627,9 +1649,156 @@ class Storage:
         
         return files, total
     
+    def list_files_first_seen_between(
+        self,
+        *,
+        period_start: str,
+        period_end: str,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Return non-deleted files first discovered in [period_start, period_end)."""
+        safe_limit = max(1, min(int(limit or 500), 5000))
+        cur = self._conn.execute(
+            """
+            SELECT
+                f.url, f.title, f.source_site, f.source_page_url, f.original_filename,
+                f.bytes, f.content_type, f.published_time, f.first_seen, f.last_seen,
+                ci.summary, ci.category, ci.keywords
+            FROM files f
+            LEFT JOIN catalog_items ci ON ci.file_url = f.url
+            WHERE f.deleted_at IS NULL
+              AND f.first_seen IS NOT NULL
+              AND f.first_seen >= ?
+              AND f.first_seen < ?
+            ORDER BY f.first_seen DESC, f.url ASC
+            LIMIT ?
+            """,
+            (period_start, period_end, safe_limit),
+        )
+        rows = cur.fetchall()
+        columns = [desc[0] for desc in cur.description]
+        files = []
+        for row in rows:
+            item = dict(zip(columns, row))
+            raw_keywords = item.get("keywords")
+            if isinstance(raw_keywords, str) and raw_keywords.strip():
+                try:
+                    item["keywords"] = json.loads(raw_keywords)
+                except json.JSONDecodeError:
+                    item["keywords"] = [raw_keywords]
+            elif raw_keywords in (None, ""):
+                item["keywords"] = []
+            files.append(item)
+        return files
+
+    def _decode_weekly_update_summary_row(self, row: sqlite3.Row | tuple[Any, ...] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        keys = [
+            "id",
+            "period_start",
+            "period_end",
+            "generated_at",
+            "file_count",
+            "files_json",
+            "summary_markdown",
+            "metadata_json",
+        ]
+        data = dict(zip(keys, row))
+        for json_field, output_field, default in (
+            ("files_json", "files", []),
+            ("metadata_json", "metadata", {}),
+        ):
+            try:
+                data[output_field] = json.loads(data.pop(json_field) or json.dumps(default))
+            except json.JSONDecodeError:
+                data[output_field] = default
+        return data
+
+    def upsert_weekly_update_summary(self, summary: dict[str, Any]) -> dict[str, Any]:
+        period_start = str(summary.get("period_start") or "").strip()
+        period_end = str(summary.get("period_end") or "").strip()
+        if not period_start or not period_end:
+            raise ValueError("period_start and period_end are required")
+        generated_at = self.now()
+        summary_id = str(summary.get("id") or f"weekly-{period_start}-{period_end}")
+        files = list(summary.get("files") or [])
+        metadata = dict(summary.get("metadata") or {})
+        file_count = int(summary.get("file_count", len(files)) or 0)
+        summary_markdown = str(summary.get("summary_markdown") or "")
+        self._conn.execute(
+            """
+            INSERT INTO weekly_update_summaries (
+                id, period_start, period_end, generated_at, file_count,
+                files_json, summary_markdown, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(period_start, period_end) DO UPDATE SET
+                generated_at=excluded.generated_at,
+                file_count=excluded.file_count,
+                files_json=excluded.files_json,
+                summary_markdown=excluded.summary_markdown,
+                metadata_json=excluded.metadata_json
+            """,
+            (
+                summary_id,
+                period_start,
+                period_end,
+                generated_at,
+                file_count,
+                json.dumps(files, ensure_ascii=False, sort_keys=True),
+                summary_markdown,
+                json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+            ),
+        )
+        self._maybe_commit()
+        return self.get_weekly_update_summary(period_start=period_start, period_end=period_end) or {}
+
+    def get_weekly_update_summary(self, *, period_start: str, period_end: str) -> dict[str, Any] | None:
+        cur = self._conn.execute(
+            """
+            SELECT id, period_start, period_end, generated_at, file_count,
+                   files_json, summary_markdown, metadata_json
+            FROM weekly_update_summaries
+            WHERE period_start = ? AND period_end = ?
+            LIMIT 1
+            """,
+            (period_start, period_end),
+        )
+        return self._decode_weekly_update_summary_row(cur.fetchone())
+
+    def get_latest_weekly_update_summary(self) -> dict[str, Any] | None:
+        cur = self._conn.execute(
+            """
+            SELECT id, period_start, period_end, generated_at, file_count,
+                   files_json, summary_markdown, metadata_json
+            FROM weekly_update_summaries
+            ORDER BY period_start DESC, generated_at DESC
+            LIMIT 1
+            """
+        )
+        return self._decode_weekly_update_summary_row(cur.fetchone())
+
+    def list_weekly_update_summaries(self, *, limit: int = 20, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
+        safe_limit = max(1, min(int(limit or 20), 100))
+        safe_offset = max(0, int(offset or 0))
+        total = int(self._conn.execute("SELECT COUNT(*) FROM weekly_update_summaries").fetchone()[0])
+        cur = self._conn.execute(
+            """
+            SELECT id, period_start, period_end, generated_at, file_count,
+                   files_json, summary_markdown, metadata_json
+            FROM weekly_update_summaries
+            ORDER BY period_start DESC, generated_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            (safe_limit, safe_offset),
+        )
+        summaries = [self._decode_weekly_update_summary_row(row) or {} for row in cur.fetchall()]
+        return summaries, total
+
     def mark_file_deleted(self, url: str, deleted_time: str) -> None:
         """Mark a file and its catalog item as deleted.
-        
+
         Args:
             url: File URL
             deleted_time: ISO timestamp for deletion

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -515,9 +515,36 @@ class NativeTaskRuntime:
             if collection_type == "chunk_generation":
                 return self._run_chunk_generation(task_id, storage, db_path, data)
 
+            if collection_type == "weekly_summary":
+                return self._run_weekly_summary(db_path, data)
+
             raise RuntimeError(f"Native runtime does not yet support collection type '{collection_type}'")
         finally:
             storage.close()
+
+    def _run_weekly_summary(self, db_path: str, data: dict[str, Any]) -> CollectionResult:
+        from ai_actuarial.api.services.weekly_updates import generate_weekly_update_summary
+
+        summary = generate_weekly_update_summary(
+            db_path=db_path,
+            period_start=str(data.get("period_start") or "").strip() or None,
+            period_end=str(data.get("period_end") or "").strip() or None,
+            max_files=int(data.get("max_files") or 500),
+        )
+        file_count = int(summary.get("file_count") or 0)
+        return CollectionResult(
+            success=True,
+            items_found=file_count,
+            items_downloaded=0,
+            items_skipped=0,
+            errors=[],
+            metadata={
+                "period_start": summary.get("period_start"),
+                "period_end": summary.get("period_end"),
+                "summary_id": summary.get("id"),
+                "file_count": file_count,
+            },
+        )
 
     def _enqueue_site_query_search_fallbacks(
         self,

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -503,7 +503,7 @@ def test_scheduled_tasks_write_and_schedule_reinit_roundtrip(tmp_path: Path, mon
     recorder = _BridgeRecorder()
     _install_bridge(app, recorder)
     config_path = Path(os.environ["CONFIG_PATH"])
-    headers = {"X-Auth-Token": seed["operator_token"]}
+    headers = {"X-Auth-Token": str(seed["operator_token"])}
 
     for invalid_interval in ("every 5 hourly", "every 1 hours extra", "every 0 hours"):
         invalid_response = client.post(
@@ -548,6 +548,37 @@ def test_scheduled_tasks_write_and_schedule_reinit_roundtrip(tmp_path: Path, mon
     assert add_response.status_code == 200, add_response.text
     written_task = next(task for task in _read_scheduled_tasks(config_path) if task["name"] == "Weekly Chunk")
     assert written_task["interval"] == "daily at 02:00"
+
+    weekly_summary_response = client.post(
+        "/api/scheduled-tasks/add",
+        json={
+            "name": "Weekly Update Summary",
+            "type": "weekly_summary",
+            "interval": "weekly",
+            "enabled": True,
+            "params": {"max_files": 50},
+        },
+        headers=headers,
+    )
+    assert weekly_summary_response.status_code == 200, weekly_summary_response.text
+    weekly_summary_task = next(
+        task for task in _read_scheduled_tasks(config_path) if task["name"] == "Weekly Update Summary"
+    )
+    assert weekly_summary_task["type"] == "weekly_summary"
+
+    run_weekly_summary = client.post(
+        "/api/collections/run",
+        json={
+            "name": "Run Weekly Summary",
+            "type": "weekly_summary",
+            "period_start": "2026-03-09T00:00:00+00:00",
+            "period_end": "2026-03-16T00:00:00+00:00",
+        },
+        headers=headers,
+    )
+    assert run_weekly_summary.status_code == 200, run_weekly_summary.text
+    assert recorder.started[-1][0] == "weekly_summary"
+    assert recorder.started[-1][1]["period_start"] == "2026-03-09T00:00:00+00:00"
 
     update_response = client.post(
         "/api/scheduled-tasks/update",

--- a/tests/test_weekly_updates.py
+++ b/tests/test_weekly_updates.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from ai_actuarial.api.app import create_app
+from ai_actuarial.api.services.weekly_updates import generate_weekly_update_summary
+from ai_actuarial.storage import Storage
+from ai_actuarial.task_runtime import NativeTaskRuntime
+
+
+PERIOD_START = "2026-03-09T00:00:00+00:00"
+PERIOD_END = "2026-03-16T00:00:00+00:00"
+
+
+def _write_config(tmp_path: Path) -> tuple[Path, Path]:
+    db_path = tmp_path / "index.db"
+    config_path = tmp_path / "sites.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "paths": {
+                    "db": str(db_path),
+                    "download_dir": str(tmp_path / "files"),
+                    "updates_dir": str(tmp_path / "updates"),
+                },
+                "defaults": {"file_exts": [".pdf"]},
+                "sites": [],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return db_path, config_path
+
+
+def _seed_weekly_files(db_path: Path) -> None:
+    storage = Storage(str(db_path))
+    try:
+        storage.insert_file(
+            url="https://old-first-seen.example/old.pdf",
+            sha256="hash-old",
+            title="Old First Seen",
+            source_site="old-first-seen.example",
+            source_page_url="https://old-first-seen.example",
+            original_filename="old.pdf",
+            local_path="/tmp/old.pdf",
+            bytes=100,
+            content_type="application/pdf",
+        )
+        storage.insert_file(
+            url="https://current-first-seen.example/current.pdf",
+            sha256="hash-current",
+            title="Current First Seen",
+            source_site="current-first-seen.example",
+            source_page_url="https://current-first-seen.example",
+            original_filename="current.pdf",
+            local_path="/tmp/current.pdf",
+            bytes=200,
+            content_type="application/pdf",
+        )
+        storage.upsert_catalog_item(
+            item={
+                "url": "https://current-first-seen.example/current.pdf",
+                "sha256": "hash-current",
+                "keywords": ["weekly"],
+                "summary": "Current file summary",
+                "category": "Pricing",
+            },
+            pipeline_version="v1",
+            status="ok",
+        )
+        storage._conn.execute(
+            "UPDATE files SET first_seen = ?, last_seen = ? WHERE url = ?",
+            (
+                "2026-03-01T12:00:00+00:00",
+                "2026-03-10T12:00:00+00:00",
+                "https://old-first-seen.example/old.pdf",
+            ),
+        )
+        storage._conn.execute(
+            "UPDATE files SET first_seen = ?, last_seen = ? WHERE url = ?",
+            (
+                "2026-03-10T08:00:00+00:00",
+                "2026-03-10T08:00:00+00:00",
+                "https://current-first-seen.example/current.pdf",
+            ),
+        )
+        storage._conn.commit()
+    finally:
+        storage.close()
+
+
+def test_weekly_summary_uses_first_seen_not_last_seen(tmp_path: Path) -> None:
+    db_path, _config_path = _write_config(tmp_path)
+    _seed_weekly_files(db_path)
+
+    summary = generate_weekly_update_summary(
+        db_path=str(db_path),
+        period_start=PERIOD_START,
+        period_end=PERIOD_END,
+    )
+
+    assert summary["file_count"] == 1
+    assert [item["url"] for item in summary["files"]] == ["https://current-first-seen.example/current.pdf"]
+    assert summary["files"][0]["summary"] == "Current file summary"
+    assert summary["metadata"]["content_change_detection"] is False
+    assert "files.first_seen" in summary["metadata"]["logic"]
+
+
+def test_weekly_updates_api_lists_summaries_and_empty_latest(tmp_path: Path, monkeypatch) -> None:
+    db_path, config_path = _write_config(tmp_path)
+    _seed_weekly_files(db_path)
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+
+    client = TestClient(create_app())
+
+    empty_latest = client.get("/api/weekly-updates/latest")
+    assert empty_latest.status_code == 200
+    assert empty_latest.json() == {"summary": None}
+
+    generate_weekly_update_summary(
+        db_path=str(db_path),
+        period_start=PERIOD_START,
+        period_end=PERIOD_END,
+    )
+
+    latest = client.get("/api/weekly-updates/latest")
+    assert latest.status_code == 200
+    assert latest.json()["summary"]["file_count"] == 1
+
+    listing = client.get("/api/weekly-updates?limit=10")
+    assert listing.status_code == 200
+    body = listing.json()
+    assert body["total"] == 1
+    assert body["summaries"][0]["period_start"] == PERIOD_START
+
+
+def test_weekly_updates_api_requires_files_read_permission(tmp_path: Path, monkeypatch) -> None:
+    db_path, config_path = _write_config(tmp_path)
+    storage = Storage(str(db_path))
+    try:
+        storage.upsert_auth_token_by_hash(
+            subject="reader",
+            group_name="reader",
+            token_hash=hashlib.sha256(b"reader-token").hexdigest(),
+            is_active=True,
+        )
+    finally:
+        storage.close()
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("REQUIRE_AUTH", "true")
+
+    client = TestClient(create_app())
+    response = client.get("/api/weekly-updates/latest", headers={"Authorization": "Bearer reader-token"})
+    assert response.status_code == 200
+
+
+def test_native_task_runtime_runs_weekly_summary(tmp_path: Path, monkeypatch) -> None:
+    db_path, config_path = _write_config(tmp_path)
+    _seed_weekly_files(db_path)
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    runtime = NativeTaskRuntime()
+    result = runtime._run_collection(
+        "task-weekly-summary",
+        "weekly_summary",
+        {"period_start": PERIOD_START, "period_end": PERIOD_END},
+    )
+
+    assert result.success is True
+    assert result.items_found == 1
+    assert result.metadata["file_count"] == 1
+
+    storage = Storage(str(db_path))
+    try:
+        latest = storage.get_latest_weekly_update_summary()
+    finally:
+        storage.close()
+    assert latest is not None
+    assert latest["files"][0]["url"] == "https://current-first-seen.example/current.pdf"


### PR DESCRIPTION
## Summary
- add weekly update summaries storage table and first_seen-based summary generation
- add GET /api/weekly-updates and /api/weekly-updates/latest
- add weekly_summary task/runtime support plus ops write allowlist coverage

## Verification
- python3 -m pytest tests/test_weekly_updates.py -q
- python3 -m pytest tests/test_fastapi_read_endpoints.py tests/test_weekly_updates.py tests/test_fastapi_ops_write_endpoints.py::test_scheduled_tasks_write_and_schedule_reinit_roundtrip -q
- python3 -m py_compile ai_actuarial/storage.py ai_actuarial/api/services/weekly_updates.py ai_actuarial/api/routers/weekly_updates.py ai_actuarial/api/app.py ai_actuarial/task_runtime.py ai_actuarial/api/services/ops_write.py tests/test_weekly_updates.py tests/test_fastapi_ops_write_endpoints.py
- git diff --check

## Notes
- Uses files.first_seen for weekly inclusion; last_seen is not used for new-file selection.
- v1 does not implement content-change detection.
- Local production docker-compose.override.yml diff is intentionally excluded from this PR.