### PR TITLE
fix: expand database search and config auth

### DIFF
--- a/ai_actuarial/api/routers/ops_write.py
+++ b/ai_actuarial/api/routers/ops_write.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import os
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
-from ai_actuarial.config import settings
 from ..deps import AuthContext, require_permissions
 from ..services.ops_write import (
     BridgeState,
@@ -55,10 +53,6 @@ def _db_path(request: Request) -> str:
     if not db_path:
         raise OpsWriteError("Database path is unavailable", status_code=500)
     return db_path
-
-
-def _config_write_auth_token() -> str:
-    return os.getenv("CONFIG_WRITE_AUTH_TOKEN") or settings.CONFIG_WRITE_AUTH_TOKEN
 
 
 def _handle_ops_error(exc: OpsWriteError) -> JSONResponse:
@@ -256,11 +250,6 @@ def api_config_backend_settings_update(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return update_backend_settings(payload, bridge=_bridge(request))
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -273,11 +262,6 @@ def api_config_categories_update(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return update_categories_config(payload)
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -290,11 +274,6 @@ def api_config_markdown_conversion_update(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return update_markdown_conversion_config(payload)
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -307,11 +286,6 @@ def api_config_ai_models_update(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return update_ai_models_config(payload, db_path=_db_path(request), bridge=_bridge(request))
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -324,11 +298,6 @@ def api_config_provider_credentials_upsert(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return upsert_provider_credential(payload, db_path=_db_path(request))
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -341,11 +310,6 @@ def api_config_provider_credentials_import_env(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return import_provider_credentials_from_env(payload, db_path=_db_path(request))
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -358,11 +322,6 @@ def api_config_provider_credentials_reencrypt(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return reencrypt_provider_credentials(payload, db_path=_db_path(request))
     except OpsWriteError as exc:
         return _handle_ops_error(exc)
@@ -375,11 +334,6 @@ def api_config_provider_credentials_delete(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         category = str(request.query_params.get("category") or "llm").strip().lower() or "llm"
         instance_id = str(request.query_params.get("instance_id") or "").strip() or None
         return delete_provider_credential(provider_id, db_path=_db_path(request), category=category, instance_id=instance_id)
@@ -394,11 +348,6 @@ def api_config_ai_routing_update(
     _auth: AuthContext = Depends(require_permissions("config.write")),
 ):
     try:
-        expected_token = _config_write_auth_token()
-        if expected_token:
-            provided_token = request.headers.get("X-Auth-Token")
-            if not provided_token or provided_token != expected_token:
-                return JSONResponse(status_code=403, content={"error": "Forbidden"})
         return update_ai_routing(payload, db_path=_db_path(request), bridge=_bridge(request))
     except OpsWriteError as exc:
         return _handle_ops_error(exc)

--- a/ai_actuarial/storage.py
+++ b/ai_actuarial/storage.py
@@ -1552,17 +1552,28 @@ class Storage:
         
         params = []
         
+        # Join with catalog_items when query/category filters need catalog fields,
+        # and later for result projection even without filters.
+        join_clause = ""
+
         if query:
-            filters.append("(LOWER(f.title) LIKE ? OR LOWER(f.original_filename) LIKE ? OR LOWER(f.url) LIKE ?)")
+            join_clause = "LEFT JOIN catalog_items c ON c.file_url = f.url"
+            filters.append(
+                "(LOWER(IFNULL(f.title, '')) LIKE ? "
+                "OR LOWER(IFNULL(f.original_filename, '')) LIKE ? "
+                "OR LOWER(IFNULL(f.url, '')) LIKE ? "
+                "OR LOWER(IFNULL(c.summary, '')) LIKE ? "
+                "OR LOWER(IFNULL(c.keywords, '')) LIKE ? "
+                "OR LOWER(IFNULL(c.category, '')) LIKE ? "
+                "OR LOWER(IFNULL(c.markdown_content, '')) LIKE ?)"
+            )
             search_term = f"%{query.lower()}%"
-            params.extend([search_term, search_term, search_term])
+            params.extend([search_term] * 7)
         
         if source:
             filters.append("LOWER(f.source_site) LIKE ?")
             params.append(f"%{source.lower()}%")
         
-        # Join with catalog_items if filtering by category (or always for data)
-        join_clause = ""
         if category:
             join_clause = "LEFT JOIN catalog_items c ON c.file_url = f.url"
             if category == '__uncategorized__':

--- a/tests/test_fastapi_ops_write_endpoints.py
+++ b/tests/test_fastapi_ops_write_endpoints.py
@@ -321,8 +321,11 @@ def test_markdown_conversion_config_read_write_endpoint_roundtrip(tmp_path: Path
     _patch_available_models(monkeypatch)
     markdown_config_path = tmp_path / "markdown_conversion.yaml"
     monkeypatch.setenv("MARKDOWN_CONVERSION_CONFIG_PATH", str(markdown_config_path))
-    client, _app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
+    monkeypatch.setenv("CONFIG_WRITE_AUTH_TOKEN", "legacy-config-write-token")
+    client, app, seed = _build_test_client(tmp_path, monkeypatch, require_auth=True)
     admin_headers = {"X-Auth-Token": str(seed["admin_token"])}
+    admin_session_cookie = _make_session_cookie(app, {"email_user_id": seed["admin_user_id"]})
+    admin_session_cookies = {app.state.fastapi_session_cookie_name: admin_session_cookie}
 
     unauthenticated = client.get("/api/config/markdown-conversion")
     assert unauthenticated.status_code == 401
@@ -341,7 +344,7 @@ def test_markdown_conversion_config_read_write_endpoint_roundtrip(tmp_path: Path
             "limits": {"default_scan_count": 25, "max_scan_count": 50000},
             "formats": {"pdf": {"candidate_chain": ["mistral", "markitdown", "local"]}},
         },
-        headers=admin_headers,
+        cookies=admin_session_cookies,
     )
     assert update.status_code == 200, update.text
     body = update.json()

--- a/tests/test_fastapi_read_endpoints.py
+++ b/tests/test_fastapi_read_endpoints.py
@@ -241,6 +241,30 @@ def test_fastapi_files_supports_filters_sorting_and_deleted(tmp_path: Path, monk
     assert filtered_body["files"][0]["title"] == "Alpha Document"
     assert filtered_body["files"][0]["category"] == "AI; Risk"
 
+    summary_search = client.get("/api/files?query=Beta%20summary")
+    assert summary_search.status_code == 200
+    summary_body = summary_search.json()
+    assert summary_body["total"] == 1
+    assert summary_body["files"][0]["title"] == "Beta Document"
+
+    keyword_search = client.get("/api/files?query=pricing")
+    assert keyword_search.status_code == 200
+    keyword_body = keyword_search.json()
+    assert keyword_body["total"] == 1
+    assert keyword_body["files"][0]["title"] == "Beta Document"
+
+    category_search = client.get("/api/files?query=Risk")
+    assert category_search.status_code == 200
+    category_body = category_search.json()
+    assert category_body["total"] == 1
+    assert category_body["files"][0]["title"] == "Alpha Document"
+
+    markdown_search = client.get("/api/files?query=Markdown%20content")
+    assert markdown_search.status_code == 200
+    markdown_body = markdown_search.json()
+    assert markdown_body["total"] == 1
+    assert markdown_body["files"][0]["title"] == "Alpha Document"
+
     deleted = client.get(
         "/api/files?include_deleted=true&order_by=title&order_dir=asc",
         headers={"Authorization": f"Bearer {seed['operator_token_plain']}"},


### PR DESCRIPTION
## Summary
- expand Database file search to include catalog summary, keywords, category, and Markdown content
- remove duplicate legacy CONFIG_WRITE_AUTH_TOKEN checks from authenticated config write routes
- add regression coverage for catalog-field search and admin session config writes

## Tests
- python3 -m pytest tests/test_fastapi_read_endpoints.py::test_fastapi_files_supports_filters_sorting_and_deleted tests/test_fastapi_ops_write_endpoints.py::test_markdown_conversion_config_read_write_endpoint_roundtrip
- git diff --check

## Deployment
- Already deployed to production; ai-api, ai-frontend, and ai-caddy reported healthy; /api/health returned 200.