### PR TITLE
Fix guest chat access

### DIFF
--- a/.hermes/project-status.md
+++ b/.hermes/project-status.md
@@ -1,43 +1,33 @@
 # Project Status
 
 - Date: 2026-06-18
-- Branch: `docs/final-state-readme-refresh`
-- Scope: Final-state README/docs refresh after managed roadmap completion; deploy latest `main` afterward.
+- Branch: `fix/guest-chat-login-entry`
+- Scope: Fix guest Chat KB selection / explain-file flow and add compact top-right login entry.
 
 ## Current State
 
-- PR-A / #156 through PR-I / #164 are merged into `main`.
-- There are no open PRs for the managed roadmap.
-- PR-I / #164 completed the Web Listening automatic loop: materialized rules now create scheduled `full_pipeline` tasks rather than collection-only `scheduled` tasks.
-- Materialized Web Listening full-pipeline params include `source_collection_type: scheduled`, the selected `site`, a `Full Pipeline: <site>` run name, `check_database: true`, and `run_rag_indexing: false` by default.
-- Tasks UI/i18n copy describes the Web Listening materialized task as a scheduled full-pipeline monitor.
-- Documentation refresh is in progress on `docs/final-state-readme-refresh`: README, Chinese README, docs index, architecture, and API migration status are being updated to reflect PR-A through PR-I, weekly summaries, typed scheduled tasks, and `full_pipeline`.
+- PR-A / #156 through PR-I / #164 and docs refresh PR #165 are merged into `main`.
+- Production guest QA found Chat regressions for non-logged-in users:
+  - `/chat` showed no selectable KBs even though public Knowledge Bases listed ready KBs.
+  - Guest chat sent questions to a missing Demo KB and returned `Visitor Demo knowledge base is not available`.
+  - Database/File Detail “Explain with AI” redirected to Chat but failed with `Visitor chat is limited to the Demo knowledge base`.
+- Root cause: backend visitor policy in `ai_actuarial/api/services/chat.py` filtered guest KB listing and forced/rejected guest queries based on `CHAT_VISITOR_DEMO_KB_ID` / default `demo`.
+- Fix in progress removes the Demo-only visitor chat restriction while keeping guest chat quota enforcement; guests can list/select public ready KBs and send direct document context through Chat.
+- Header login entry now stays visible as a compact top-right button on small screens.
 - Sibling repositories remain out of scope.
 
 ## Verification
 
-- PR-I local focused tests before merge:
-  - `python3 -m pytest tests/test_web_listening_rule.py tests/test_task_runtime_full_pipeline.py tests/test_tasks_react_source.py -q`: 32 passed; existing SWIG deprecation warnings.
-  - `python3 -m pytest tests/test_fastapi_ops_write_endpoints.py::test_scheduled_tasks_write_and_schedule_reinit_roundtrip tests/test_web_listening_rule.py -q`: 5 passed; existing SWIG deprecation warnings.
+- Guest QA subagent on production before fix: confirmed database/category/file browsing work for guests; confirmed Chat KB selection and explain-file fail; no console errors observed.
+- Read-only code investigation subagent: traced guest KB filtering and direct-document rejection to `ai_actuarial/api/services/chat.py`; located header login controls in `client/src/components/Layout.tsx`.
+- Focused local verification after fix:
+  - `python3 -m pytest tests/test_fastapi_chat_endpoints.py::test_visitor_chat_knowledge_bases_show_public_ready_kbs tests/test_fastapi_chat_endpoints.py::test_guest_equivalent_tokens_can_list_public_chat_kbs tests/test_fastapi_chat_endpoints.py::test_visitor_chat_knowledge_bases_do_not_depend_on_demo_kb_config tests/test_fastapi_chat_endpoints.py::test_visitor_chat_query_allows_selected_public_kb tests/test_fastapi_chat_endpoints.py::test_visitor_chat_query_allows_direct_document_context tests/test_auth_react_source.py -q`: 6 passed; existing SWIG deprecation warnings.
+  - `python3 -m pytest tests/test_fastapi_chat_endpoints.py tests/test_auth_react_source.py tests/test_fastapi_auth_endpoints.py -q`: 47 passed; existing SWIG deprecation warnings.
   - `npm run build`: passed; Vite emitted the existing large-chunk warning.
   - `git diff --check`: passed.
-  - Static added-line security scan: no findings.
-  - Independent reviewer subagent: passed with no blocking security or logic findings.
-  - `codex exec -s read-only ...`: `NO BLOCKING FINDINGS`.
-- PR #164 remote CI: `python-smoke` succeeded.
-- PR #164 Copilot review: generated no inline comments.
-- Post-merge: `git fetch origin --prune` confirmed the remote PR-I branch is deleted; `gh pr list --state open` returned no open PRs.
-- Docs refresh verification on `docs/final-state-readme-refresh`:
-  - Active doc relative-link scan: passed.
-  - Active doc stale-current-status scan: passed.
-  - `python3 -m ai_actuarial --help`: passed.
-  - `python3 -m pytest tests/test_web_listening_rule.py tests/test_weekly_updates.py tests/test_task_runtime_full_pipeline.py tests/test_tasks_react_source.py -q`: 40 passed; existing SWIG deprecation warnings.
-  - `npm run build`: passed; Vite emitted the existing large-chunk warning.
-  - `git diff --check`: passed.
-  - Independent reviewer subagents: one found an incorrect `web_page` typed-param doc claim; fixed. Follow-up links/stale reviewer passed.
-  - `codex exec -s read-only ...`: `NO BLOCKING FINDINGS`.
 
 ## Local Notes
 
+- Modified files: `.hermes/project-status.md`, `ai_actuarial/api/services/chat.py`, `client/src/components/Layout.tsx`, `tests/test_fastapi_chat_endpoints.py`, `tests/test_auth_react_source.py`.
 - Existing protected stashes from earlier work remain untouched, including `protected-project-status-before-pr-f` and `protected-local-files-before-pr-d-review`.
-- Next gate: verify docs refresh, commit/push/open/merge docs PR, sync `main`, then update the website service to latest `main` and run public health checks.
+- Next gate: independent review / Codex review, commit/push/open PR, inspect CI/Copilot comments, merge, deploy, and run production guest smoke.

--- a/ai_actuarial/api/services/chat.py
+++ b/ai_actuarial/api/services/chat.py
@@ -45,6 +45,8 @@ MAX_DOCUMENT_FIELD_CHARS = 512
 MAX_AGENTIC_SYNTHESIS_CHUNKS = 8
 MAX_AGENTIC_SYNTHESIS_CONTENT_CHARS = 4000
 MAX_AGENTIC_FALLBACK_ITEMS = 5
+
+
 def _ensure_conversation_schema(storage: Storage) -> None:
     conn = storage._conn
     conn.execute(

--- a/ai_actuarial/api/services/chat.py
+++ b/ai_actuarial/api/services/chat.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import json
 import logging
-import os
 import sqlite3
 import time
 import uuid
@@ -46,81 +45,6 @@ MAX_DOCUMENT_FIELD_CHARS = 512
 MAX_AGENTIC_SYNTHESIS_CHUNKS = 8
 MAX_AGENTIC_SYNTHESIS_CONTENT_CHARS = 4000
 MAX_AGENTIC_FALLBACK_ITEMS = 5
-DEFAULT_VISITOR_DEMO_KB_ID = "demo"
-
-
-def _visitor_demo_kb_id() -> str:
-    configured = _normalize_text(os.getenv("CHAT_VISITOR_DEMO_KB_ID"))
-    return configured or DEFAULT_VISITOR_DEMO_KB_ID
-
-
-def _visitor_demo_kb_only_error() -> ChatApiError:
-    return ChatApiError(
-        "Visitor chat is limited to the Demo knowledge base",
-        status_code=403,
-        payload={
-            "success": False,
-            "code": "VISITOR_DEMO_KB_ONLY",
-            "error": "Visitor chat is limited to the Demo knowledge base",
-        },
-    )
-
-
-def _is_visitor_auth(auth: AuthContext | None) -> bool:
-    token = (auth.token if auth else None) or {}
-    group_name = _normalize_text(token.get("group_name")).lower()
-    permissions = auth.permissions if auth else frozenset()
-    return not token or group_name in {"guest", "anonymous"} or "chat.conversations" not in permissions
-
-
-def _requested_kb_ids(kb_ids: Any) -> list[str]:
-    if isinstance(kb_ids, list):
-        values = kb_ids
-    elif isinstance(kb_ids, str):
-        if kb_ids.strip().lower() in {"", "auto", "all"}:
-            return []
-        values = [kb_ids]
-    else:
-        return []
-    requested: list[str] = []
-    for value in values:
-        normalized = _normalize_text(value)
-        if normalized.lower() in {"auto", "all"}:
-            continue
-        if normalized and normalized not in requested:
-            requested.append(normalized)
-    return requested
-
-
-def _kb_exists(storage: Storage, kb_id: str) -> bool:
-    try:
-        row = storage._conn.execute("SELECT 1 FROM rag_knowledge_bases WHERE kb_id = ? LIMIT 1", (kb_id,)).fetchone()
-    except sqlite3.OperationalError:
-        return False
-    return row is not None
-
-
-def _enforce_visitor_demo_kb_selection(kb_ids: Any) -> str:
-    demo_kb_id = _visitor_demo_kb_id()
-    requested = _requested_kb_ids(kb_ids)
-    if requested and requested != [demo_kb_id]:
-        raise _visitor_demo_kb_only_error()
-    return demo_kb_id
-
-
-def _enforce_visitor_demo_kb_available(storage: Storage, demo_kb_id: str) -> None:
-    if not demo_kb_id or not _kb_exists(storage, demo_kb_id):
-        raise ChatApiError(
-            "Visitor Demo knowledge base is not available",
-            status_code=403,
-            payload={
-                "success": False,
-                "code": "VISITOR_DEMO_KB_UNAVAILABLE",
-                "error": "Visitor Demo knowledge base is not available",
-            },
-        )
-
-
 def _ensure_conversation_schema(storage: Storage) -> None:
     conn = storage._conn
     conn.execute(
@@ -492,7 +416,6 @@ def _embedding_metadata_matches(
 def list_knowledge_bases(*, db_path: str, auth: AuthContext | None = None) -> dict[str, Any]:
     storage = Storage(db_path)
     try:
-        demo_kb_id = _visitor_demo_kb_id() if auth is not None and _is_visitor_auth(auth) else ""
         embeddings_runtime = resolve_ai_function_runtime("embeddings", storage=storage)
         current_embeddings = {
             "provider": embeddings_runtime.provider,
@@ -530,8 +453,6 @@ def list_knowledge_bases(*, db_path: str, auth: AuthContext | None = None) -> di
             ).fetchall()
         for row in rows:
             kb_id = row[0]
-            if demo_kb_id and kb_id != demo_kb_id:
-                continue
             composition = storage.get_kb_composition_status(kb_id)
             latest_index = composition.get("latest_index") or {}
             has_index = bool(composition.get("has_index"))
@@ -586,8 +507,6 @@ def list_knowledge_bases(*, db_path: str, auth: AuthContext | None = None) -> di
                 }
             )
         data: dict[str, Any] = {"knowledge_bases": knowledge_bases, "current_embeddings": current_embeddings}
-        if demo_kb_id:
-            data["visitor_demo_kb_id"] = demo_kb_id
         return {"success": True, "data": data}
     finally:
         storage.close()
@@ -1013,9 +932,6 @@ def query_chat(*, db_path: str, request, auth: AuthContext, payload: dict[str, A
         raise ChatApiError(f"Invalid rag_mode '{rag_mode}'", status_code=400)
 
     kb_ids = payload.get("kb_ids")
-    visitor_demo_kb_id = _enforce_visitor_demo_kb_selection(kb_ids) if _is_visitor_auth(auth) else ""
-    if visitor_demo_kb_id:
-        kb_ids = [visitor_demo_kb_id]
     conversation_id = _normalize_text(payload.get("conversation_id")) or None
     document_content = _normalize_text(payload.get("document_content"))
     document_filename = _normalize_text(payload.get("document_filename")) or "Document"
@@ -1026,8 +942,6 @@ def query_chat(*, db_path: str, request, auth: AuthContext, payload: dict[str, A
         raise ChatApiError("Too many files selected; choose up to 3.", status_code=400)
     if rag_mode == "agentic" and (document_content or document_sources):
         raise ChatApiError("Agentic RAG cannot be combined with direct document context", status_code=400)
-    if visitor_demo_kb_id and (document_content or document_sources):
-        raise _visitor_demo_kb_only_error()
     agentic_kb_id = _selected_agentic_kb_id(kb_ids) if rag_mode == "agentic" else None
 
     modules = _full_chat_modules()
@@ -1035,8 +949,6 @@ def query_chat(*, db_path: str, request, auth: AuthContext, payload: dict[str, A
     user_id, session_update = _resolve_chat_user(request, auth)
     storage = Storage(db_path)
     try:
-        if visitor_demo_kb_id:
-            _enforce_visitor_demo_kb_available(storage, visitor_demo_kb_id)
         _enforce_chat_quota(storage=storage, request=request, auth=auth)
         config = modules["config"].ChatbotConfig.from_config(storage=storage, default_mode=mode)
         conversation_manager = modules["conversation"].ConversationManager(storage, config)
@@ -1048,8 +960,6 @@ def query_chat(*, db_path: str, request, auth: AuthContext, payload: dict[str, A
                 raise ChatApiError("Conversation not found", status_code=404)
             if conversation.get("user_id") != user_id:
                 raise ChatApiError("Access denied", status_code=403)
-            if visitor_demo_kb_id and conversation.get("kb_id") != visitor_demo_kb_id:
-                raise _visitor_demo_kb_only_error()
         else:
             primary_kb = None
             if agentic_kb_id:

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -175,7 +175,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               ) : (
                 <>
                   <Link href="/login">
-                    <div className="hidden sm:flex items-center rounded-lg border border-border px-3 py-1.5 text-sm hover:bg-muted cursor-pointer">
+                    <div className="flex items-center rounded-md border border-border px-2 py-1 text-xs sm:px-3 sm:py-1.5 sm:text-sm hover:bg-muted cursor-pointer" data-testid="button-login">
                       {i18n.t("auth.signIn")}
                     </div>
                   </Link>

--- a/tests/test_auth_react_source.py
+++ b/tests/test_auth_react_source.py
@@ -60,7 +60,8 @@ def test_auth_react_shell_restores_native_auth_routes_and_contracts():
     assert 'i18n.t("nav.users")' in layout_src
     assert 'i18n.t("auth.signIn")' in layout_src
     assert 'data-testid="button-login"' in layout_src
-    assert 'flex items-center rounded-md border border-border px-2 py-1 text-xs' in layout_src
+    login_button_classes = layout_src.split('data-testid="button-login"', 1)[0].rsplit('className="', 1)[1]
+    assert not login_button_classes.startswith("hidden ")
     assert 'i18n.t("auth.register")' in layout_src
     assert 'apiGet<AuthMeResponse>("/api/auth/me")' in auth_ctx_src
     assert 'apiPost("/api/auth/logout")' in auth_ctx_src

--- a/tests/test_auth_react_source.py
+++ b/tests/test_auth_react_source.py
@@ -59,6 +59,8 @@ def test_auth_react_shell_restores_native_auth_routes_and_contracts():
     assert 'permissions.includes("users.manage")' in layout_src
     assert 'i18n.t("nav.users")' in layout_src
     assert 'i18n.t("auth.signIn")' in layout_src
+    assert 'data-testid="button-login"' in layout_src
+    assert 'flex items-center rounded-md border border-border px-2 py-1 text-xs' in layout_src
     assert 'i18n.t("auth.register")' in layout_src
     assert 'apiGet<AuthMeResponse>("/api/auth/me")' in auth_ctx_src
     assert 'apiPost("/api/auth/logout")' in auth_ctx_src

--- a/tests/test_fastapi_chat_endpoints.py
+++ b/tests/test_fastapi_chat_endpoints.py
@@ -480,7 +480,7 @@ def test_fastapi_chat_conversation_and_catalog_surfaces_work(tmp_path: Path, mon
     assert missing.status_code == 404, missing.text
 
 
-def test_visitor_chat_knowledge_bases_are_limited_to_configured_demo_kb(tmp_path: Path, monkeypatch) -> None:
+def test_visitor_chat_knowledge_bases_show_public_ready_kbs(tmp_path: Path, monkeypatch) -> None:
     client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
 
     monkeypatch.setenv("CHAT_VISITOR_DEMO_KB_ID", "chat-kb-a")
@@ -488,11 +488,11 @@ def test_visitor_chat_knowledge_bases_are_limited_to_configured_demo_kb(tmp_path
     assert response.status_code == 200, response.text
     payload = response.json()["data"]
 
-    assert payload["visitor_demo_kb_id"] == "chat-kb-a"
-    assert [item["kb_id"] for item in payload["knowledge_bases"]] == ["chat-kb-a"]
+    assert "visitor_demo_kb_id" not in payload
+    assert {item["kb_id"] for item in payload["knowledge_bases"]} >= {"chat-kb-a", "chat-kb-b"}
 
 
-def test_guest_equivalent_tokens_are_limited_to_configured_demo_kb(tmp_path: Path, monkeypatch) -> None:
+def test_guest_equivalent_tokens_can_list_public_chat_kbs(tmp_path: Path, monkeypatch) -> None:
     client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
 
     token = "unknown-role-token"
@@ -512,11 +512,11 @@ def test_guest_equivalent_tokens_are_limited_to_configured_demo_kb(tmp_path: Pat
     assert response.status_code == 200, response.text
     payload = response.json()["data"]
 
-    assert payload["visitor_demo_kb_id"] == "chat-kb-a"
-    assert [item["kb_id"] for item in payload["knowledge_bases"]] == ["chat-kb-a"]
+    assert "visitor_demo_kb_id" not in payload
+    assert {item["kb_id"] for item in payload["knowledge_bases"]} >= {"chat-kb-a", "chat-kb-b"}
 
 
-def test_visitor_chat_knowledge_bases_empty_when_default_demo_kb_missing(tmp_path: Path, monkeypatch) -> None:
+def test_visitor_chat_knowledge_bases_do_not_depend_on_demo_kb_config(tmp_path: Path, monkeypatch) -> None:
     client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
 
     monkeypatch.delenv("CHAT_VISITOR_DEMO_KB_ID", raising=False)
@@ -524,88 +524,156 @@ def test_visitor_chat_knowledge_bases_empty_when_default_demo_kb_missing(tmp_pat
     assert response.status_code == 200, response.text
     payload = response.json()["data"]
 
-    assert payload["visitor_demo_kb_id"] == "demo"
-    assert payload["knowledge_bases"] == []
+    assert "visitor_demo_kb_id" not in payload
+    assert {item["kb_id"] for item in payload["knowledge_bases"]} >= {"chat-kb-a", "chat-kb-b"}
 
 
-def test_visitor_chat_knowledge_bases_fail_closed_for_blank_demo_kb_config(tmp_path: Path, monkeypatch) -> None:
+def _install_guest_chat_fakes(monkeypatch) -> None:
+    import ai_actuarial.api.services.chat as chat_service
+
+    monkeypatch.setattr(
+        chat_service,
+        "AI_CHAT_QUOTA",
+        {**chat_service.AI_CHAT_QUOTA, "anonymous": 2, "guest": 2},
+    )
+    monkeypatch.setattr(chat_service, "_resolve_chat_user", lambda request, auth: ("guest:test", None))
+
+    class FakeConversationManager:
+        def __init__(self, storage, config):
+            self.storage = storage
+            chat_service._ensure_conversation_schema(storage)
+
+        def create_conversation(self, user_id: str, kb_id: str | None = None, mode: str = "expert", metadata=None):
+            conversation_id = "conv_guest_query"
+            now = "2026-04-16T00:00:00+00:00"
+            self.storage._conn.execute("DELETE FROM messages WHERE conversation_id = ?", (conversation_id,))
+            self.storage._conn.execute("DELETE FROM conversations WHERE conversation_id = ?", (conversation_id,))
+            self.storage._conn.execute(
+                """
+                INSERT INTO conversations
+                (conversation_id, user_id, title, kb_id, mode, created_at, updated_at, message_count, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (conversation_id, user_id, "Guest Query", kb_id, mode, now, now, 0, json.dumps(metadata) if metadata else None),
+            )
+            self.storage._conn.commit()
+            return conversation_id
+
+        def get_conversation(self, conversation_id: str):
+            row = self.storage._conn.execute(
+                "SELECT conversation_id, user_id, title, kb_id, mode, created_at, updated_at, message_count, metadata FROM conversations WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if not row:
+                return None
+            return {
+                "conversation_id": row[0],
+                "user_id": row[1],
+                "title": row[2],
+                "kb_id": row[3],
+                "mode": row[4],
+                "metadata": json.loads(row[8]) if row[8] else None,
+            }
+
+        def add_message(self, conversation_id: str, role: str, content: str, citations=None, metadata=None):
+            message_id = f"msg_{role}"
+            self.storage._conn.execute(
+                """
+                INSERT OR REPLACE INTO messages
+                (message_id, conversation_id, role, content, citations, created_at, token_count, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (message_id, conversation_id, role, content, json.dumps(citations) if citations else None, "2026-04-16T00:00:00+00:00", None, json.dumps(metadata) if metadata else None),
+            )
+            self.storage._conn.commit()
+            return message_id
+
+        def get_context(self, conversation_id: str):
+            return []
+
+    class FakeRetriever:
+        def __init__(self, storage, config):
+            pass
+
+        def retrieve(self, query, kb_ids):
+            return [{"content": "Chat KB B public content", "metadata": {"filename": "kb-b.pdf", "kb_id": "chat-kb-b"}}]
+
+    class FakeLLMClient:
+        def __init__(self, config, storage=None):
+            pass
+
+        def generate_response(self, query, chunks, mode, conversation_history):
+            return "Guest chat response"
+
+    class FakeQueryRouter:
+        def __init__(self, storage, config):
+            pass
+
+        def select_kb(self, query):
+            return ["chat-kb-b"]
+
+    class FakeConfigModule:
+        class ChatbotConfig:
+            @staticmethod
+            def from_config(storage=None, default_mode="expert"):
+                return SimpleNamespace(available_modes=["expert"], similarity_threshold=0.35, model="fake-chat-model")
+
+    class FakeExceptionsModule:
+        class NoResultsException(Exception):
+            pass
+
+        class EmbeddingConfigurationMismatchException(Exception):
+            pass
+
+    monkeypatch.setattr(
+        chat_service,
+        "_full_chat_modules",
+        lambda: {
+            "config": FakeConfigModule,
+            "conversation": SimpleNamespace(ConversationManager=FakeConversationManager),
+            "exceptions": FakeExceptionsModule,
+            "retrieval": SimpleNamespace(RAGRetriever=FakeRetriever),
+            "llm": SimpleNamespace(LLMClient=FakeLLMClient),
+            "router": SimpleNamespace(QueryRouter=FakeQueryRouter),
+        },
+    )
+
+
+def test_visitor_chat_query_allows_selected_public_kb(tmp_path: Path, monkeypatch) -> None:
     client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
+    _install_guest_chat_fakes(monkeypatch)
 
-    monkeypatch.setenv("CHAT_VISITOR_DEMO_KB_ID", "   ")
-    response = client.get("/api/chat/knowledge-bases", headers={"X-Auth-Token": ""})
-    assert response.status_code == 200, response.text
-    payload = response.json()["data"]
-
-    assert payload["visitor_demo_kb_id"] == "demo"
-    assert payload["knowledge_bases"] == []
-
-
-def test_visitor_chat_query_rejects_crafted_non_demo_kb(tmp_path: Path, monkeypatch) -> None:
-    client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
-
-    monkeypatch.setenv("CHAT_VISITOR_DEMO_KB_ID", "chat-kb-a")
     response = client.post(
         "/api/chat/query",
         json={"message": "capital", "kb_ids": ["chat-kb-b"], "mode": "expert"},
         headers={"X-Auth-Token": ""},
     )
 
-    assert response.status_code == 403, response.text
-    body = response.json()
-    assert body["code"] == "VISITOR_DEMO_KB_ONLY"
-    assert "Demo knowledge base" in body["error"]
+    assert response.status_code == 200, response.text
+    payload = response.json()["data"]
+    assert payload["conversation_id"] == "conv_guest_query"
+    assert payload["citations"][0]["kb_id"] == "chat-kb-b"
 
 
-def test_visitor_chat_selection_treats_list_sentinels_as_demo_kb(monkeypatch) -> None:
-    import ai_actuarial.api.services.chat as chat_service
-
-    monkeypatch.setenv("CHAT_VISITOR_DEMO_KB_ID", "chat-kb-a")
-
-    assert chat_service._enforce_visitor_demo_kb_selection(["all"]) == "chat-kb-a"
-    assert chat_service._enforce_visitor_demo_kb_selection(["auto"]) == "chat-kb-a"
-
-
-def test_visitor_chat_query_rejects_legacy_empty_kb_conversation(tmp_path: Path, monkeypatch) -> None:
+def test_visitor_chat_query_allows_direct_document_context(tmp_path: Path, monkeypatch) -> None:
     client, _app, _seed = _build_test_client(tmp_path, monkeypatch)
-
-    import ai_actuarial.api.services.chat as chat_service
-
-    monkeypatch.setenv("CHAT_VISITOR_DEMO_KB_ID", "chat-kb-a")
-    monkeypatch.setattr(chat_service, "_resolve_chat_user", lambda request, auth: ("guest:test", None))
-    storage = Storage(str(tmp_path / "index.db"))
-    try:
-        chat_service._ensure_conversation_schema(storage)
-        storage._conn.execute(
-            """
-            INSERT INTO conversations
-            (conversation_id, user_id, title, kb_id, mode, created_at, updated_at, message_count, metadata)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "conv_legacy_empty_kb",
-                "guest:test",
-                "Legacy visitor conversation",
-                None,
-                "expert",
-                "2026-04-16T00:00:00+00:00",
-                "2026-04-16T00:00:00+00:00",
-                0,
-                None,
-            ),
-        )
-        storage._conn.commit()
-    finally:
-        storage.close()
+    _install_guest_chat_fakes(monkeypatch)
 
     response = client.post(
         "/api/chat/query",
-        json={"message": "capital", "kb_ids": ["chat-kb-a"], "conversation_id": "conv_legacy_empty_kb"},
+        json={
+            "message": "Explain this document",
+            "mode": "expert",
+            "document_content": "Important guest-visible document content.",
+            "document_filename": "public.pdf",
+        },
         headers={"X-Auth-Token": ""},
     )
 
-    assert response.status_code == 403, response.text
-    body = response.json()
-    assert body["code"] == "VISITOR_DEMO_KB_ONLY"
+    assert response.status_code == 200, response.text
+    payload = response.json()["data"]
+    assert payload["metadata"]["context_notice"]["original_chars"] > 0
+    assert payload["citations"][0]["filename"] == "public.pdf"
 
 
 def test_fastapi_chat_knowledge_bases_defaults_manifest_profile_for_legacy_schema(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- remove the Demo-only backend restriction for visitor Chat so non-logged-in users can list/select public ready KBs
- allow guest Chat direct document context for the file explain flow while preserving chat quota enforcement
- keep a compact top-right login button visible on small screens

## Verification
- python3 -m pytest tests/test_fastapi_chat_endpoints.py tests/test_auth_react_source.py tests/test_fastapi_auth_endpoints.py -q
- npm run build
- git diff --check
- two independent read-only review agents: NO BLOCKING FINDINGS