### PR TITLE
fix: preserve encoded file URL identity

### DIFF
--- a/client/src/hooks/use-latest-request.ts
+++ b/client/src/hooks/use-latest-request.ts
@@ -1,0 +1,17 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useLatestRequestGuard(identity: string): (requestIdentity: string) => () => boolean {
+  const identityRef = useRef(identity);
+  const generationRef = useRef(0);
+  identityRef.current = identity;
+
+  useEffect(() => () => {
+    generationRef.current += 1;
+  }, []);
+
+  return useCallback((requestIdentity: string) => {
+    if (identityRef.current !== requestIdentity) return () => false;
+    const generation = ++generationRef.current;
+    return () => identityRef.current === requestIdentity && generationRef.current === generation;
+  }, []);
+}

--- a/client/src/lib/navigation.ts
+++ b/client/src/lib/navigation.ts
@@ -1,3 +1,5 @@
+import { useSearch as useBrowserSearch } from "wouter/use-browser-location";
+
 function isSafeRelativePath(value: string): boolean {
   return value.startsWith("/") && !value.startsWith("//");
 }
@@ -17,6 +19,15 @@ export function getCurrentRelativeLocation(): string {
 
   const next = `${window.location.pathname}${window.location.search}${window.location.hash}`;
   return sanitizeReturnPath(next) || "/";
+}
+
+export function getRawSearchParams(rawSearch?: string): URLSearchParams {
+  const search = rawSearch ?? (typeof window === "undefined" ? "" : window.location.search);
+  return new URLSearchParams(search);
+}
+
+export function useRawSearchParams(): URLSearchParams {
+  return getRawSearchParams(useBrowserSearch());
 }
 
 export function getReturnPathFromSearch(search: string): string | null {

--- a/client/src/pages/FileDetail.tsx
+++ b/client/src/pages/FileDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useLocation, useSearch } from "wouter";
+import { useLocation } from "wouter";
 import { motion } from "framer-motion";
 import {
   ArrowLeft,
@@ -25,11 +25,12 @@ import {
   Clock,
   CheckCircle2,
 } from "lucide-react";
-import { buildFileDetailPath, buildFilePreviewPath, getReturnPathFromSearch, sanitizeReturnPath } from "@/lib/navigation";
+import { buildFileDetailPath, buildFilePreviewPath, sanitizeReturnPath, useRawSearchParams } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "@/components/Layout";
 import { ApiError, apiGet, apiPost, setStoredAuthToken } from "@/lib/api";
 import { useTaskOptions } from "@/hooks/use-task-options";
+import { useLatestRequestGuard } from "@/hooks/use-latest-request";
 import { useAuth } from "@/context/AuthContext";
 import ConfirmDeleteModal from "@/components/ConfirmDeleteModal";
 
@@ -393,9 +394,9 @@ export default function FileDetail() {
   const { t } = useTranslation();
   const { permissions } = useAuth();
   const [, navigate] = useLocation();
-  const searchString = useSearch();
-  const fileUrl = new URLSearchParams(searchString).get("url") || "";
-  const fromParam = getReturnPathFromSearch(searchString);
+  const searchParams = useRawSearchParams();
+  const fileUrl = searchParams.get("url") || "";
+  const fromParam = sanitizeReturnPath(searchParams.get("from"));
 
   function goBack() {
     // If navigated from within the app with an explicit "from" param, use it.
@@ -471,22 +472,37 @@ export default function FileDetail() {
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
+  const beginFileRequest = useLatestRequestGuard(fileUrl);
+  const beginMarkdownRequest = useLatestRequestGuard(fileUrl);
+  const beginChunksRequest = useLatestRequestGuard(fileUrl);
+  const beginChunkSubmission = useLatestRequestGuard(fileUrl);
+
   const fetchFile = useCallback(async () => {
-    if (!fileUrl) return;
+    const requestIdentity = fileUrl;
+    const isLatest = beginFileRequest(requestIdentity);
+    if (!requestIdentity || !isLatest()) return;
     setLoading(true);
     setError(null);
     try {
-      const res = await apiGet<{ file: FileData }>(`/api/files/detail?url=${encodeURIComponent(fileUrl)}`);
+      const res = await apiGet<{ file: FileData }>(`/api/files/detail?url=${encodeURIComponent(requestIdentity)}`);
+      if (!isLatest()) return;
       setFile(res.file);
     } catch (e) {
+      if (!isLatest()) return;
       setError(e instanceof Error ? e.message : "Failed to load file");
-    } finally { setLoading(false); }
-  }, [fileUrl]);
+    } finally {
+      if (isLatest()) setLoading(false);
+    }
+  }, [beginFileRequest, fileUrl]);
 
   const refreshMarkdown = useCallback(async () => {
-    if (!fileUrl) return;
+    const requestIdentity = fileUrl;
+    const isLatest = beginMarkdownRequest(requestIdentity);
+    if (!requestIdentity || !isLatest()) return;
+    setMdLoading(true);
     try {
-      const res = await apiGet<{ markdown?: MarkdownData }>(`/api/files/${encodeURIComponent(fileUrl)}/markdown`);
+      const res = await apiGet<{ markdown?: MarkdownData }>(`/api/files/${encodeURIComponent(requestIdentity)}/markdown`);
+      if (!isLatest()) return;
       setMarkdown(res.markdown || null);
       setFile((current) => current ? {
         ...current,
@@ -494,16 +510,28 @@ export default function FileDetail() {
         markdown_updated_at: res.markdown?.markdown_updated_at,
       } : current);
       if (res.markdown?.markdown_content) setMdEditContent(res.markdown.markdown_content);
-    } catch { setMarkdown(null); }
-  }, [fileUrl]);
+    } catch {
+      if (isLatest()) setMarkdown(null);
+    } finally {
+      if (isLatest()) setMdLoading(false);
+    }
+  }, [beginMarkdownRequest, fileUrl]);
 
   const refreshChunks = useCallback(async () => {
-    if (!fileUrl) return;
+    const requestIdentity = fileUrl;
+    const isLatest = beginChunksRequest(requestIdentity);
+    if (!requestIdentity || !isLatest()) return;
+    setChunkSetsLoading(true);
     try {
-      const res = await apiGet<{ data?: { chunk_sets?: ChunkSet[] }; chunk_sets?: ChunkSet[] }>(`/api/files/${encodeURIComponent(fileUrl)}/chunk-sets`);
+      const res = await apiGet<{ data?: { chunk_sets?: ChunkSet[] }; chunk_sets?: ChunkSet[] }>(`/api/files/${encodeURIComponent(requestIdentity)}/chunk-sets`);
+      if (!isLatest()) return;
       setChunkSets(res.data?.chunk_sets || res.chunk_sets || []);
-    } catch { setChunkSets([]); }
-  }, [fileUrl]);
+    } catch {
+      if (isLatest()) setChunkSets([]);
+    } finally {
+      if (isLatest()) setChunkSetsLoading(false);
+    }
+  }, [beginChunksRequest, fileUrl]);
 
   const conversionPoller = useTaskPoller(refreshMarkdown);
   const catalogPoller = useTaskPoller(fetchFile);
@@ -529,14 +557,12 @@ export default function FileDetail() {
 
   useEffect(() => {
     if (!fileUrl) return;
-    setMdLoading(true);
-    refreshMarkdown().finally(() => setMdLoading(false));
+    void refreshMarkdown();
   }, [fileUrl, refreshMarkdown]);
 
   useEffect(() => {
     if (!fileUrl) return;
-    setChunkSetsLoading(true);
-    refreshChunks().finally(() => setChunkSetsLoading(false));
+    void refreshChunks();
   }, [fileUrl, refreshChunks]);
 
   useEffect(() => {
@@ -656,6 +682,9 @@ export default function FileDetail() {
 
   async function submitChunk() {
     if (!file) return;
+    const requestIdentity = file.url;
+    const isLatest = beginChunkSubmission(requestIdentity);
+    if (!isLatest()) return;
     setChunkSubmitting(true);
     const body: Record<string, unknown> = {
       overwrite_same_profile: chunkOverwrite,
@@ -673,16 +702,19 @@ export default function FileDetail() {
       body.kb_id = selectedKbId;
     }
     try {
-      await apiPost(`/api/files/${encodeURIComponent(file.url)}/chunk-sets/generate`, body);
+      await apiPost(`/api/files/${encodeURIComponent(requestIdentity)}/chunk-sets/generate`, body);
+      if (!isLatest()) return;
       setShowChunkModal(false);
       await refreshChunks();
     } catch (error) {
+      if (!isLatest()) return;
       if (error instanceof ApiError && error.status === 403) {
         const token = window.prompt(t("fv.chunk_auth_token_prompt"), "") || "";
         if (token.trim()) {
           try {
             setStoredAuthToken(token, false);
-            await apiPost(`/api/files/${encodeURIComponent(file.url)}/chunk-sets/generate`, body);
+            await apiPost(`/api/files/${encodeURIComponent(requestIdentity)}/chunk-sets/generate`, body);
+            if (!isLatest()) return;
             setShowChunkModal(false);
             await refreshChunks();
             return;
@@ -691,7 +723,9 @@ export default function FileDetail() {
           }
         }
       }
-    } finally { setChunkSubmitting(false); }
+    } finally {
+      if (isLatest()) setChunkSubmitting(false);
+    }
   }
 
   async function handleDelete() {

--- a/client/src/pages/FilePreview.tsx
+++ b/client/src/pages/FilePreview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useLocation, useSearch } from "wouter";
+import { useLocation } from "wouter";
 import { motion } from "framer-motion";
 import {
   ArrowLeft,
@@ -14,10 +14,11 @@ import {
   ImageIcon,
   Lock,
 } from "lucide-react";
-import { buildFileDetailPath, getReturnPathFromSearch } from "@/lib/navigation";
+import { buildFileDetailPath, sanitizeReturnPath, useRawSearchParams } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "@/components/Layout";
 import { useAuth } from "@/context/AuthContext";
+import { useLatestRequestGuard } from "@/hooks/use-latest-request";
 import { apiGet } from "@/lib/api";
 
 interface FileInfo {
@@ -286,11 +287,10 @@ export default function FilePreview() {
   const isGuest = !isLoggedIn || user?.role === "guest";
   const canDownload = permissions.includes("files.download");
   const [, navigate] = useLocation();
-  const searchStr = useSearch();
-  const searchParams = new URLSearchParams(searchStr);
+  const searchParams = useRawSearchParams();
   const fileUrl = searchParams.get("file_url") || "";
   const initialChunkSetId = searchParams.get("chunk_set_id") || "";
-  const fromParam = getReturnPathFromSearch(searchStr);
+  const fromParam = sanitizeReturnPath(searchParams.get("from"));
 
   const isDesktop = useMediaQuery("(min-width: 1024px)");
 
@@ -298,22 +298,29 @@ export default function FilePreview() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeChunkSetId, setActiveChunkSetId] = useState(initialChunkSetId);
+  const beginPreviewRequest = useLatestRequestGuard(fileUrl);
 
   const fetchPreview = useCallback(async (chunkSetId?: string) => {
-    if (!fileUrl) return;
+    const requestIdentity = fileUrl;
+    const isLatest = beginPreviewRequest(requestIdentity);
+    if (!requestIdentity || !isLatest()) return;
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams({ file_url: fileUrl });
+      const params = new URLSearchParams({ file_url: requestIdentity });
       if (chunkSetId) params.set("chunk_set_id", chunkSetId);
       const res = await apiGet<{ data?: PreviewData } & PreviewData>(`/api/rag/files/preview?${params}`);
       const d = res.data || res;
+      if (!isLatest()) return;
       setData(d);
       setActiveChunkSetId(d.active_chunk_set_id || "");
     } catch (e) {
+      if (!isLatest()) return;
       setError(e instanceof Error ? e.message : "Failed to load preview");
-    } finally { setLoading(false); }
-  }, [fileUrl]);
+    } finally {
+      if (isLatest()) setLoading(false);
+    }
+  }, [beginPreviewRequest, fileUrl]);
 
   useEffect(() => { fetchPreview(initialChunkSetId); }, [fetchPreview, initialChunkSetId]);
 

--- a/client/src/pages/NativeFileDetail.tsx
+++ b/client/src/pages/NativeFileDetail.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { useLocation, useSearch } from "wouter";
+import { useEffect, useState, type ReactNode } from "react";
+import { useLocation } from "wouter";
 import { ArrowLeft, ExternalLink, FileText, Loader2 } from "lucide-react";
 import { apiGet } from "@/lib/api";
-import { getReturnPathFromSearch } from "@/lib/navigation";
+import { sanitizeReturnPath, useRawSearchParams } from "@/lib/navigation";
 
 type FileData = {
   url: string;
@@ -53,11 +53,10 @@ function DetailRow({ label, value }: { label: string; value: ReactNode }) {
 }
 
 export default function NativeFileDetail() {
-  const search = useSearch();
   const [, navigate] = useLocation();
-  const params = useMemo(() => new URLSearchParams(search), [search]);
+  const params = useRawSearchParams();
   const fileUrl = params.get("url") || "";
-  const returnPath = getReturnPathFromSearch(search) || "/database";
+  const returnPath = sanitizeReturnPath(params.get("from")) || "/database";
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/tests/test_file_detail_react_source.py
+++ b/tests/test_file_detail_react_source.py
@@ -1,9 +1,14 @@
+import json
+import subprocess
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1] / "client" / "src"
 FILE_DETAIL_TSX = ROOT / "pages" / "FileDetail.tsx"
 FILE_PREVIEW_TSX = ROOT / "pages" / "FilePreview.tsx"
+NATIVE_FILE_DETAIL_TSX = ROOT / "pages" / "NativeFileDetail.tsx"
+LATEST_REQUEST_HOOK_TS = ROOT / "hooks" / "use-latest-request.ts"
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_file_detail_ai_explain_passes_loaded_markdown_to_chat():
@@ -58,3 +63,311 @@ def test_file_preview_passes_download_permission_to_original_pane():
 
     assert "function OriginalPane({ fileInfo, canDownload }" in src
     assert "canDownload={canDownload}" in src
+
+
+def test_file_routes_parse_raw_browser_search_without_changing_encoded_url_identity():
+    file_urls = [
+        "https://example.com/a%20b.pdf",
+        "https://example.com/report%28final%29.pdf",
+        "https://example.com/research%26pricing.pdf",
+        "https://example.com/INVITACIO%CC%81N.pdf",
+        "https://example.com/a+b.pdf",
+    ]
+    script = """
+import { buildFileDetailPath, buildFilePreviewPath, getRawSearchParams } from './client/src/lib/navigation.ts';
+const fileUrls = JSON.parse(process.argv[1]);
+for (const fileUrl of fileUrls) {
+  for (const [route, key] of [
+    [buildFileDetailPath(fileUrl), 'url'],
+    [buildFilePreviewPath(fileUrl), 'file_url'],
+  ]) {
+    globalThis.window = { location: { search: route.slice(route.indexOf('?')) } };
+    const actual = getRawSearchParams().get(key);
+    if (actual !== fileUrl) throw new Error(`${actual} !== ${fileUrl}`);
+  }
+}
+"""
+
+    result = subprocess.run(
+        ["npm", "exec", "--", "tsx", "-e", script, json.dumps(file_urls)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_file_detail_and_preview_pages_use_raw_browser_search():
+    for path in (FILE_DETAIL_TSX, FILE_PREVIEW_TSX, NATIVE_FILE_DETAIL_TSX):
+        src = path.read_text(encoding="utf-8")
+
+        assert "useRawSearchParams" in src
+        assert "useSearch" not in src
+
+
+def test_raw_search_hook_reacts_to_same_path_query_navigation():
+    file_url_a = "https://example.com/A%20%28one%29%26INVITACIO%CC%81N+a.pdf"
+    file_url_b = "https://example.com/B%20%28two%29%26INVITACIO%CC%81N+b.pdf"
+    script = """
+(async () => {
+const fileUrlA = process.argv[1];
+const fileUrlB = process.argv[2];
+const events = new EventTarget();
+globalThis.window = events;
+globalThis.addEventListener = events.addEventListener.bind(events);
+globalThis.removeEventListener = events.removeEventListener.bind(events);
+globalThis.dispatchEvent = events.dispatchEvent.bind(events);
+globalThis.location = { pathname: '/file-detail', search: '' };
+globalThis.history = {
+  state: null,
+  pushState(state, _unused, to) {
+    this.state = state;
+    const next = new URL(String(to), 'https://app.example');
+    location.pathname = next.pathname;
+    location.search = next.search;
+  },
+  replaceState(state, unused, to) { this.pushState(state, unused, to); },
+};
+
+const React = await import('react');
+const internals = React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+let subscription;
+let render;
+internals.H = {
+  useSyncExternalStore(subscribe, getSnapshot) {
+    subscription ||= subscribe(() => render());
+    return getSnapshot();
+  },
+};
+
+const navigation = await import('./client/src/lib/navigation.ts');
+const { useRawSearchParams } = navigation.default || navigation;
+function verifySamePathQueryNavigation(path, key) {
+  location.pathname = path;
+  location.search = `?${key}=${encodeURIComponent(fileUrlA)}`;
+  const observed = [];
+  render = () => observed.push(useRawSearchParams().get(key));
+  render();
+  history.pushState(null, '', `${path}?${key}=${encodeURIComponent(fileUrlB)}`);
+  if (observed[0] !== fileUrlA) throw new Error(`${path} initial identity changed: ${observed[0]}`);
+  if (observed.at(-1) !== fileUrlB) throw new Error(`${path} query navigation did not resolve B: ${observed.at(-1)}`);
+}
+
+verifySamePathQueryNavigation('/file-detail', 'url');
+verifySamePathQueryNavigation('/file-preview', 'file_url');
+})().catch((error) => { console.error(error); process.exitCode = 1; });
+"""
+
+    result = subprocess.run(
+        ["npm", "exec", "--", "tsx", "-e", script, file_url_a, file_url_b],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_query_navigation_reloads_detail_preview_and_native_detail():
+    detail_src = FILE_DETAIL_TSX.read_text(encoding="utf-8")
+    preview_src = FILE_PREVIEW_TSX.read_text(encoding="utf-8")
+    native_src = NATIVE_FILE_DETAIL_TSX.read_text(encoding="utf-8")
+
+    assert "const searchParams = useRawSearchParams();" in detail_src
+    assert "}, [beginFileRequest, fileUrl]);" in detail_src
+    assert "}, [beginMarkdownRequest, fileUrl]);" in detail_src
+    assert "}, [beginChunksRequest, fileUrl]);" in detail_src
+    assert "useEffect(() => { fetchFile(); }, [fetchFile]);" in detail_src
+    assert "`/api/files/detail?url=${encodeURIComponent(requestIdentity)}`" in detail_src
+    assert "const searchParams = useRawSearchParams();" in preview_src
+    assert "}, [beginPreviewRequest, fileUrl]);" in preview_src
+    assert "useEffect(() => { fetchPreview(initialChunkSetId); }, [fetchPreview, initialChunkSetId]);" in preview_src
+    assert "const params = new URLSearchParams({ file_url: requestIdentity });" in preview_src
+    assert "`/api/rag/files/preview?${params}`" in preview_src
+    assert "const params = useRawSearchParams();" in native_src
+    assert "}, [fileUrl]);" in native_src
+    assert "`/api/files/detail?url=${encodeURIComponent(fileUrl)}`" in native_src
+
+
+def test_latest_request_guard_rejects_deferred_stale_success_error_and_finally():
+    script = """
+(async () => {
+const React = await import('react');
+const internals = React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+const refs = [];
+let refIndex = 0;
+internals.H = {
+  useRef(initialValue) {
+    const index = refIndex++;
+    refs[index] ||= { current: initialValue };
+    return refs[index];
+  },
+  useCallback(callback) { return callback; },
+  useEffect() {},
+};
+
+const hooks = await import('./client/src/hooks/use-latest-request.ts');
+const { useLatestRequestGuard } = hooks.default || hooks;
+function render(identity) {
+  refIndex = 0;
+  return useLatestRequestGuard(identity);
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+async function run(request, state, beginRequest, requestIdentity) {
+  const isLatest = beginRequest(requestIdentity);
+  state.loading = true;
+  state.error = null;
+  try {
+    const result = await request.promise;
+    if (isLatest()) state.value = result;
+  } catch (error) {
+    if (isLatest()) state.error = error.message;
+  } finally {
+    if (isLatest()) state.loading = false;
+  }
+}
+
+const staleSuccessState = { value: null, error: null, loading: false };
+const successA = deferred();
+const successB = deferred();
+const beginSuccessA = render('A');
+const runSuccessA = run(successA, staleSuccessState, beginSuccessA, 'A');
+const beginSuccessB = render('B');
+const runSuccessB = run(successB, staleSuccessState, beginSuccessB, 'B');
+successB.resolve('B');
+await runSuccessB;
+successA.resolve('A');
+await runSuccessA;
+if (JSON.stringify(staleSuccessState) !== JSON.stringify({ value: 'B', error: null, loading: false })) {
+  throw new Error(`stale A success/finally overwrote B: ${JSON.stringify(staleSuccessState)}`);
+}
+
+const staleErrorState = { value: null, error: null, loading: false };
+const errorA = deferred();
+const errorB = deferred();
+const beginErrorA = render('A');
+const runErrorA = run(errorA, staleErrorState, beginErrorA, 'A');
+const beginErrorB = render('B');
+const runErrorB = run(errorB, staleErrorState, beginErrorB, 'B');
+errorB.resolve('B');
+await runErrorB;
+errorA.reject(new Error('A failed'));
+await runErrorA;
+if (JSON.stringify(staleErrorState) !== JSON.stringify({ value: 'B', error: null, loading: false })) {
+  throw new Error(`stale A error/finally overwrote B: ${JSON.stringify(staleErrorState)}`);
+}
+})().catch((error) => { console.error(error); process.exitCode = 1; });
+"""
+
+    result = subprocess.run(
+        ["npm", "exec", "--", "tsx", "-e", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_latest_request_guard_rejects_stale_callbacks_that_start_after_navigation():
+    script = """
+(async () => {
+const React = await import('react');
+const internals = React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+const refs = [];
+let refIndex = 0;
+internals.H = {
+  useRef(initialValue) {
+    const index = refIndex++;
+    refs[index] ||= { current: initialValue };
+    return refs[index];
+  },
+  useCallback(callback) { return callback; },
+  useEffect() {},
+};
+
+const hooks = await import('./client/src/hooks/use-latest-request.ts');
+const { useLatestRequestGuard } = hooks.default || hooks;
+refIndex = 0;
+const beginA = useLatestRequestGuard('A');
+refIndex = 0;
+const beginB = useLatestRequestGuard('B');
+const state = { value: null, error: null, loading: false };
+let requestsStarted = 0;
+
+async function run(beginRequest, requestIdentity, outcome) {
+  const isLatest = beginRequest(requestIdentity);
+  if (!isLatest()) return;
+  requestsStarted += 1;
+  state.loading = true;
+  state.error = null;
+  try {
+    if (outcome instanceof Error) throw outcome;
+    if (isLatest()) state.value = outcome;
+  } catch (error) {
+    if (isLatest()) state.error = error.message;
+  } finally {
+    if (isLatest()) state.loading = false;
+  }
+}
+
+await run(beginB, 'B', 'B');
+const afterB = JSON.stringify(state);
+
+// Old poller and chunk-completion closures both start only after B completed.
+await run(beginA, 'A', 'poller A');
+await run(beginA, 'A', new Error('chunk A failed'));
+
+if (requestsStarted !== 1) throw new Error(`stale A callback started a request: ${requestsStarted}`);
+if (JSON.stringify(state) !== afterB) {
+  throw new Error(`late-start stale A success/error/finally overwrote B: ${JSON.stringify(state)}`);
+}
+})().catch((error) => { console.error(error); process.exitCode = 1; });
+"""
+
+    result = subprocess.run(
+        ["npm", "exec", "--", "tsx", "-e", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_file_detail_and_preview_guard_every_query_dependent_request_state():
+    detail_src = FILE_DETAIL_TSX.read_text(encoding="utf-8")
+    preview_src = FILE_PREVIEW_TSX.read_text(encoding="utf-8")
+    hook_src = LATEST_REQUEST_HOOK_TS.read_text(encoding="utf-8")
+
+    assert "identityRef.current === requestIdentity" in hook_src
+    assert "generationRef.current === generation" in hook_src
+    for request_name in ("File", "Markdown", "Chunks"):
+        assert f"const begin{request_name}Request = useLatestRequestGuard(fileUrl);" in detail_src
+    assert "const beginChunkSubmission = useLatestRequestGuard(fileUrl);" in detail_src
+    assert detail_src.count("if (!requestIdentity || !isLatest()) return;") >= 3
+    assert "const isLatest = beginChunkSubmission(requestIdentity);" in detail_src
+    assert "if (isLatest()) setChunkSubmitting(false);" in detail_src
+    assert detail_src.count("if (!isLatest()) return;") >= 3
+    assert "if (isLatest()) setLoading(false);" in detail_src
+    assert "if (isLatest()) setMarkdown(null);" in detail_src
+    assert "if (isLatest()) setMdLoading(false);" in detail_src
+    assert "if (isLatest()) setChunkSets([]);" in detail_src
+    assert "if (isLatest()) setChunkSetsLoading(false);" in detail_src
+
+    assert "const beginPreviewRequest = useLatestRequestGuard(fileUrl);" in preview_src
+    assert "const isLatest = beginPreviewRequest(requestIdentity);" in preview_src
+    assert "if (!isLatest()) return;" in preview_src
+    assert "if (isLatest()) setLoading(false);" in preview_src


### PR DESCRIPTION
## Summary
- parse raw browser search reactively so encoded database URLs are decoded exactly once
- guard detail and preview requests by exact URL identity plus request generation
- prevent stale poller and chunk callbacks from overwriting the current file

## Verification
- 24 focused/adjacent tests passed
- npm run build
- git diff --check
- mandatory Codex review PASS
- independent Hermes reviewer PASS