### PR TITLE
PR-E: Admin UI wrap-up for Markdown and Web Listening

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,32 +1,34 @@
 # Project Status
 
 - Date: 2026-06-17
-- Branch: `task/product-ux-followups`
-- PR: [#156](https://github.com/ferryhe/AI_actuarial_inforsearch/pull/156)
-- Scope: PR gate follow-up for product UX changes.
+- Branch: `feature/pr-e-admin-ui-wrapup`
+- Scope: PR-E Admin UI wrap-up for Markdown configuration and Web Listening management entry.
 
 ## Current State
 
-- PR #156 is open and mergeable.
-- GitHub CI check `python-smoke` was passing before follow-up fixes.
-- Copilot left four valid review comments; this run applied safe fixes on the same PR branch:
-  - imported `FileText` in Settings for the Markdown Conversion tab;
-  - removed duplicate `scheduled-tasks:changed` dispatch from the parent Tasks callback;
-  - guarded browser-only event dispatch in `WebListeningForm`;
-  - kept agentic `synthesis_source` within the documented `llm` / `deterministic_fallback` contract for no-result responses.
+- PR-A / #156: merged earlier (product UX baseline).
+- PR-B / #157: merged earlier (security and test baseline).
+- PR-C / #158: merged earlier (categories browsing page).
+- PR-D / #159: merged on 2026-06-17 at merge commit `056ab425e222190546145015563e6e511cd80322`; branch `feature/pr-d-chat-demo-kb` was deleted on origin and no local branch remains.
+- PR-E branch `feature/pr-e-admin-ui-wrapup` is in progress from `main` / `origin/main` at `056ab425e222190546145015563e6e511cd80322`.
+- No open GitHub PRs were present before starting PR-E.
+- PR-E changes are intentionally narrow:
+  - expose the Web Listening entry using its required `sites.write` permission instead of hiding it behind `tasks.run` only;
+  - add the missing RAG Indexing task-history filter for discoverability;
+  - prevent invalid/empty/negative Markdown conversion limit edits from being coerced to `0` in the settings UI.
 
 ## Verification
 
-- `git status --short --branch` checked before work; unrelated local `docker-compose.override.yml` production override remains dirty and uncommitted.
-- `gh pr view 156 --json state,mergeable,statusCheckRollup,reviewDecision,comments,reviews,url` checked.
-- `gh api repos/ferryhe/AI_actuarial_inforsearch/pulls/156/comments --paginate` checked Copilot inline comments.
-- `gh pr checks 156 --watch=false` showed `python-smoke` passing before follow-up push.
-- `python3 -m pytest tests/test_fastapi_chat_endpoints.py tests/test_tasks_react_source.py tests/test_settings_react_source.py` passed: 46 passed, 3 warnings.
-- `npm run build` passed; Vite emitted only the existing large-chunk warning.
-- `git diff --check` passed.
-- Required Codex CLI local review gate was attempted with `codex exec -s read-only review --uncommitted`, but could not run because Codex auth token refresh failed with 401 `refresh_token_reused` / `token_expired`.
+- Startup checks run from `/opt/ai_actuarial_inforsearch`: `git status --short --branch`, `git remote -v`, `gh auth status`, `git fetch --prune origin`, `gh pr list --state open`, and stash inspection.
+- Read-only planning subagent inspected PR-E scope and ran `python3 -m pytest tests/test_settings_react_source.py tests/test_tasks_react_source.py tests/test_web_listening_rule.py -q`: 28 passed, 3 warnings.
+- Focused implementation checks run locally:
+  - `python3 -m pytest tests/test_settings_react_source.py tests/test_tasks_react_source.py tests/test_web_listening_rule.py tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip -q`: 30 passed, 3 warnings.
+  - `npm run build`: passed; Vite emitted only the existing large-chunk warning.
+  - `git diff --check`: passed.
 
 ## Notes
 
 - Sibling repositories remain out of scope.
-- Do not commit local `.env`, secrets, generated credentials, or `docker-compose.override.yml`.
+- Do not commit local `.env`, secrets, generated credentials, or production-only overrides such as `docker-compose.override.yml` unless explicitly scoped.
+- A stash named `protected-local-files-before-pr-d-review` remains in git stash from earlier protected-local-file handling; do not drop it without confirming it is no longer needed.
+- Existing older stashes (`fix/chat-retrieval-no-results`, `main` WIP, `fix/caddy-fail2ban-access-log`) remain untouched.

--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -25,6 +25,7 @@
   - `python3 -m pytest tests/test_settings_react_source.py tests/test_tasks_react_source.py tests/test_web_listening_rule.py tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip -q`: 30 passed, 3 warnings.
   - `npm run build`: passed; Vite emitted only the existing large-chunk warning.
   - `git diff --check`: passed.
+- Codex CLI pre-PR review initially found two valid P2 issues (non-matching Web Listening history filter and schedule-only Web Listening visibility); both were fixed before opening PR #160. Copilot then left one valid Markdown limit-edit UX comment on PR #160; this branch now uses editable per-limit draft strings and resets invalid drafts on blur.
 
 ## Notes
 

--- a/client/src/pages/Tasks.tsx
+++ b/client/src/pages/Tasks.tsx
@@ -254,7 +254,12 @@ export default function Tasks() {
     }
   }
 
-  const visibleTaskTypes = taskTypes.filter((tt) => tt.type !== "site_config" || canManageSites);
+  const visibleTaskTypes = taskTypes.filter((tt) => {
+    if (tt.type === "site_config") return canManageSites;
+    if (tt.type === "web_listening") return canManageSites;
+    return canRunTasks;
+  });
+  const canShowTaskEntryGrid = visibleTaskTypes.length > 0;
   const activeTaskType = visibleTaskTypes.find((tt) => tt.type === activeForm);
 
   return (
@@ -303,7 +308,7 @@ export default function Tasks() {
         </div>
       )}
       {/* 1. All Tasks (task type selection grid) */}
-      {canRunTasks ? <div>
+      {canShowTaskEntryGrid ? <div>
         <h2 className="text-lg font-semibold mb-3">{t("tasks.new_task")}</h2>
         <AnimatePresence mode="wait">
           {activeForm ? (

--- a/client/src/pages/settings/MarkdownConversionTab.tsx
+++ b/client/src/pages/settings/MarkdownConversionTab.tsx
@@ -84,10 +84,12 @@ export function MarkdownConversionTab() {
   };
 
   const updateLimit = (name: string, value: string) => {
+    if (!value.trim()) return;
     const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) return;
     setConfig((prev) => prev ? {
       ...prev,
-      limits: { ...(prev.limits || {}), [name]: Number.isFinite(parsed) ? parsed : 0 },
+      limits: { ...(prev.limits || {}), [name]: parsed },
     } : prev);
   };
 

--- a/client/src/pages/settings/MarkdownConversionTab.tsx
+++ b/client/src/pages/settings/MarkdownConversionTab.tsx
@@ -48,18 +48,21 @@ export function MarkdownConversionTab() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [limitDrafts, setLimitDrafts] = useState<Record<string, string>>({});
 
   const loadConfig = async () => {
     setLoading(true);
     setError(null);
     try {
       const res = await apiGet<MarkdownConversionOptions>("/api/config/markdown-conversion");
-      setConfig(res.config || {
+      const nextConfig = res.config || {
         default_tool: res.default_tool,
         tools: Object.fromEntries((res.tools || []).map((tool) => [tool.name, tool])),
         formats: res.formats,
         limits: res.limits,
-      });
+      };
+      setConfig(nextConfig);
+      setLimitDrafts(Object.fromEntries(Object.entries(nextConfig.limits || {}).map(([key, limit]) => [key, String(limit)])));
     } catch (e) {
       setError(e instanceof Error ? e.message : t("settings.markdown_load_error"));
     } finally {
@@ -84,6 +87,7 @@ export function MarkdownConversionTab() {
   };
 
   const updateLimit = (name: string, value: string) => {
+    setLimitDrafts((prev) => ({ ...prev, [name]: value }));
     if (!value.trim()) return;
     const parsed = Number(value);
     if (!Number.isFinite(parsed) || parsed < 0) return;
@@ -91,6 +95,11 @@ export function MarkdownConversionTab() {
       ...prev,
       limits: { ...(prev.limits || {}), [name]: parsed },
     } : prev);
+  };
+
+  const resetLimitDraft = (name: string) => {
+    const current = config?.limits?.[name];
+    setLimitDrafts((prev) => ({ ...prev, [name]: current == null ? "" : String(current) }));
   };
 
   const saveConfig = async () => {
@@ -190,7 +199,7 @@ export function MarkdownConversionTab() {
         {Object.entries(config.limits || {}).map(([name, value]) => (
           <label key={name} className="grid sm:grid-cols-[220px_1fr] gap-3 items-center text-sm">
             <span className="text-muted-foreground">{name}</span>
-            <input type="number" value={value} onChange={(e) => updateLimit(name, e.target.value)} className="rounded-lg border border-border bg-background px-3 py-2 text-sm" />
+            <input type="number" value={limitDrafts[name] ?? String(value)} onChange={(e) => updateLimit(name, e.target.value)} onBlur={() => resetLimitDraft(name)} className="rounded-lg border border-border bg-background px-3 py-2 text-sm" />
           </label>
         ))}
         <p className="flex items-center gap-1.5 text-xs text-muted-foreground"><AlertTriangle className="w-3.5 h-3.5" />{t("settings.markdown_paid_hint")}</p>

--- a/client/src/pages/tasks/FilterBar.tsx
+++ b/client/src/pages/tasks/FilterBar.tsx
@@ -55,6 +55,7 @@ export function FilterBar({
         <option value="catalog">Catalog</option>
         <option value="markdown_conversion">Markdown</option>
         <option value="chunk_generation">Chunk</option>
+        <option value="rag_indexing">RAG Indexing</option>
       </select>
     </div>
   );

--- a/tests/test_settings_react_source.py
+++ b/tests/test_settings_react_source.py
@@ -72,6 +72,8 @@ def test_settings_exposes_markdown_conversion_as_independent_tab():
     assert "<MarkdownConversionTab />" in src
     assert '"/api/config/markdown-conversion"' in tab_src
     assert 'data-testid="markdown-conversion-tab"' in tab_src
+    assert "if (!value.trim()) return" in tab_src
+    assert "!Number.isFinite(parsed) || parsed < 0" in tab_src
     assert '"settings.tab_markdown_conversion"' in i18n
 
 

--- a/tests/test_settings_react_source.py
+++ b/tests/test_settings_react_source.py
@@ -72,8 +72,11 @@ def test_settings_exposes_markdown_conversion_as_independent_tab():
     assert "<MarkdownConversionTab />" in src
     assert '"/api/config/markdown-conversion"' in tab_src
     assert 'data-testid="markdown-conversion-tab"' in tab_src
+    assert "limitDrafts" in tab_src
+    assert "setLimitDrafts" in tab_src
     assert "if (!value.trim()) return" in tab_src
     assert "!Number.isFinite(parsed) || parsed < 0" in tab_src
+    assert "onBlur={() => resetLimitDraft(name)}" in tab_src
     assert '"settings.tab_markdown_conversion"' in i18n
 
 

--- a/tests/test_tasks_react_source.py
+++ b/tests/test_tasks_react_source.py
@@ -195,6 +195,17 @@ def test_tasks_page_exposes_agentic_site_monitoring_form():
     assert 'data-testid="form-web-listening"' in form_src
 
 
+def test_web_listening_entry_uses_site_permission_not_tasks_run_only():
+    tasks_src = TASKS_TSX.read_text(encoding="utf-8")
+    filter_src = (ROOT / "pages" / "tasks" / "FilterBar.tsx").read_text(encoding="utf-8")
+
+    assert 'tt.type === "web_listening"' in tasks_src
+    assert "return canManageSites" in tasks_src
+    assert "const canShowTaskEntryGrid = visibleTaskTypes.length > 0" in tasks_src
+    assert "{canShowTaskEntryGrid ? <div>" in tasks_src
+    assert '<option value="rag_indexing">RAG Indexing</option>' in filter_src
+
+
 def test_tasks_page_refreshes_history_on_completion_and_exposes_global_logs():
     src = TASKS_TSX.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- expose Web Listening entry based on site-management permission instead of generic task-run permission
- harden Markdown conversion limit edits so empty/invalid/negative UI values are not coerced to zero
- add the missing RAG indexing history filter and focused source-contract coverage
- update project status for PR-E

## Verification
- python3 -m pytest tests/test_settings_react_source.py tests/test_tasks_react_source.py tests/test_web_listening_rule.py tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip -q
- npm run build
- git diff --check
- independent reviewer subagent: pass
- codex exec -s read-only review --uncommitted: pass after addressing two valid P2 findings
