### PR TITLE
fix: address chat KB-first review comments

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -4,7 +4,7 @@
 - Branch: `fix/pr152-copilot-followups`
 - Baseline: current branch created from `origin/main` after merged PR #152.
 - Scope: Follow-up fixes for post-merge Copilot comments on PR #152.
-- PR: follow-up PR not opened yet; addresses comments from merged [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152).
+- PR: [#153](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/153) — open; addresses comments from merged [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152).
 - Previous PRs: [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) through [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152) — merged.
 
 ## Current State

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,38 +1,29 @@
 # Project Status
 
 - Date: 2026-06-16
-- Branch: `task/p1-2-chat-kb-first`
-- Baseline: current branch created from `origin/main` per delegated task context.
-- Scope: P1-2 Chat KB-first UI plus Chat API/types/session extraction.
-- PR: [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152) — open; Copilot follow-up comments are being addressed in this branch.
-- Previous PRs: [#151](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/151) — merged; no new post-#151 comments per task context.
+- Branch: `fix/pr152-copilot-followups`
+- Baseline: current branch created from `origin/main` after merged PR #152.
+- Scope: Follow-up fixes for post-merge Copilot comments on PR #152.
+- PR: follow-up PR not opened yet; addresses comments from merged [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152).
+- Previous PRs: [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) through [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152) — merged.
 
 ## Current State
 
-- Refactored `client/src/pages/Chat.tsx` so Chat contracts live in `client/src/pages/chat/types.ts`.
-- Extracted Chat API endpoint calls into `client/src/pages/chat/api.ts`; API routes/contracts remain unchanged:
-  - `/api/chat/conversations`
-  - `/api/chat/knowledge-bases`
-  - `/api/chat/available-documents`
-  - `/api/chat/query`
-  - `/api/files/{file_url}/markdown`
-- Extracted conversation/session state and conversation load/create/delete helpers into `client/src/pages/chat/useChatSession.ts`.
-- Updated the Chat left sidebar to be KB-first:
-  - Knowledge base selection is now the primary left-sidebar entry with selectable KB rows and status/count labels.
-  - Conversation history remains available below the KB section.
-  - Documents are de-emphasized behind a smaller sidebar toggle rather than a first-class equal tab.
-- Kept Agentic RAG backend untouched.
+- PR #152 is merged, completing the P1-2 Chat KB-first/API/types/session work.
+- This branch is limited to follow-up fixes for valid Copilot comments discovered after #152 merged:
+  - The Documents panel toggle is disabled and guarded when conversation history is unavailable, so it cannot flip internal state to `conversations` for users without conversation permission.
+  - Chat knowledge-base availability labels now use existing i18n keys in both KB renderers instead of hard-coded Chinese strings.
+  - Source-level tests cover the guarded toggle and i18n KB status labels.
 - Local `docker-compose.override.yml` still has an unrelated production override diff and must remain uncommitted.
 
 ## Verification
 
-- `python3 -m pytest tests/test_chat_react_source.py tests/test_fastapi_chat_endpoints.py tests/test_fastapi_agentic_rag_endpoints.py -q` passed (54 tests; 3 pre-existing SWIG/import warnings).
+- `python3 -m pytest tests/test_chat_react_source.py -q` passed (14 tests; coverage no-data warning from source-level tests).
+- `python3 -m pytest tests/test_chat_react_source.py tests/test_fastapi_chat_endpoints.py tests/test_fastapi_agentic_rag_endpoints.py -q` passed (56 tests; 3 pre-existing SWIG/import warnings).
 - `npm run build` passed; Vite emitted the pre-existing large-chunk warning for the main bundle.
 - `git diff --check` passed.
-- `npx tsc --noEmit` was attempted and failed on pre-existing unrelated TypeScript errors in `client/src/pages/Settings.tsx`, `client/src/pages/tasks/ScheduleFromTaskButton.tsx`, and `client/src/pages/tasks/ScheduledTasksSection.tsx`; no Chat-specific TypeScript errors were reported before those existing errors stopped the command.
 
 ## Notes
 
 - Sibling repositories remain out of scope for this project run.
 - Do not copy secrets, `.env` files, generated credentials, active Docker volumes, logs, or local production overrides into this PR.
-- No commit, push, or PR was performed per delegated task instruction.

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -243,6 +243,20 @@ function getKbResultCountLabel(kb: KnowledgeBase, ragMode: RagMode, t: Translate
   return "";
 }
 
+function getKbAvailabilityLabel(kb: KnowledgeBase, ragMode: RagMode, t: Translate): string {
+  const isAgenticReady = isAgenticKbReady(kb);
+  const agenticStatus = String(kb.agentic_ready_manifest?.status || "missing").trim() || "missing";
+  if (ragMode === "agentic") {
+    return isAgenticReady
+      ? t("chat.agentic_status_ready")
+      : t("chat.agentic_status").replace("{status}", agenticStatus);
+  }
+  if (kb.availability === "needs_reindex") return t("chat.kb_status.needs_reindex");
+  if (kb.availability === "building") return t("chat.kb_status.building");
+  if (kb.availability === "ready") return t("chat.kb_status.ready");
+  return kb.availability || "";
+}
+
 function normalizeAgenticToolTrace(value: unknown): AgenticToolTraceEntry[] {
   if (Array.isArray(value)) {
     return value.filter((item): item is AgenticToolTraceEntry => Boolean(item && typeof item === "object"));
@@ -873,12 +887,17 @@ export default function Chat() {
                 </span>
                 <button
                   type="button"
-                  onClick={() => setSidebarTab(sidebarTab === "documents" && canUseConversations ? "conversations" : "documents")}
+                  onClick={() => {
+                    if (!canUseConversations) return;
+                    setSidebarTab((current) => current === "documents" ? "conversations" : "documents");
+                  }}
+                  disabled={!canUseConversations}
                   className={cn(
                     "inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors",
                     sidebarTab === "documents"
                       ? "bg-card text-foreground shadow-sm"
-                      : "text-muted-foreground hover:bg-card hover:text-foreground"
+                      : "text-muted-foreground hover:bg-card hover:text-foreground",
+                    !canUseConversations && "cursor-not-allowed opacity-60"
                   )}
                   data-testid="button-toggle-documents-panel"
                 >
@@ -911,19 +930,8 @@ export default function Chat() {
                     const isUsable = kb.usable !== false;
                     const isAgenticReady = isAgenticKbReady(kb);
                     const isSelectable = ragMode === "agentic" ? isAgenticReady : isUsable;
-                    const agenticStatus = String(kb.agentic_ready_manifest?.status || "missing").trim() || "missing";
                     const resultCountLabel = getKbResultCountLabel(kb, ragMode, t);
-                    const availabilityLabel = ragMode === "agentic"
-                      ? (isAgenticReady
-                        ? t("chat.agentic_status_ready")
-                        : t("chat.agentic_status").replace("{status}", agenticStatus))
-                      : kb.availability === "needs_reindex"
-                        ? t("chat.kb_status.needs_reindex")
-                        : kb.availability === "building"
-                          ? t("chat.kb_status.building")
-                          : kb.availability === "ready"
-                            ? t("chat.kb_status.ready")
-                            : kb.availability || "";
+                    const availabilityLabel = getKbAvailabilityLabel(kb, ragMode, t);
                     return (
                       <button
                         key={kb.kb_id}
@@ -1378,19 +1386,8 @@ export default function Chat() {
                         const isUsable = kb.usable !== false;
                         const isAgenticReady = isAgenticKbReady(kb);
                         const isSelectable = ragMode === "agentic" ? isAgenticReady : isUsable;
-                        const agenticStatus = String(kb.agentic_ready_manifest?.status || "missing").trim() || "missing";
                         const resultCountLabel = getKbResultCountLabel(kb, ragMode, t);
-                        const availabilityLabel = ragMode === "agentic"
-                          ? (isAgenticReady
-                            ? t("chat.agentic_status_ready")
-                            : t("chat.agentic_status").replace("{status}", agenticStatus))
-                          : kb.availability === "needs_reindex"
-                          ? "需重建"
-                          : kb.availability === "building"
-                            ? "构建中"
-                            : kb.availability === "ready"
-                              ? "可用"
-                              : kb.availability || "";
+                        const availabilityLabel = getKbAvailabilityLabel(kb, ragMode, t);
                         return (
                         <button
                           key={kb.kb_id}

--- a/tests/test_chat_react_source.py
+++ b/tests/test_chat_react_source.py
@@ -49,6 +49,9 @@ def test_chat_sidebar_is_kb_first_and_documents_deemphasized():
     assert 'data-testid="kb-first-sidebar"' in src
     assert 'data-testid={`kb-sidebar-option-${kb.kb_id}`}' in src
     assert 'data-testid="button-toggle-documents-panel"' in src
+    assert "disabled={!canUseConversations}" in src
+    assert "if (!canUseConversations) return;" in src
+    assert 'setSidebarTab((current) => current === "documents" ? "conversations" : "documents")' in src
     assert 'data-testid="tab-documents"' not in src
     assert 'data-testid="tab-conversations"' not in src
 
@@ -194,6 +197,16 @@ def test_chat_agentic_kb_dropdown_labels_ready_data_sections_not_standard_chunks
     assert '"chat.chunks_label"' in src
     assert "ragMode === \"agentic\"" in src
     assert "const resultCountLabel = getKbResultCountLabel(kb, ragMode, t)" in src
+    assert "const availabilityLabel = getKbAvailabilityLabel(kb, ragMode, t)" in src
+    assert 't("chat.kb_status.needs_reindex")' in src
+    assert 't("chat.kb_status.building")' in src
+    assert 't("chat.kb_status.ready")' in src
+    assert '"需重建"' not in CHAT_TSX.read_text(encoding="utf-8")
+    assert '"构建中"' not in CHAT_TSX.read_text(encoding="utf-8")
+    assert '"可用"' not in CHAT_TSX.read_text(encoding="utf-8")
+    assert '"chat.kb_status.needs_reindex": "Needs reindex"' in i18n_src
+    assert '"chat.kb_status.building": "Building"' in i18n_src
+    assert '"chat.kb_status.ready": "Ready"' in i18n_src
     assert "{resultCountLabel}" in src
     assert "{kb.chunk_count} chunks" not in src
     assert '"chat.sections_label": "{count} sections"' in i18n_src


### PR DESCRIPTION
## Summary
- guard and disable the Chat Documents panel toggle when conversation history is unavailable
- route KB availability labels through existing i18n keys in both KB selectors
- refresh project status and add source-level coverage for the PR #152 follow-up fixes

## Verification
- python3 -m pytest tests/test_chat_react_source.py -q
- python3 -m pytest tests/test_chat_react_source.py tests/test_fastapi_chat_endpoints.py tests/test_fastapi_agentic_rag_endpoints.py -q
- npm run build
- git diff --check

Follow-up for merged PR #152 Copilot comments.