### PR TITLE
Docs: refresh final project state

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,30 +1,43 @@
 # Project Status
 
 - Date: 2026-06-18
-- Branch: `feature/pr-i-web-listening-full-loop`
-- Scope: PR-I Web Listening full automatic loop.
+- Branch: `docs/final-state-readme-refresh`
+- Scope: Final-state README/docs refresh after managed roadmap completion; deploy latest `main` afterward.
 
 ## Current State
 
-- PR-A / #156 through PR-H / #163 are merged into `main`.
-- PR-I implementation is prepared on `feature/pr-i-web-listening-full-loop`.
-- Web Listening rule materialization now creates an enabled `full_pipeline` scheduled task instead of a collection-only `scheduled` task.
+- PR-A / #156 through PR-I / #164 are merged into `main`.
+- There are no open PRs for the managed roadmap.
+- PR-I / #164 completed the Web Listening automatic loop: materialized rules now create scheduled `full_pipeline` tasks rather than collection-only `scheduled` tasks.
 - Materialized Web Listening full-pipeline params include `source_collection_type: scheduled`, the selected `site`, a `Full Pipeline: <site>` run name, `check_database: true`, and `run_rag_indexing: false` by default.
-- Tasks UI/i18n copy now describes the Web Listening materialized task as a scheduled full-pipeline monitor.
+- Tasks UI/i18n copy describes the Web Listening materialized task as a scheduled full-pipeline monitor.
+- Documentation refresh is in progress on `docs/final-state-readme-refresh`: README, Chinese README, docs index, architecture, and API migration status are being updated to reflect PR-A through PR-I, weekly summaries, typed scheduled tasks, and `full_pipeline`.
 - Sibling repositories remain out of scope.
 
 ## Verification
 
-- `python3 -m pytest tests/test_web_listening_rule.py tests/test_task_runtime_full_pipeline.py tests/test_tasks_react_source.py -q`: 32 passed; existing SWIG deprecation warnings.
-- `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py::test_scheduled_tasks_write_and_schedule_reinit_roundtrip tests/test_web_listening_rule.py -q`: 5 passed; existing SWIG deprecation warnings.
-- `npm run build`: passed; Vite emitted the existing large-chunk warning.
-- `git diff --check`: passed.
-- Static added-line security scan: no findings.
-- Independent reviewer subagent: passed with no blocking security or logic findings.
-- `codex exec -s read-only ...`: `NO BLOCKING FINDINGS`.
+- PR-I local focused tests before merge:
+  - `python3 -m pytest tests/test_web_listening_rule.py tests/test_task_runtime_full_pipeline.py tests/test_tasks_react_source.py -q`: 32 passed; existing SWIG deprecation warnings.
+  - `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py::test_scheduled_tasks_write_and_schedule_reinit_roundtrip tests/test_web_listening_rule.py -q`: 5 passed; existing SWIG deprecation warnings.
+  - `npm run build`: passed; Vite emitted the existing large-chunk warning.
+  - `git diff --check`: passed.
+  - Static added-line security scan: no findings.
+  - Independent reviewer subagent: passed with no blocking security or logic findings.
+  - `codex exec -s read-only ...`: `NO BLOCKING FINDINGS`.
+- PR #164 remote CI: `python-smoke` succeeded.
+- PR #164 Copilot review: generated no inline comments.
+- Post-merge: `git fetch origin --prune` confirmed the remote PR-I branch is deleted; `gh pr list --state open` returned no open PRs.
+- Docs refresh verification on `docs/final-state-readme-refresh`:
+  - Active doc relative-link scan: passed.
+  - Active doc stale-current-status scan: passed.
+  - `python3 -m ai_actuarial --help`: passed.
+  - `python3 -m pytest tests/test_web_listening_rule.py tests/test_weekly_updates.py tests/test_task_runtime_full_pipeline.py tests/test_tasks_react_source.py -q`: 40 passed; existing SWIG deprecation warnings.
+  - `npm run build`: passed; Vite emitted the existing large-chunk warning.
+  - `git diff --check`: passed.
+  - Independent reviewer subagents: one found an incorrect `web_page` typed-param doc claim; fixed. Follow-up links/stale reviewer passed.
+  - `codex exec -s read-only ...`: `NO BLOCKING FINDINGS`.
 
 ## Local Notes
 
-- Modified files for PR-I: `.hermes/project-status.md`, `ai_actuarial/web_listening_rule.py`, `client/src/hooks/use-i18n.ts`, `tests/test_tasks_react_source.py`, `tests/test_web_listening_rule.py`.
 - Existing protected stashes from earlier work remain untouched, including `protected-project-status-before-pr-f` and `protected-local-files-before-pr-d-review`.
-- Next gate: commit, push, open PR-I, then inspect CI/review/Copilot comments before merge.
+- Next gate: verify docs refresh, commit/push/open/merge docs PR, sync `main`, then update the website service to latest `main` and run public health checks.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ AI Actuarial Info Search is a FastAPI + React document-intelligence platform for
 
 - **Runtime:** FastAPI is the only `/api/*` authority; React/Vite is the only maintained product UI. The legacy server-rendered/Replit-era workflow is retired.
 - **Security/RBAC:** session/token auth, scoped permissions, upload-batch file import, SSRF-safe public URL fetch, auth/rate-limit hardening, and bounded untrusted Chat document context are active.
-- **Customer product surface:** the Dashboard is customer-facing first: sources, categories, weekly additions, document detail, and Agent entry points. Backend processing metrics live in admin/ops pages instead of the homepage.
+- **Customer product surface:** the Dashboard is customer-facing first: sources, categories, latest weekly additions from backend weekly summaries, document detail, and Agent entry points. Backend processing metrics live in admin/ops pages instead of the homepage.
 - **Document conversion:** Markdown conversion is driven by `config/markdown_conversion.yaml` and Settings. Tool ordering, format routing, paid/API-tool enablement, and tuning are configurable; paid/API tools are not auto-selected by default.
-- **Collection automation:** configured crawls, search-provider fallback, browser-upload file imports, scheduled tasks, and web-listening rule draft/validate/materialize workflows are supported.
-- **Weekly updates:** `/api/weekly-updates` and `/api/weekly-updates/latest` summarize newly discovered files using `files.first_seen`.
+- **Collection automation:** configured crawls, search-provider fallback, browser-upload file imports, typed scheduled tasks, `weekly_summary`, `full_pipeline`, and web-listening rule draft/validate/materialize workflows are supported.
+- **Weekly updates:** `/api/weekly-updates` and `/api/weekly-updates/latest` summarize newly discovered files using `files.first_seen`; the default weekly task uses `relative_period: previous_week` for the completed UTC ISO week.
 - **RAG and Chat:** standard vector RAG and Agentic RAG coexist. Chat is knowledge-base first, keeps conversation/session history, and supports standard multi-KB chat plus single-ready-KB Agentic mode.
-- **Roadmap completion:** Agentic RAG PRs #133-#145 plus roadmap PRs #147-#154 are merged; the managed backlog in `.hermes/project-status.md` is complete.
+- **Roadmap completion:** Agentic RAG PRs #133-#145, consolidation PRs #147-#154, and managed Feishu-plan PR-A through PR-I (#156-#164) are merged; there are no open managed-roadmap PRs.
 
 ## Feature Set
 
@@ -38,7 +38,7 @@ AI Actuarial Info Search is a FastAPI + React document-intelligence platform for
 
 - Draft `web-listening-agent-rule.v1` YAML rules from a source URL and acquisition goal.
 - Validate rule YAML before applying it.
-- Materialize validated rules into acquisition profile, monitor task, section selection, and monitor scope configuration.
+- Materialize validated rules into acquisition profile, scheduled `full_pipeline` monitor task, section selection, and monitor scope configuration.
 
 ### RAG, Agentic RAG, and Chat
 
@@ -148,12 +148,11 @@ Run a configured site crawl:
 }
 ```
 
-Run a weekly summary task:
+Run a weekly summary task for the previously completed UTC ISO week:
 
 ```json
 {
-  "period_start": "2026-06-01T00:00:00+00:00",
-  "period_end": "2026-06-08T00:00:00+00:00",
+  "relative_period": "previous_week",
   "max_files": 500
 }
 ```
@@ -237,7 +236,7 @@ python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().d
 npm run build
 python -m pytest tests/test_fastapi_entrypoint.py tests/test_fastapi_no_flask_runtime.py tests/test_react_fastapi_authority.py tests/test_fastapi_react_cleanup.py -q
 python -m pytest tests/test_fastapi_auth_endpoints.py tests/test_auth_react_source.py tests/test_fastapi_chat_endpoints.py tests/test_tasks_react_source.py -q
-python -m pytest tests/test_markdown_conversion_config.py tests/test_web_listening_rule.py tests/test_weekly_updates.py -q
+python -m pytest tests/test_markdown_conversion_config.py tests/test_web_listening_rule.py tests/test_weekly_updates.py tests/test_task_runtime_full_pipeline.py -q
 python -m pytest tests/agentic_rag/test_eval.py tests/agentic_rag/test_planner_agentic_loop.py -q
 python -m ai_actuarial.agentic_rag.eval --mode agentic --cases eval/agentic_cases.jsonl --output-dir eval/fixtures/agentic_ready_data --profile formula --json
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,12 +10,12 @@ AI Actuarial Info Search 是面向精算和保险研究场景的 FastAPI + React
 
 - **运行时：** FastAPI 是唯一 `/api/*` 权威入口；React/Vite 是唯一维护中的产品 UI。旧 server-rendered/Replit 时代工作流已退出当前产品。
 - **安全/RBAC：** session/token 鉴权、细粒度权限、upload-batch 文件导入、公共 URL SSRF 防护、登录/注册限流，以及 Chat 文档上下文边界控制已启用。
-- **客户产品面：** Dashboard 优先展示客户关心的来源、分类、本周新增、资料详情和问 Agent 入口；后台处理指标放在 admin/ops 页面，不再作为首页主内容。
+- **客户产品面：** Dashboard 优先展示客户关心的来源、分类、来自后端 weekly summary 的最新周报新增、资料详情和问 Agent 入口；后台处理指标放在 admin/ops 页面，不再作为首页主内容。
 - **Markdown 转换：** 由 `config/markdown_conversion.yaml` 和 Settings 管理工具顺序、格式路由、付费/API 工具开关和 tuning；付费/API 工具默认不自动触发。
-- **采集自动化：** 支持配置站点爬取、搜索服务兜底、浏览器上传文件导入、定时任务，以及 web-listening 规则 draft/validate/materialize。
-- **本周新增：** `/api/weekly-updates` 和 `/api/weekly-updates/latest` 基于 `files.first_seen` 汇总新发现资料。
+- **采集自动化：** 支持配置站点爬取、搜索服务兜底、浏览器上传文件导入、typed 定时任务、`weekly_summary`、`full_pipeline`，以及 web-listening 规则 draft/validate/materialize。
+- **周报新增：** `/api/weekly-updates` 和 `/api/weekly-updates/latest` 基于 `files.first_seen` 汇总新发现资料；默认 weekly task 使用 `relative_period: previous_week` 覆盖已完成的 UTC ISO 周。
 - **RAG 和 Chat：** 标准向量 RAG 与 Agentic RAG 并存。Chat 已转为知识库优先体验，保留会话历史，支持标准多知识库 Chat 和单个 ready KB 的 Agentic 模式。
-- **路线图完成：** Agentic RAG PR #133-#145 以及后续路线图 PR #147-#154 均已合并；`.hermes/project-status.md` 中的 managed backlog 已完成。
+- **路线图完成：** Agentic RAG PR #133-#145、整合 PR #147-#154，以及飞书计划 managed PR-A 到 PR-I（#156-#164）均已合并；当前没有未完成的 managed-roadmap PR。
 
 ## 功能集
 
@@ -38,7 +38,7 @@ AI Actuarial Info Search 是面向精算和保险研究场景的 FastAPI + React
 
 - 根据来源 URL 和采集目标生成 `web-listening-agent-rule.v1` YAML 草稿。
 - 在应用前校验 rule YAML。
-- 将校验后的规则 materialize 为 acquisition profile、monitor task、section selection 和 monitor scope 配置。
+- 将校验后的规则 materialize 为 acquisition profile、定时 `full_pipeline` monitor task、section selection 和 monitor scope 配置。
 
 ### RAG、Agentic RAG 和 Chat
 
@@ -148,12 +148,11 @@ SQLite 路径以 `config/sites.yaml -> paths.db` 为准；`DB_PATH` 只是 YAML 
 }
 ```
 
-运行 weekly summary：
+运行已完成 UTC ISO 周的 weekly summary：
 
 ```json
 {
-  "period_start": "2026-06-01T00:00:00+00:00",
-  "period_end": "2026-06-08T00:00:00+00:00",
+  "relative_period": "previous_week",
   "max_files": 500
 }
 ```
@@ -237,7 +236,7 @@ python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().d
 npm run build
 python -m pytest tests/test_fastapi_entrypoint.py tests/test_fastapi_no_flask_runtime.py tests/test_react_fastapi_authority.py tests/test_fastapi_react_cleanup.py -q
 python -m pytest tests/test_fastapi_auth_endpoints.py tests/test_auth_react_source.py tests/test_fastapi_chat_endpoints.py tests/test_tasks_react_source.py -q
-python -m pytest tests/test_markdown_conversion_config.py tests/test_web_listening_rule.py tests/test_weekly_updates.py -q
+python -m pytest tests/test_markdown_conversion_config.py tests/test_web_listening_rule.py tests/test_weekly_updates.py tests/test_task_runtime_full_pipeline.py -q
 python -m pytest tests/agentic_rag/test_eval.py tests/agentic_rag/test_planner_agentic_loop.py -q
 python -m ai_actuarial.agentic_rag.eval --mode agentic --cases eval/agentic_cases.jsonl --output-dir eval/fixtures/agentic_ready_data --profile formula --json
 ```

--- a/docs/API_MIGRATION_STATUS.md
+++ b/docs/API_MIGRATION_STATUS.md
@@ -16,14 +16,14 @@ The legacy server-rendered runtime has been retired from the active tree. React 
 - **Unmatched `/api/*`:** FastAPI returns `410`
 - **Migration inventory:** available only when `FASTAPI_ENABLE_MIGRATION_INVENTORY=1`
 - **RAG modes:** standard vector RAG and Agentic RAG both use native FastAPI endpoints.
-- **Roadmap surfaces:** Markdown conversion config, web-listening rule draft/validate/materialize, weekly updates, customer Dashboard, and KB-first Chat are all native FastAPI + React surfaces.
+- **Roadmap surfaces:** Markdown conversion config, typed scheduled tasks, `weekly_summary`, `full_pipeline`, web-listening rule draft/validate/materialize, weekly updates, customer Dashboard, and KB-first Chat are all native FastAPI + React surfaces.
 
 ## Product Contract Status
 
 The routed React product shell is expected to use native FastAPI endpoints for:
 
 - Dashboard
-  - Customer-facing sources, categories, weekly additions, file-detail links, and Agent entry points
+  - Customer-facing sources, categories, latest weekly additions from `/api/weekly-updates/latest`, file-detail links, and Agent entry points
   - Backend processing metrics stay in admin/ops surfaces rather than the homepage
 - Database
 - File Detail / File Preview
@@ -32,6 +32,7 @@ The routed React product shell is expected to use native FastAPI endpoints for:
   - Standard multi-KB mode
   - Agentic single-ready-KB mode
 - Tasks
+  - Typed scheduled task parameters for backend-supported `catalog`, `url`, `weekly_summary`, and `full_pipeline` params
 - Logs
 - Knowledge / KB Detail
 - Agentic ready_data manifest status/build actions
@@ -85,7 +86,7 @@ The routed React product shell is expected to use native FastAPI endpoints for:
 - `/api/tasks/history`
 - `/api/tasks/log/{task_id}`
 - `/api/tasks/stop/{task_id}`
-- `/api/collections/run`
+- `/api/collections/run` (`scheduled`, `weekly_summary`, and `full_pipeline` run types)
 - `/api/utils/browse-folder`
 
 ### Weekly Updates
@@ -158,8 +159,9 @@ Agentic Chat is also exposed through the main chat contract by sending `rag_mode
 
 - `tests/test_fastapi_entrypoint.py`, `tests/test_fastapi_no_flask_runtime.py`, `tests/test_react_fastapi_authority.py`, and `tests/test_fastapi_react_cleanup.py` keep the FastAPI + React product boundary from regressing.
 - `tests/test_markdown_conversion_config.py` and related ops endpoint tests cover Markdown conversion config normalization, caching, and Settings read/write behavior.
-- `tests/test_web_listening_rule.py` covers rule draft/validate/materialize behavior and YAML coercion.
-- `tests/test_weekly_updates.py` covers weekly summary API/task behavior using `files.first_seen`.
+- `tests/test_web_listening_rule.py` covers rule draft/validate/materialize behavior, YAML coercion, and materialized `full_pipeline` monitor tasks.
+- `tests/test_weekly_updates.py` covers weekly summary API/task behavior using `files.first_seen`, including previous-week relative periods.
+- `tests/test_task_runtime_full_pipeline.py` covers automatic full-pipeline chaining and failure handling.
 - `tests/test_fastapi_chat_endpoints.py` and source-level Chat tests cover KB-first Chat behavior.
 - `tests/agentic_rag/test_eval.py` and the CI Agentic eval smoke keep the deterministic ready_data eval path active.
 
@@ -181,7 +183,7 @@ Agentic Chat is also exposed through the main chat contract by sending `rag_mode
 
 ```bash
 python -m pytest tests/test_fastapi_entrypoint.py tests/test_fastapi_no_flask_runtime.py tests/test_react_fastapi_authority.py tests/test_fastapi_react_cleanup.py -q
-python -m pytest tests/test_markdown_conversion_config.py tests/test_web_listening_rule.py tests/test_weekly_updates.py -q
+python -m pytest tests/test_markdown_conversion_config.py tests/test_web_listening_rule.py tests/test_weekly_updates.py tests/test_task_runtime_full_pipeline.py -q
 python -m pytest tests/test_fastapi_chat_endpoints.py tests/test_tasks_react_source.py -q
 npm run build
 python -m pytest tests/agentic_rag/test_eval.py -q

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ The active RAG posture has two paths:
 - **Standard RAG**: vector indexes, embeddings, LLM-backed answer generation, multi-KB chat, and direct selected-document comparison.
 - **Agentic RAG**: KB-scoped ready_data manifests, deterministic local read tools, structured evidence/citations, and tool traces for a single Agentic-ready KB.
 
-The Feishu-plan roadmap is complete on `main`: Markdown conversion config, customer Dashboard, web-listening rules, weekly updates, and KB-first Chat are active product surfaces rather than future phases.
+The Feishu-plan roadmap PR-A through PR-I (#156-#164) is complete on `main`: Markdown conversion config, customer Dashboard, typed scheduled tasks, weekly summaries, `full_pipeline` chaining, web-listening rules, and KB-first Chat are active product surfaces rather than future phases.
 
 ## Core System Chain
 
@@ -27,6 +27,7 @@ site config + markdown conversion config
 -> file download + SHA256 dedupe
 -> cataloging + Markdown conversion
 -> weekly-update summaries from first_seen files
+-> optional full_pipeline chaining across collection, Markdown, catalog, chunking, and RAG indexing
 -> semantic chunking + embeddings
 -> knowledge base indexing
 -> standard RAG retrieval + KB-first chat
@@ -56,7 +57,7 @@ site config + markdown conversion config
 6. Standard RAG and Agentic RAG must remain explicit modes; Agentic Chat currently requires exactly one ready KB and cannot be combined with direct document context.
 7. Dashboard should stay customer-facing by default; operational processing metrics belong in admin/ops routes.
 8. Markdown conversion behavior belongs in `config/markdown_conversion.yaml` plus Settings, not hard-coded tool order lists.
-9. Web-listening rule materialization must preserve the typed `web-listening-agent-rule.v1` contract.
+9. Web-listening rule materialization must preserve the typed `web-listening-agent-rule.v1` contract and create scheduled `full_pipeline` monitors, not collection-only tasks.
 
 ## Key Subsystems
 
@@ -89,12 +90,12 @@ site config + markdown conversion config
 
 - `ai_actuarial/web_listening_rule.py`: `web-listening-agent-rule.v1` schema and validation.
 - `ai_actuarial/api/services/ops_write.py`: draft/validate/materialize operations.
-- Materialized config lives in the standard site/schedule config surfaces.
+- Materialized config lives in the standard site/schedule config surfaces and uses scheduled `full_pipeline` tasks with `source_collection_type: scheduled`, `check_database: true`, and RAG indexing disabled unless explicitly requested.
 
 ### Weekly Updates
 
 - `ai_actuarial/api/services/weekly_updates.py`: summary generation from `files.first_seen`.
-- `weekly_update_summaries` storage table and `weekly_summary` collection task.
+- `weekly_update_summaries` storage table and `weekly_summary` collection task; default scheduling uses `relative_period: previous_week` for the completed UTC ISO week.
 - `/api/weekly-updates` and `/api/weekly-updates/latest` expose summaries to Dashboard/product UI.
 
 ### RAG and Chat
@@ -144,6 +145,7 @@ Product API/UI ready_data builds are constrained to the configured SQLite databa
 - `GET /api/config/markdown-conversion`
 - `GET /api/weekly-updates/latest`
 - `POST /api/web-listening/rules/validate`
+- `POST /api/collections/run` with `type: full_pipeline`
 - `GET /api/rag/knowledge-bases/{kb_id}/agentic-ready-manifest`
 - `POST /api/rag/knowledge-bases/{kb_id}/agentic-ready-manifest/build`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,10 @@ This directory keeps maintained documentation first. Historical implementation r
 
 ## Current References
 
-- [Root README](../README.md): current product overview, final roadmap status, setup, feature set, and common commands.
+- [Root README](../README.md): current product overview, final PR-A through PR-I roadmap status, setup, feature set, and common commands.
 - [Chinese README](../README.zh-CN.md): Chinese product overview and setup notes.
 - [Security Policy](../SECURITY.md): maintained security posture and production checklist.
-- [Architecture](ARCHITECTURE.md): current FastAPI + React architecture, standard/Agentic RAG modes, Markdown conversion, weekly updates, and web-listening rule surfaces.
+- [Architecture](ARCHITECTURE.md): current FastAPI + React architecture, standard/Agentic RAG modes, Markdown conversion, weekly updates, `full_pipeline`, and web-listening rule surfaces.
 - [API Migration Status](API_MIGRATION_STATUS.md): source of truth for the React/FastAPI boundary and maintained representative native API surfaces.
 - [Deployment Runbook](deployment-runbook.md): deployment operations.
 - [Rate Limiting](rate-limit-config.md): active rate-limit behavior for product endpoints and auth credential submissions.
@@ -29,11 +29,13 @@ This directory keeps maintained documentation first. Historical implementation r
 - FastAPI is the only product API authority for `/api/*`; React is the only maintained product UI.
 - Security/RBAC hardening is merged, including upload-batch file import, SSRF checks, scoped permissions, auth rate limits, and bounded Chat document context.
 - Agentic RAG is complete: KB ready-data manifests, `general` / `regulation` / `formula` profiles, deterministic read tools, Agentic Chat, structured citations, tool traces, and CI-backed eval smoke coverage.
-- Final Feishu-plan roadmap items are complete on `main`:
+- Final Feishu-plan roadmap items PR-A through PR-I (#156-#164) are complete on `main`:
   - Markdown conversion config split into `config/markdown_conversion.yaml` plus Settings/runtime integration.
-  - Customer-facing Dashboard focused on document sources, categories, weekly additions, details, and Agent entry points.
+  - Customer-facing Dashboard focused on document sources, categories, latest weekly additions, details, and Agent entry points.
   - `web-listening-agent-rule.v1` draft/validate/materialize workflow.
-  - Weekly updates API/storage/task runtime using `files.first_seen`.
+  - Weekly updates API/storage/task runtime using `files.first_seen`, plus a default previous-week `weekly_summary` schedule.
+  - Typed Scheduled Tasks UI with backend-supported params, `weekly_summary`, and `full_pipeline`.
+  - Web-listening materialization now creates scheduled `full_pipeline` monitor tasks.
   - Knowledge-base-first Chat UI plus API/types/session extraction.
 - Valid remote Copilot/review follow-up comments from the roadmap PR sequence were handled in dedicated follow-up PRs before the backlog was marked complete.
 


### PR DESCRIPTION
## Summary
- Refresh README/Chinese README to reflect PR-A through PR-I completion, latest weekly summaries, typed scheduled tasks, and full_pipeline support
- Update docs index, architecture, and API migration status for web-listening full_pipeline monitor tasks and previous-week weekly_summary defaults
- Record verification in project status

## Verification
- Active doc relative-link scan: passed
- Active doc stale-current-status scan: passed
- python3 -m ai_actuarial --help
- python3 -m pytest tests/test_web_listening_rule.py tests/test_weekly_updates.py tests/test_task_runtime_full_pipeline.py tests/test_tasks_react_source.py -q
- npm run build
- git diff --check
- Independent reviewer subagents
- codex exec -s read-only review: NO BLOCKING FINDINGS