### PR TITLE
fix: address Copilot follow-up comments

### DIFF
--- a/ai_actuarial/api/services/ops_read.py
+++ b/ai_actuarial/api/services/ops_read.py
@@ -17,6 +17,7 @@ from ai_actuarial.markdown_conversion_config import get_markdown_conversion_opti
 from ai_actuarial.config import settings
 from ai_actuarial.services.token_encryption import TokenEncryption
 from ai_actuarial.shared_runtime import (
+    coerce_bool,
     get_categories_config_path,
     get_sites_config_path,
     load_yaml,
@@ -119,7 +120,7 @@ def get_config_sites() -> dict[str, object]:
                 "allow_url_patterns": site.get("allow_url_patterns", []),
                 "queries": site.get("queries", []),
                 "file_exts": site.get("file_exts", site_defaults.get("file_exts", [])),
-                "collect_page_content": bool(site.get("collect_page_content", False)),
+                "collect_page_content": coerce_bool(site.get("collect_page_content"), default=False),
             }
         )
     global_schedule = site_defaults.get("schedule_interval")

--- a/ai_actuarial/api/services/ops_write.py
+++ b/ai_actuarial/api/services/ops_write.py
@@ -584,7 +584,7 @@ def validate_web_listening_rule(data: dict[str, Any]) -> dict[str, Any]:
     payload = _coerce_required_dict(data)
     raw_rule = payload.get("rule_yaml") or payload.get("yaml") or payload.get("rule")
     if raw_rule is None:
-        raise OpsWriteError("rule or rule_yaml is required")
+        raise OpsWriteError("rule, rule_yaml, or yaml is required")
     rule, errors, warnings = validate_rule(raw_rule, check_url_safety=True)
     result: dict[str, Any] = {
         "success": not errors,
@@ -608,7 +608,7 @@ def materialize_web_listening_rule(data: dict[str, Any], *, bridge: BridgeState 
     payload = _coerce_required_dict(data)
     raw_rule = payload.get("rule_yaml") or payload.get("yaml") or payload.get("rule")
     if raw_rule is None:
-        raise OpsWriteError("rule or rule_yaml is required")
+        raise OpsWriteError("rule, rule_yaml, or yaml is required")
     rule, errors, warnings = validate_rule(raw_rule, check_url_safety=True)
     if errors or rule is None:
         raise OpsWriteError("; ".join(errors) or "Invalid web listening rule")

--- a/ai_actuarial/api/services/weekly_updates.py
+++ b/ai_actuarial/api/services/weekly_updates.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping
 
@@ -68,6 +67,7 @@ def _format_summary_markdown(*, period_start: str, period_end: str, files: list[
 def generate_weekly_update_summary(
     *,
     db_path: str,
+    storage: Storage | None = None,
     period_start: str | None = None,
     period_end: str | None = None,
     max_files: int = 500,
@@ -77,14 +77,14 @@ def generate_weekly_update_summary(
         period_start = period_start or default_start
         period_end = period_end or default_end
 
-    storage = Storage(db_path)
+    active_storage = storage or Storage(db_path)
     try:
         files = [
             _project_weekly_file(row)
-            for row in storage.list_files_first_seen_between(
+            for row in active_storage.list_files_first_seen_between(
                 period_start=period_start,
                 period_end=period_end,
-                limit=max(1, int(max_files or 500)),
+                limit=parse_int_clamped(max_files, default=500, min_value=1, max_value=10_000),
             )
         ]
         summary = {
@@ -102,9 +102,10 @@ def generate_weekly_update_summary(
                 "content_change_detection": False,
             },
         }
-        stored = storage.upsert_weekly_update_summary(summary)
+        stored = active_storage.upsert_weekly_update_summary(summary)
     finally:
-        storage.close()
+        if storage is None:
+            active_storage.close()
     return stored
 
 

--- a/ai_actuarial/shared_runtime.py
+++ b/ai_actuarial/shared_runtime.py
@@ -24,7 +24,7 @@ def _env_flag_override(*names: str) -> bool | None:
     return None
 
 
-def _coerce_bool(value: object, default: bool = False) -> bool:
+def coerce_bool(value: object, default: bool = False) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -36,6 +36,10 @@ def _coerce_bool(value: object, default: bool = False) -> bool:
     if value is None:
         return default
     return bool(value)
+
+
+def _coerce_bool(value: object, default: bool = False) -> bool:
+    return coerce_bool(value, default)
 
 
 def _feature_bool(

--- a/ai_actuarial/task_runtime.py
+++ b/ai_actuarial/task_runtime.py
@@ -27,7 +27,7 @@ from ai_actuarial.crawler import Crawler, SiteConfig
 from ai_actuarial.rag.indexing import IndexingPipeline
 from ai_actuarial.rag.knowledge_base import KnowledgeBaseManager
 from ai_actuarial.search import search_all
-from ai_actuarial.shared_runtime import append_task_log, get_sites_config_path, load_yaml, task_log_path
+from ai_actuarial.shared_runtime import append_task_log, coerce_bool, get_sites_config_path, load_yaml, parse_int_clamped, task_log_path
 from ai_actuarial.storage import Storage
 
 logger = logging.getLogger(__name__)
@@ -516,20 +516,21 @@ class NativeTaskRuntime:
                 return self._run_chunk_generation(task_id, storage, db_path, data)
 
             if collection_type == "weekly_summary":
-                return self._run_weekly_summary(db_path, data)
+                return self._run_weekly_summary(db_path, data, storage=storage)
 
             raise RuntimeError(f"Native runtime does not yet support collection type '{collection_type}'")
         finally:
             storage.close()
 
-    def _run_weekly_summary(self, db_path: str, data: dict[str, Any]) -> CollectionResult:
+    def _run_weekly_summary(self, db_path: str, data: dict[str, Any], *, storage: Storage | None = None) -> CollectionResult:
         from ai_actuarial.api.services.weekly_updates import generate_weekly_update_summary
 
         summary = generate_weekly_update_summary(
             db_path=db_path,
+            storage=storage,
             period_start=str(data.get("period_start") or "").strip() or None,
             period_end=str(data.get("period_end") or "").strip() or None,
-            max_files=int(data.get("max_files") or 500),
+            max_files=parse_int_clamped(data.get("max_files"), default=500, min_value=1, max_value=10_000),
         )
         file_count = int(summary.get("file_count") or 0)
         return CollectionResult(
@@ -1190,7 +1191,7 @@ class NativeTaskRuntime:
                 content_selector=str(row.get("content_selector") or "").strip() or None,
                 allow_url_patterns=self._coerce_list(row.get("allow_url_patterns")),
                 queries=list(row.get("queries") or []),
-                collect_page_content=bool(row.get("collect_page_content", False)),
+                collect_page_content=coerce_bool(row.get("collect_page_content"), default=False),
                 check_database=bool(data.get("check_database", True)),
             )
             for row in site_rows

--- a/client/src/pages/tasks/MarkdownForm.tsx
+++ b/client/src/pages/tasks/MarkdownForm.tsx
@@ -102,6 +102,11 @@ export function MarkdownForm({ onSubmit, submitting }: { onSubmit: (d: Record<st
             value={scanCount}
             onChange={(value) => {
               setScanCountTouched(true);
+              const parsed = parseInt(value, 10);
+              if (!Number.isNaN(parsed) && parsed < 1) {
+                setScanCount("1");
+                return;
+              }
               setScanCount(value);
             }}
             placeholder={String(markdownConversionLimits.defaultScanCount)}

--- a/tests/test_fastapi_ops_read_endpoints.py
+++ b/tests/test_fastapi_ops_read_endpoints.py
@@ -98,6 +98,7 @@ def _write_config_files(base_dir: Path) -> tuple[Path, Path, Path]:
                 "exclude_prefixes": ["/skip"],
                 "schedule_interval": "weekly",
                 "content_selector": "main article",
+                "collect_page_content": "false",
             }
         ],
         "scheduled_tasks": [
@@ -390,6 +391,7 @@ def test_fastapi_ops_read_routes_are_native_and_return_expected_shapes(tmp_path:
         body = fast.json()
         if endpoint == "/api/config/sites":
             assert body["sites"][0]["name"] == "Alpha Site"
+            assert body["sites"][0]["collect_page_content"] is False
         elif endpoint == "/api/schedule/status":
             assert body["count"] == 1
             assert body["jobs"][0]["label"].startswith("daily")

--- a/tests/test_markdown_conversion_config.py
+++ b/tests/test_markdown_conversion_config.py
@@ -12,7 +12,7 @@ from ai_actuarial.markdown_conversion_config import (
     normalize_markdown_conversion_config,
     write_markdown_conversion_config,
 )
-from ai_actuarial.ai_runtime import resolve_ocr_runtime
+from ai_actuarial.ai_runtime import OCRRuntime, apply_ocr_runtime_environment, resolve_ocr_runtime
 from doc_to_md.registry import pick_auto_engine
 
 
@@ -137,3 +137,36 @@ def test_resolve_ocr_runtime_auto_does_not_become_docling(monkeypatch):
     runtime = resolve_ocr_runtime(engine_override="auto", yaml_config={"ai_config": {"ocr": {"provider": "local", "model": "docling"}}})
 
     assert runtime.engine == "auto"
+
+
+def test_apply_ocr_runtime_environment_reuses_markdown_config_cache(monkeypatch, tmp_path):
+    target = tmp_path / "markdown_conversion.yaml"
+    target.write_text(yaml.safe_dump({"tools": {"markitdown": {"tuning": {"max_pages": 3}}}}), encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_CONVERSION_CONFIG_PATH", str(target))
+
+    import ai_actuarial.ai_runtime as ai_runtime
+    import ai_actuarial.markdown_conversion_config as markdown_config
+
+    ai_runtime._MARKDOWN_CONVERSION_TUNING_CACHE.clear()
+    calls = []
+    real_loader = markdown_config.load_markdown_conversion_config
+
+    def counting_loader(path=None):
+        calls.append(path)
+        return real_loader(path)
+
+    monkeypatch.setattr(markdown_config, "load_markdown_conversion_config", counting_loader)
+    runtime = OCRRuntime(
+        engine="markitdown",
+        provider="local",
+        model="markitdown",
+        api_key=None,
+        base_url=None,
+        credential_source="test",
+        raw_config={},
+    )
+
+    apply_ocr_runtime_environment(runtime)
+    apply_ocr_runtime_environment(runtime)
+
+    assert len(calls) == 1

--- a/tests/test_web_listening_rule.py
+++ b/tests/test_web_listening_rule.py
@@ -133,7 +133,7 @@ def test_task_runtime_passes_collect_page_content_from_yaml() -> None:
                 {
                     "name": "Content Site",
                     "url": "https://content.example",
-                    "collect_page_content": True,
+                    "collect_page_content": "false",
                     "content_selector": "article",
                     "allow_url_patterns": ["/research"],
                 }
@@ -142,6 +142,6 @@ def test_task_runtime_passes_collect_page_content_from_yaml() -> None:
         {"site": "Content Site"},
     )
     assert len(site_configs) == 1
-    assert site_configs[0].collect_page_content is True
+    assert site_configs[0].collect_page_content is False
     assert site_configs[0].content_selector == "article"
     assert site_configs[0].allow_url_patterns == ["/research"]

--- a/tests/test_weekly_updates.py
+++ b/tests/test_weekly_updates.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 
 import yaml
@@ -140,24 +139,15 @@ def test_weekly_updates_api_lists_summaries_and_empty_latest(tmp_path: Path, mon
     assert body["summaries"][0]["period_start"] == PERIOD_START
 
 
-def test_weekly_updates_api_requires_files_read_permission(tmp_path: Path, monkeypatch) -> None:
-    db_path, config_path = _write_config(tmp_path)
-    storage = Storage(str(db_path))
-    try:
-        storage.upsert_auth_token_by_hash(
-            subject="reader",
-            group_name="reader",
-            token_hash=hashlib.sha256(b"reader-token").hexdigest(),
-            is_active=True,
-        )
-    finally:
-        storage.close()
+def test_weekly_updates_api_is_public_readable_when_auth_required(tmp_path: Path, monkeypatch) -> None:
+    _db_path, config_path = _write_config(tmp_path)
     monkeypatch.setenv("CONFIG_PATH", str(config_path))
     monkeypatch.setenv("REQUIRE_AUTH", "true")
 
     client = TestClient(create_app())
-    response = client.get("/api/weekly-updates/latest", headers={"Authorization": "Bearer reader-token"})
+    response = client.get("/api/weekly-updates/latest")
     assert response.status_code == 200
+    assert response.json() == {"summary": None}
 
 
 def test_native_task_runtime_runs_weekly_summary(tmp_path: Path, monkeypatch) -> None:
@@ -183,3 +173,36 @@ def test_native_task_runtime_runs_weekly_summary(tmp_path: Path, monkeypatch) ->
         storage.close()
     assert latest is not None
     assert latest["files"][0]["url"] == "https://current-first-seen.example/current.pdf"
+
+
+def test_native_task_runtime_weekly_summary_clamps_invalid_max_files(tmp_path: Path, monkeypatch) -> None:
+    db_path, config_path = _write_config(tmp_path)
+    _seed_weekly_files(db_path)
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+
+    runtime = NativeTaskRuntime()
+    result = runtime._run_collection(
+        "task-weekly-summary-invalid-max",
+        "weekly_summary",
+        {"period_start": PERIOD_START, "period_end": PERIOD_END, "max_files": "not-a-number"},
+    )
+
+    assert result.success is True
+    assert result.items_found == 1
+
+
+def test_generate_weekly_summary_can_reuse_existing_storage(tmp_path: Path) -> None:
+    db_path, _config_path = _write_config(tmp_path)
+    _seed_weekly_files(db_path)
+    storage = Storage(str(db_path))
+    try:
+        summary = generate_weekly_update_summary(
+            db_path=str(db_path),
+            storage=storage,
+            period_start=PERIOD_START,
+            period_end=PERIOD_END,
+        )
+        assert summary["file_count"] == 1
+        assert storage.get_latest_weekly_update_summary() is not None
+    finally:
+        storage.close()


### PR DESCRIPTION
## Summary
- Fix weekly updates follow-up comments from PR #150: safe max_files parsing, Storage reuse, public-read test semantics, unused import cleanup.
- Fix web listening rule follow-up comments from PR #149: explicit string boolean parsing and clearer yaml alias errors.
- Fix markdown conversion follow-up from PR #147: cache reuse coverage and scan count UI clamp.

## Verification
- python3 -m pytest tests/test_weekly_updates.py tests/test_web_listening_rule.py tests/test_fastapi_ops_read_endpoints.py::test_fastapi_ops_read_routes_are_native_and_return_expected_shapes tests/test_markdown_conversion_config.py -q
- python3 -m py_compile ai_actuarial/shared_runtime.py ai_actuarial/task_runtime.py ai_actuarial/api/services/weekly_updates.py ai_actuarial/api/services/ops_read.py ai_actuarial/api/services/ops_write.py tests/test_weekly_updates.py tests/test_web_listening_rule.py tests/test_fastapi_ops_read_endpoints.py tests/test_markdown_conversion_config.py
- npm run build
- git diff --check

## Notes
- Local production docker-compose.override.yml remains uncommitted and excluded from this PR.
- Follow-up PR before continuing new roadmap PRs, per Boss request.