### PR TITLE
docs: mark managed roadmap backlog complete

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,29 +1,37 @@
 # Project Status
 
-- Date: 2026-06-16
-- Branch: `fix/pr152-copilot-followups`
-- Baseline: current branch created from `origin/main` after merged PR #152.
-- Scope: Follow-up fixes for post-merge Copilot comments on PR #152.
-- PR: [#153](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/153) — open; addresses comments from merged [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152).
-- Previous PRs: [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) through [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152) — merged.
+- Date: 2026-06-17
+- Branch: `task/final-roadmap-status`
+- Baseline: `origin/main` at merged PR #153.
+- Scope: Final status refresh for the AI Actuarial Feishu-plan managed PR backlog.
+- Completed roadmap PRs:
+  - [#147](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/147) — P0-1 Markdown conversion config split and admin/UI/runtime integration.
+  - [#148](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/148) — P0-2 customer-facing dashboard homepage.
+  - [#149](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/149) — P0-3 web-listening-agent-rule schema/API/materialization.
+  - [#150](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/150) — P1-1 weekly updates API/storage/task runtime.
+  - [#151](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/151) — follow-up fixes for valid Copilot comments on #147/#149/#150.
+  - [#152](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/152) — P1-2 Chat KB-first UI plus Chat API/types/session extraction.
+  - [#153](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/153) — follow-up fixes for valid Copilot comments on #152.
+- Previous Agentic RAG PRs: #133-#145 plus [#146](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/146) are complete; Agentic RAG is out of scope for new implementation work.
 
 ## Current State
 
-- PR #152 is merged, completing the P1-2 Chat KB-first/API/types/session work.
-- This branch is limited to follow-up fixes for valid Copilot comments discovered after #152 merged:
-  - The Documents panel toggle is disabled and guarded when conversation history is unavailable, so it cannot flip internal state to `conversations` for users without conversation permission.
-  - Chat knowledge-base availability labels now use existing i18n keys in both KB renderers instead of hard-coded Chinese strings.
-  - Source-level tests cover the guarded toggle and i18n KB status labels.
+- The remaining Feishu-plan backlog named in the managed controller prompt is complete and merged into `main`.
+- `gh pr list --state open` returned no open PRs for `ferryhe/AI_actuarial_inforsearch` at the start of this run.
+- Recent merged PR review-comment state was checked for #147-#153:
+  - Valid comments on #147/#149/#150 were addressed by #151.
+  - Valid comments on #152 were addressed by #153.
+  - #151 and #153 generated no new Copilot inline comments.
 - Local `docker-compose.override.yml` still has an unrelated production override diff and must remain uncommitted.
 
 ## Verification
 
-- `python3 -m pytest tests/test_chat_react_source.py -q` passed (14 tests; coverage no-data warning from source-level tests).
-- `python3 -m pytest tests/test_chat_react_source.py tests/test_fastapi_chat_endpoints.py tests/test_fastapi_agentic_rag_endpoints.py -q` passed (56 tests; 3 pre-existing SWIG/import warnings).
-- `npm run build` passed; Vite emitted the pre-existing large-chunk warning for the main bundle.
-- `git diff --check` passed.
+- `git status --short --branch` checked before work; only the expected local production override was dirty on `main`.
+- GitHub open PR state checked with `gh pr list --state open`.
+- Recent PR states/checks/comments checked with `gh pr view` and GitHub PR comments API for #147-#153.
+- This status-only change does not alter application runtime code.
 
 ## Notes
 
 - Sibling repositories remain out of scope for this project run.
-- Do not copy secrets, `.env` files, generated credentials, active Docker volumes, logs, or local production overrides into this PR.
+- Do not copy secrets, `.env` files, generated credentials, active Docker volumes, logs, or local production overrides into PRs.


### PR DESCRIPTION
## Summary
- refresh project status after managed Feishu-plan PRs #147-#153 were merged
- record that Copilot follow-up PRs #151 and #153 closed the valid review comments
- keep the local production docker-compose.override.yml diff explicitly out of scope

## Verification
- git diff --check
- GitHub open PR/recent review-comment state checked for #147-#153

Status-only change; no runtime code modified.